### PR TITLE
Automated UI Screenshots and CI Artifact Upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.3'
         extensions: mbstring, xml, ctype, iconv, mysql
         coverage: xdebug
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
     - name: Install dependencies
       run: ./test/install.sh
-    - name: Run tests
+
+    - name: Run PHPUnit tests
       run: composer test
+
+    - name: Run UI tests with screenshots
+      run: python3 test/Integration/verify_ui.py
+
+    - name: Upload screenshots
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: screenshots
+        path: test/screenshots/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .phpunit.cache/
 .env
 *.log
+/test/screenshots/

--- a/test/Integration/verify_ui.py
+++ b/test/Integration/verify_ui.py
@@ -4,6 +4,10 @@ import subprocess
 import time
 
 def run_cuj(page):
+    # Ensure screenshots directory exists
+    screenshot_dir = "test/screenshots"
+    os.makedirs(screenshot_dir, exist_ok=True)
+
     # Start the PHP server
     env = os.environ.copy()
     env["DB_NAME"] = ":memory:"
@@ -14,27 +18,27 @@ def run_cuj(page):
     time.sleep(2)  # Wait for server to start
 
     try:
+        # Step 1: Navigate to Project Details
         page.goto("http://localhost:8088")
         page.wait_for_timeout(1000)
 
         # Check if we see the project details
-        # The title should contain the repo name
         page.wait_for_selector("h1:has-text('owner/repo')")
-        page.wait_for_timeout(500)
+        page.screenshot(path=f"{screenshot_dir}/01_project_details.png")
+        print(f"Saved screenshot: {screenshot_dir}/01_project_details.png")
 
-        # Check if tasks are visible
+        # Step 2: Verify tasks are visible
         page.wait_for_selector("text=Sample Issue #1")
-        page.wait_for_timeout(500)
+        page.screenshot(path=f"{screenshot_dir}/02_tasks_list.png")
+        print(f"Saved screenshot: {screenshot_dir}/02_tasks_list.png")
 
-        # Click "Run Agent" on the first task
-        # Note: In our mock, triggerAgent returns a simulated response or error
-        # Since GOOGLE_JULES_API_KEY is likely missing, it will show an error response
+        # Step 3: Click "Run Agent" on the first task
         page.click("button:has-text('Run Agent') >> nth=0")
-        page.wait_for_timeout(1000)
+        page.wait_for_timeout(2000) # Wait for agent simulation
 
         # Take screenshot of the result (including agent response)
-        page.screenshot(path="/home/jules/verification/screenshots/project_details.png")
-        page.wait_for_timeout(1000)
+        page.screenshot(path=f"{screenshot_dir}/03_agent_triggered.png")
+        print(f"Saved screenshot: {screenshot_dir}/03_agent_triggered.png")
 
     finally:
         server_process.terminate()
@@ -42,9 +46,7 @@ def run_cuj(page):
 if __name__ == "__main__":
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
-        context = browser.new_context(
-            record_video_dir="/home/jules/verification/videos"
-        )
+        context = browser.new_context()
         page = context.new_page()
         try:
             run_cuj(page)

--- a/test/install.sh
+++ b/test/install.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
 composer install
+pip install playwright
+python3 -m playwright install --with-deps chromium


### PR DESCRIPTION
This change integrates Playwright-based UI screenshot capturing into the CI/CD pipeline as requested in GEMINI.md. 

Key changes:
1. **Dependency Management**: `test/install.sh` now installs `playwright` and the `chromium` browser.
2. **Test Logic**: `test/Integration/verify_ui.py` was enhanced to save screenshots at various stages of the project details and task execution flow. It now uses relative paths for better portability in CI environments.
3. **CI/CD Integration**: The GitHub Actions workflow (`.github/workflows/ci.yml`) now sets up Python, executes the UI tests, and uses `actions/upload-artifact` to make the captured screenshots available for review after every run.
4. **Repository Hygiene**: Added the screenshots directory to `.gitignore` to ensure binary artifacts are not tracked in the repository.

Fixes #40

---
*PR created automatically by Jules for task [12313645563522951422](https://jules.google.com/task/12313645563522951422) started by @chatelao*