### PR TITLE
Update documentation for multiple GitHub accounts support

### DIFF
--- a/CONCEPT.md
+++ b/CONCEPT.md
@@ -9,8 +9,8 @@ This application aims to provide a centralized platform for controlling and coor
 - **Improved Collaboration**: Enable team members to manage and monitor agent activities in a unified interface.
 
 ## Use Cases
-- **User Authentication**: Secure login using Google SSO to manage access for different users.
-- **Project Coordination**: Linking GitHub repositories and issues to specific agent tasks.
+- **User Authentication**: Secure login using Google SSO to manage access for different users, with support for linking multiple GitHub accounts per user.
+- **Project Coordination**: Linking GitHub repositories and issues from any connected GitHub account to specific agent tasks.
 - **Agent Triggering**: Automatically or manually initiating Google Jules agents based on GitHub issue activity.
 - **Status Monitoring**: Tracking the progress and results of agent-led tasks within the application.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -18,8 +18,8 @@ The application follows a modular architecture, separating concerns between the 
     - **Tools**: PHPUnit for unit testing, Mocking libraries for API responses
 
 ## Data Model
-- **Users**: Stores user profiles and Google SSO identifiers.
-- **Projects**: Links users to GitHub repositories.
+- **Users**: Stores user profiles, Google SSO identifiers, and associated GitHub account tokens.
+- **Projects**: Links users (via their connected GitHub accounts) to GitHub repositories.
 - **Agents**: Configurable agent definitions and their capabilities.
 - **Tasks**: Logs of agent activities, linked to GitHub issues and project progress.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,4 +23,5 @@
 - [ ] Comprehensive test suite (Unit, Integration, E2E).
 - [ ] CI/CD pipeline optimization with caching.
 - [ ] Multi-user management features and role-based access.
+- [ ] Support for multiple GitHub accounts per ai-brain user.
 - [ ] Performance tuning and security hardening.


### PR DESCRIPTION
This PR updates the project's core documentation to reflect a new goal: allowing a single ai-brain user (authenticated via Google SSO) to link and manage multiple GitHub accounts.

Changes:
- **ROADMAP.md**: Added a new task in Phase 4 for multi-GitHub account support.
- **CONCEPT.md**: Updated Use Cases for User Authentication and Project Coordination to mention multi-account support.
- **DESIGN.md**: Updated the Data Model section to specify that Users can have multiple associated GitHub tokens and Projects link to repositories via these connected accounts.

Fixes #43

---
*PR created automatically by Jules for task [8735515742756809083](https://jules.google.com/task/8735515742756809083) started by @chatelao*