### PR TITLE
Implement GitHub Webhook Handler and Issue-to-Task Mapping

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,8 +10,8 @@
 ## Phase 2: GitHub Integration
 - [x] Implement GitHub OAuth for repository access.
 - [x] Create interface to link GitHub repositories to projects.
-- [ ] Develop webhook handler for GitHub issues.
-- [ ] Basic issue-to-task mapping.
+- [x] Develop webhook handler for GitHub issues.
+- [x] Basic issue-to-task mapping.
 
 ## Phase 3: Agent Orchestration
 - [ ] Integrate Google Jules API.

--- a/src/backend/Project.php
+++ b/src/backend/Project.php
@@ -12,10 +12,20 @@ class Project
 
     public function create(int $userId, string $githubRepo): bool
     {
+        $webhookSecret = bin2hex(random_bytes(16));
         $stmt = $this->db->getConnection()->prepare(
-            "INSERT INTO projects (user_id, github_repo) VALUES (?, ?)"
+            "INSERT INTO projects (user_id, github_repo, webhook_secret) VALUES (?, ?, ?)"
         );
-        return $stmt->execute([$userId, $githubRepo]);
+        return $stmt->execute([$userId, $githubRepo, $webhookSecret]);
+    }
+
+    public function findByRepo(string $githubRepo): array
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "SELECT * FROM projects WHERE github_repo = ?"
+        );
+        $stmt->execute([$githubRepo]);
+        return $stmt->fetchAll();
     }
 
     public function findByUserId(int $userId): array

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App;
+
+use PDO;
+
+class WebhookHandler
+{
+    public function __construct(private Database $db)
+    {
+    }
+
+    public function verifySignature(string $payload, string $signature, string $secret): bool
+    {
+        $hash = 'sha256=' . hash_hmac('sha256', $payload, $secret);
+        return hash_equals($hash, $signature);
+    }
+
+    public function handle(int $projectId, array $event): bool
+    {
+        $action = $event['action'] ?? '';
+        $issue = $event['issue'] ?? null;
+
+        if (!$issue || !in_array($action, ['opened', 'reopened', 'edited'])) {
+            return false;
+        }
+
+        $connection = $this->db->getConnection();
+        $driver = $connection->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $sql = "INSERT INTO tasks (project_id, issue_number, title, body, github_data, status)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(project_id, issue_number) DO UPDATE SET
+                        title = excluded.title,
+                        body = excluded.body,
+                        github_data = excluded.github_data";
+        } else {
+            $sql = "INSERT INTO tasks (project_id, issue_number, title, body, github_data, status)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON DUPLICATE KEY UPDATE
+                        title = VALUES(title),
+                        body = VALUES(body),
+                        github_data = VALUES(github_data)";
+        }
+
+        $stmt = $connection->prepare($sql);
+
+        return $stmt->execute([
+            $projectId,
+            $issue['number'],
+            $issue['title'],
+            $issue['body'],
+            json_encode($issue),
+            'pending'
+        ]);
+    }
+}

--- a/src/frontend/webhook.php
+++ b/src/frontend/webhook.php
@@ -1,0 +1,59 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Database;
+use App\Project;
+use App\WebhookHandler;
+
+$db = new Database();
+$projectModel = new Project($db);
+$handler = new WebhookHandler($db);
+
+$payload = file_get_contents('php://input');
+$signature = $_SERVER['HTTP_X_HUB_SIGNATURE_256'] ?? '';
+$event = $_SERVER['HTTP_X_GITHUB_EVENT'] ?? '';
+
+if (empty($payload) || empty($signature) || $event !== 'issues') {
+    http_response_code(400);
+    exit('Invalid request');
+}
+
+$data = json_decode($payload, true);
+$repoFullName = $data['repository']['full_name'] ?? '';
+
+if (empty($repoFullName)) {
+    http_response_code(400);
+    exit('Repository information missing');
+}
+
+$projects = $projectModel->findByRepo($repoFullName);
+
+if (empty($projects)) {
+    http_response_code(404);
+    exit('Project not found');
+}
+
+$verified = false;
+$matchingProject = null;
+
+foreach ($projects as $project) {
+    if ($handler->verifySignature($payload, $signature, $project['webhook_secret'])) {
+        $verified = true;
+        $matchingProject = $project;
+        break;
+    }
+}
+
+if (!$verified) {
+    http_response_code(401);
+    exit('Invalid signature');
+}
+
+if ($handler->handle($matchingProject['id'], $data)) {
+    http_response_code(200);
+    echo 'OK';
+} else {
+    http_response_code(500);
+    echo 'Failed to process event';
+}

--- a/src/sql/schema.sql
+++ b/src/sql/schema.sql
@@ -13,6 +13,21 @@ CREATE TABLE IF NOT EXISTS projects (
     id INT AUTO_INCREMENT PRIMARY KEY,
     user_id INT NOT NULL,
     github_repo VARCHAR(255) NOT NULL,
+    webhook_secret VARCHAR(255),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    project_id INT NOT NULL,
+    issue_number INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    body TEXT,
+    status ENUM('pending', 'in_progress', 'completed', 'failed') DEFAULT 'pending',
+    github_data JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    UNIQUE KEY project_issue (project_id, issue_number)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/test/Integration/ProjectDBIntegrationTest.php
+++ b/test/Integration/ProjectDBIntegrationTest.php
@@ -33,8 +33,23 @@ class ProjectDBIntegrationTest extends TestCase
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INT NOT NULL,
             github_repo VARCHAR(255) NOT NULL,
+            webhook_secret VARCHAR(255),
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )");
+
+        $this->pdo->exec("CREATE TABLE tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id INT NOT NULL,
+            issue_number INT NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            body TEXT,
+            status TEXT DEFAULT 'pending',
+            github_data TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+            UNIQUE(project_id, issue_number)
         )");
 
         $this->db = $this->createMock(Database::class);
@@ -52,6 +67,18 @@ class ProjectDBIntegrationTest extends TestCase
         $this->assertTrue($result);
 
         $projects = $this->projectModel->findByUserId($userId);
+        $this->assertCount(1, $projects);
+        $this->assertEquals($repo, $projects[0]['github_repo']);
+        $this->assertNotEmpty($projects[0]['webhook_secret']);
+    }
+
+    public function testFindByRepo()
+    {
+        $userId = 1;
+        $repo = 'owner/repo';
+        $this->projectModel->create($userId, $repo);
+
+        $projects = $this->projectModel->findByRepo($repo);
         $this->assertCount(1, $projects);
         $this->assertEquals($repo, $projects[0]['github_repo']);
     }

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\WebhookHandler;
+use PDO;
+
+class WebhookHandlerTest extends TestCase
+{
+    private $db;
+    private $pdo;
+    private $handler;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->pdo->exec("CREATE TABLE tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id INT NOT NULL,
+            issue_number INT NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            body TEXT,
+            status TEXT DEFAULT 'pending',
+            github_data TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(project_id, issue_number)
+        )");
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        $this->handler = new WebhookHandler($this->db);
+    }
+
+    public function testVerifySignature()
+    {
+        $payload = '{"action":"opened"}';
+        $secret = 'test_secret';
+        $signature = 'sha256=' . hash_hmac('sha256', $payload, $secret);
+
+        $this->assertTrue($this->handler->verifySignature($payload, $signature, $secret));
+        $this->assertFalse($this->handler->verifySignature($payload, 'wrong_signature', $secret));
+    }
+
+    public function testHandleIssueOpened()
+    {
+        $projectId = 1;
+        $event = [
+            'action' => 'opened',
+            'issue' => [
+                'number' => 123,
+                'title' => 'Test Issue',
+                'body' => 'Issue description'
+            ]
+        ];
+
+        $result = $this->handler->handle($projectId, $event);
+        $this->assertTrue($result);
+
+        $stmt = $this->pdo->prepare("SELECT * FROM tasks WHERE project_id = ? AND issue_number = ?");
+        $stmt->execute([$projectId, 123]);
+        $task = $stmt->fetch();
+
+        $this->assertNotFalse($task);
+        $this->assertEquals('Test Issue', $task['title']);
+        $this->assertEquals('Issue description', $task['body']);
+        $this->assertEquals('pending', $task['status']);
+    }
+
+    public function testHandleIssueUpdate()
+    {
+        $projectId = 1;
+        $eventOpened = [
+            'action' => 'opened',
+            'issue' => [
+                'number' => 123,
+                'title' => 'Original Title',
+                'body' => 'Original Body'
+            ]
+        ];
+
+        $this->handler->handle($projectId, $eventOpened);
+
+        $eventEdited = [
+            'action' => 'edited',
+            'issue' => [
+                'number' => 123,
+                'title' => 'Updated Title',
+                'body' => 'Updated Body'
+            ]
+        ];
+
+        $result = $this->handler->handle($projectId, $eventEdited);
+        $this->assertTrue($result);
+
+        $stmt = $this->pdo->prepare("SELECT * FROM tasks WHERE project_id = ? AND issue_number = ?");
+        $stmt->execute([$projectId, 123]);
+        $task = $stmt->fetch();
+
+        $this->assertEquals('Updated Title', $task['title']);
+        $this->assertEquals('Updated Body', $task['body']);
+    }
+
+    public function testHandleUnsupportedAction()
+    {
+        $projectId = 1;
+        $event = [
+            'action' => 'labeled',
+            'issue' => [
+                'number' => 123,
+                'title' => 'Test Issue',
+                'body' => 'Issue description'
+            ]
+        ];
+
+        $result = $this->handler->handle($projectId, $event);
+        $this->assertFalse($result);
+    }
+}

--- a/test/Unit/DB/SchemaTest.php
+++ b/test/Unit/DB/SchemaTest.php
@@ -33,6 +33,9 @@ class SchemaTest extends TestCase
             $query = str_ireplace('AUTO_INCREMENT', '', $query);
             $query = preg_replace('/ENGINE=InnoDB.*/i', '', $query);
             $query = str_ireplace('TIMESTAMP DEFAULT CURRENT_TIMESTAMP', 'DATETIME DEFAULT CURRENT_TIMESTAMP', $query);
+            $query = preg_replace('/ENUM\([^)]+\)/i', 'TEXT', $query);
+            $query = str_ireplace('ON UPDATE CURRENT_TIMESTAMP', '', $query);
+            $query = preg_replace('/UNIQUE KEY \w+ \(/i', 'UNIQUE(', $query);
 
             $this->pdo->exec($query);
         }
@@ -61,6 +64,24 @@ class SchemaTest extends TestCase
         $this->assertContains('id', $columnNames);
         $this->assertContains('user_id', $columnNames);
         $this->assertContains('github_repo', $columnNames);
+        $this->assertContains('webhook_secret', $columnNames);
         $this->assertContains('created_at', $columnNames);
+    }
+
+    public function testTasksTableHasCorrectColumns()
+    {
+        $stmt = $this->pdo->query("PRAGMA table_info(tasks)");
+        $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $columnNames = array_column($columns, 'name');
+        $this->assertContains('id', $columnNames);
+        $this->assertContains('project_id', $columnNames);
+        $this->assertContains('issue_number', $columnNames);
+        $this->assertContains('title', $columnNames);
+        $this->assertContains('body', $columnNames);
+        $this->assertContains('status', $columnNames);
+        $this->assertContains('github_data', $columnNames);
+        $this->assertContains('created_at', $columnNames);
+        $this->assertContains('updated_at', $columnNames);
     }
 }


### PR DESCRIPTION
This PR implements the next step in the roadmap by adding GitHub webhook integration. The application can now receive issue events (opened, reopened, edited) from GitHub, verify the authenticity of the requests, and synchronize the issue data into a local `tasks` table. This provides the foundation for future agent orchestration based on these tasks.

Fixes #34

---
*PR created automatically by Jules for task [13708188375636522487](https://jules.google.com/task/13708188375636522487) started by @chatelao*