### PR TITLE
Externalize PlantUML architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,7 @@
 A PHP application to control agents from Google Jules, coordinated by GitHub repositories and issues. It provides a centralized platform for managing AI agent workflows through a unified web interface.
 
 ## Architecture
-```plantuml
-@startuml
-!theme plain
-
-actor User
-
-package "Web Server" {
-    component "Frontend\n(Tailwind CSS, Alpine.js)" as Frontend
-    component "PHP Backend\n(src/)" as Backend
-    database "MySQL Database" as DB
-}
-
-package "External Integrations" {
-    cloud "Google SSO" as SSO
-    cloud "GitHub API" as GitHub
-    cloud "Google Jules API" as Jules
-}
-
-User --> Frontend : Accesses Dashboard
-Frontend <--> Backend : Request/Response
-Backend <--> DB : Data Persistence
-Backend <--> SSO : User Authentication
-Backend <--> GitHub : Repo/Issue Coordination
-Backend <--> Jules : Agent Control
-
-@enduml
-```
+![Architecture](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ai-brain/main/docs/architecture.puml)
 
 ## Features
 - **Centralized Agent Management**: Coordinate multiple AI agents across projects.

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -1,0 +1,25 @@
+@startuml
+!theme plain
+
+actor User
+
+package "Web Server" {
+    component "Frontend\n(Tailwind CSS, Alpine.js)" as Frontend
+    component "PHP Backend\n(src/)" as Backend
+    database "MySQL Database" as DB
+}
+
+package "External Integrations" {
+    cloud "Google SSO" as SSO
+    cloud "GitHub API" as GitHub
+    cloud "Google Jules API" as Jules
+}
+
+User --> Frontend : Accesses Dashboard
+Frontend <--> Backend : Request/Response
+Backend <--> DB : Data Persistence
+Backend <--> SSO : User Authentication
+Backend <--> GitHub : Repo/Issue Coordination
+Backend <--> Jules : Agent Control
+
+@enduml


### PR DESCRIPTION
I have moved the inline PlantUML architecture diagram from `README.md` into a new file `docs/architecture.puml`. I then updated `README.md` to reference a rendered version of this diagram using the PlantUML proxy service, which points to the raw content of the new `.puml` file on GitHub. This keeps the `README.md` cleaner while still displaying the diagram dynamically.

Fixes #22

---
*PR created automatically by Jules for task [9025958848928671875](https://jules.google.com/task/9025958848928671875) started by @chatelao*