### PR TITLE
Implement GitHub status tracking and agent response persistence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,9 +14,9 @@
 - [x] Basic issue-to-task mapping.
 
 ## Phase 3: Agent Orchestration
-- [ ] Integrate Google Jules API.
-- [ ] Build the orchestration engine to trigger agents from issues.
-- [ ] Implement progress tracking and status updates back to GitHub.
+- [x] Integrate Google Jules API.
+- [x] Build the orchestration engine to trigger agents from issues.
+- [x] Implement progress tracking and status updates back to GitHub.
 - [ ] Add logging and monitoring for agent activities.
 
 ## Phase 4: Refinement & Scaling

--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App;
+
+use Github\Client;
+use Github\AuthMethod;
+use Exception;
+
+class GitHubService
+{
+    private Client $client;
+
+    public function __construct(?Client $client = null, ?string $token = null)
+    {
+        $this->client = $client ?? new Client();
+        if ($token) {
+            $this->client->authenticate($token, null, AuthMethod::ACCESS_TOKEN);
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function postComment(string $repo, int $issueNumber, string $comment): array
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+
+        return $this->client->api('issue')->comments()->create($username, $repository, $issueNumber, [
+            'body' => $comment
+        ]);
+    }
+}

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -37,6 +37,14 @@ class Task
         return $stmt->execute([$status, $id]);
     }
 
+    public function updateAgentResponse(int $id, string $response, string $status = 'completed'): bool
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "UPDATE tasks SET agent_response = ?, status = ? WHERE id = ?"
+        );
+        return $stmt->execute([$response, $status, $id]);
+    }
+
     public function create(array $data): bool
     {
         $stmt = $this->db->getConnection()->prepare(

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -8,6 +8,7 @@ use App\User;
 use App\Project;
 use App\Task;
 use App\JulesService;
+use App\GitHubService;
 
 $auth = new Auth();
 $db = new Database();
@@ -44,12 +45,39 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['trigger_agent'])) {
 
     if ($task && $task['project_id'] === $project['id']) {
         try {
-            $lastAgentResponse = $julesService->triggerAgent($task);
+            $githubToken = $user['github_token'] ?? null;
+            $githubService = null;
+            if ($githubToken) {
+                $githubService = new GitHubService(null, $githubToken);
+            }
+
+            // Update status to in_progress
             $taskModel->updateStatus($taskId, 'in_progress');
+
+            if ($githubService) {
+                $githubService->postComment($project['github_repo'], $task['issue_number'], "🤖 Agent has started processing this issue...");
+            }
+
+            $lastAgentResponse = $julesService->triggerAgent($task);
+
+            $taskModel->updateAgentResponse($taskId, $lastAgentResponse, 'completed');
+
+            if ($githubService) {
+                $githubService->postComment($project['github_repo'], $task['issue_number'], "✅ Agent has completed the analysis:\n\n" . $lastAgentResponse);
+            }
+
             // Refresh tasks
             $tasks = $taskModel->findByProjectId($projectId);
         } catch (\Exception $e) {
             $errorMessage = "Error triggering agent: " . $e->getMessage();
+            $taskModel->updateStatus($taskId, 'failed');
+            if (isset($githubService) && $githubService) {
+                try {
+                    $githubService->postComment($project['github_repo'], $task['issue_number'], "❌ Agent failed to process this issue: " . $e->getMessage());
+                } catch (\Exception $ge) {
+                    // Ignore GitHub commenting errors on top of main error
+                }
+            }
         }
     }
 }

--- a/src/sql/schema.sql
+++ b/src/sql/schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     body TEXT,
     status ENUM('pending', 'in_progress', 'completed', 'failed') DEFAULT 'pending',
     github_data JSON,
+    agent_response TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,

--- a/test/Integration/verify_project_ui.php
+++ b/test/Integration/verify_project_ui.php
@@ -7,6 +7,9 @@ use App\User;
 use App\Project;
 use App\Task;
 
+// Set environment for testing
+putenv('DB_NAME=:memory:');
+
 // Initialize session if not started
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
@@ -44,6 +47,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     body TEXT,
     status TEXT DEFAULT 'pending',
     github_data TEXT,
+    agent_response TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(project_id, issue_number)

--- a/test/Unit/GitHubServiceTest.php
+++ b/test/Unit/GitHubServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\GitHubService;
+use Github\Client;
+use Github\Api\Issue;
+use Github\Api\Issue\Comments;
+
+class GitHubServiceTest extends TestCase
+{
+    public function testPostComment()
+    {
+        $mockComments = $this->createMock(Comments::class);
+        $mockComments->expects($this->once())
+            ->method('create')
+            ->with('owner', 'repo', 123, ['body' => 'Test comment'])
+            ->willReturn(['id' => 1]);
+
+        $mockIssue = $this->createMock(Issue::class);
+        $mockIssue->method('comments')->willReturn($mockComments);
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->method('api')->with('issue')->willReturn($mockIssue);
+
+        $service = new GitHubService($mockClient);
+        $result = $service->postComment('owner/repo', 123, 'Test comment');
+
+        $this->assertEquals(['id' => 1], $result);
+    }
+
+    public function testPostCommentInvalidRepo()
+    {
+        $service = new GitHubService();
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Invalid repository name: invalid-repo");
+        $service->postComment('invalid-repo', 123, 'Test comment');
+    }
+}


### PR DESCRIPTION
This change integrates GitHub issue commenting and local storage of agent responses. When an agent is triggered from the project dashboard, it now posts status updates (started, completed, failed) back to the corresponding GitHub issue. The agent's final analysis is also saved in the database and displayed in the UI.

Fixes #38

---
*PR created automatically by Jules for task [14814746129925680404](https://jules.google.com/task/14814746129925680404) started by @chatelao*