### PR TITLE
Multi-account GitHub Support

### DIFF
--- a/src/backend/Project.php
+++ b/src/backend/Project.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use PDO;
+use Exception;
 
 class Project
 {
@@ -10,19 +11,31 @@ class Project
     {
     }
 
-    public function create(int $userId, string $githubRepo): bool
+    public function create(int $userId, int $githubAccountId, string $githubRepo): bool
     {
+        // Verify that the github account belongs to the user
+        $stmt = $this->db->getConnection()->prepare(
+            "SELECT id FROM user_github_accounts WHERE id = ? AND user_id = ?"
+        );
+        $stmt->execute([$githubAccountId, $userId]);
+        if (!$stmt->fetch()) {
+            throw new Exception("Invalid GitHub account selected.");
+        }
+
         $webhookSecret = bin2hex(random_bytes(16));
         $stmt = $this->db->getConnection()->prepare(
-            "INSERT INTO projects (user_id, github_repo, webhook_secret) VALUES (?, ?, ?)"
+            "INSERT INTO projects (user_id, github_account_id, github_repo, webhook_secret) VALUES (?, ?, ?, ?)"
         );
-        return $stmt->execute([$userId, $githubRepo, $webhookSecret]);
+        return $stmt->execute([$userId, $githubAccountId, $githubRepo, $webhookSecret]);
     }
 
     public function findByRepo(string $githubRepo): array
     {
         $stmt = $this->db->getConnection()->prepare(
-            "SELECT * FROM projects WHERE github_repo = ?"
+            "SELECT p.*, a.github_token, a.github_username
+             FROM projects p
+             JOIN user_github_accounts a ON p.github_account_id = a.id
+             WHERE p.github_repo = ?"
         );
         $stmt->execute([$githubRepo]);
         return $stmt->fetchAll();
@@ -31,7 +44,11 @@ class Project
     public function findByUserId(int $userId): array
     {
         $stmt = $this->db->getConnection()->prepare(
-            "SELECT * FROM projects WHERE user_id = ? ORDER BY created_at DESC"
+            "SELECT p.*, a.github_username
+             FROM projects p
+             JOIN user_github_accounts a ON p.github_account_id = a.id
+             WHERE p.user_id = ?
+             ORDER BY p.created_at DESC"
         );
         $stmt->execute([$userId]);
         return $stmt->fetchAll();
@@ -40,7 +57,10 @@ class Project
     public function findById(int $id): ?array
     {
         $stmt = $this->db->getConnection()->prepare(
-            "SELECT * FROM projects WHERE id = ?"
+            "SELECT p.*, a.github_token, a.github_username
+             FROM projects p
+             JOIN user_github_accounts a ON p.github_account_id = a.id
+             WHERE p.id = ?"
         );
         $stmt->execute([$id]);
         $project = $stmt->fetch();

--- a/src/backend/User.php
+++ b/src/backend/User.php
@@ -56,11 +56,34 @@ class User
         }
     }
 
-    public function updateGitHubCredentials(int $id, string $token, string $username): bool
+    public function addGitHubAccount(int $userId, string $token, string $username): bool
+    {
+        // Check database type first
+        $dbType = $this->db->getConnection()->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($dbType === 'sqlite') {
+            $stmt = $this->db->getConnection()->prepare(
+                "INSERT INTO user_github_accounts (user_id, github_token, github_username)
+                 VALUES (?, ?, ?)
+                 ON CONFLICT(user_id, github_username) DO UPDATE SET github_token = excluded.github_token"
+            );
+            return $stmt->execute([$userId, $token, $username]);
+        }
+
+        $stmt = $this->db->getConnection()->prepare(
+            "INSERT INTO user_github_accounts (user_id, github_token, github_username)
+             VALUES (?, ?, ?)
+             ON DUPLICATE KEY UPDATE github_token = ?"
+        );
+        return $stmt->execute([$userId, $token, $username, $token]);
+    }
+
+    public function getGitHubAccounts(int $userId): array
     {
         $stmt = $this->db->getConnection()->prepare(
-            "UPDATE users SET github_token = ?, github_username = ? WHERE id = ?"
+            "SELECT * FROM user_github_accounts WHERE user_id = ?"
         );
-        return $stmt->execute([$token, $username, $id]);
+        $stmt->execute([$userId]);
+        return $stmt->fetchAll();
     }
 }

--- a/src/frontend/github-callback.php
+++ b/src/frontend/github-callback.php
@@ -18,7 +18,7 @@ $githubAuth = new GitHubAuth();
 if (isset($_GET['code']) && isset($_GET['state'])) {
     try {
         $githubData = $githubAuth->authenticate($_GET['code'], $_GET['state']);
-        $userModel->updateGitHubCredentials($auth->getUserId(), $githubData['access_token'], $githubData['github_username']);
+        $userModel->addGitHubAccount($auth->getUserId(), $githubData['access_token'], $githubData['github_username']);
         header('Location: index.php?github=success');
         exit;
     } catch (Exception $e) {

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -15,15 +15,20 @@ $projectModel = new Project($db);
 $user = $auth->isLoggedIn() ? $userModel->findById($auth->getUserId()) : null;
 
 // Handle Project Creation
-if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['github_repo'])) {
+if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['github_repo']) && isset($_POST['github_account_id'])) {
     if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
         die("CSRF token validation failed.");
     }
     $repo = trim($_POST['github_repo']);
-    if (!empty($repo)) {
-        $projectModel->create($user['id'], $repo);
-        header('Location: index.php?success=project_created');
-        exit;
+    $accountId = (int)$_POST['github_account_id'];
+    if (!empty($repo) && $accountId > 0) {
+        try {
+            $projectModel->create($user['id'], $accountId, $repo);
+            header('Location: index.php?success=project_created');
+            exit;
+        } catch (Exception $e) {
+            $errorMessage = $e->getMessage();
+        }
     }
 }
 
@@ -38,6 +43,9 @@ if ($user && isset($_GET['delete_project'])) {
 }
 
 $projects = $user ? $projectModel->findByUserId($user['id']) : [];
+$githubAccounts = $user ? $userModel->getGitHubAccounts($user['id']) : [];
+
+$errorMessage = $errorMessage ?? null;
 
 ?>
 <!DOCTYPE html>
@@ -90,25 +98,37 @@ $projects = $user ? $projectModel->findByUserId($user['id']) : [];
                         </div>
                     <?php endif; ?>
 
+                    <?php if ($errorMessage): ?>
+                        <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+                            <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
+                        </div>
+                    <?php endif; ?>
+
                     <div class="grid w-full grid-cols-1 gap-4 mt-4">
                         <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm sm:p-6">
                             <h3 class="text-base font-normal text-gray-500">Welcome to Agent Control</h3>
                             <?php if ($user): ?>
                                 <p class="text-2xl font-bold leading-none text-gray-900 sm:text-3xl">Dashboard</p>
-                                <div class="mt-4 flex items-center justify-between">
-                                    <div>
-                                        <p class="text-gray-600">You are logged in as <strong><?= htmlspecialchars($user['email']) ?></strong>.</p>
-                                        <?php if ($user['github_username']): ?>
-                                            <p class="text-green-600 flex items-center mt-1">
-                                                <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-                                                Linked to GitHub as <strong><?= htmlspecialchars($user['github_username']) ?></strong>
-                                            </p>
-                                        <?php else: ?>
+                                <div class="mt-4">
+                                    <p class="text-gray-600">You are logged in as <strong><?= htmlspecialchars($user['email']) ?></strong>.</p>
+                                    <div class="mt-4">
+                                        <h4 class="text-lg font-semibold text-gray-900">Linked GitHub Accounts</h4>
+                                        <div class="mt-2 space-y-2">
+                                            <?php if (empty($githubAccounts)): ?>
+                                                <p class="text-sm text-gray-500 italic">No GitHub accounts linked yet.</p>
+                                            <?php else: ?>
+                                                <?php foreach ($githubAccounts as $account): ?>
+                                                    <div class="flex items-center text-green-600">
+                                                        <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+                                                        Linked as <strong><?= htmlspecialchars($account['github_username']) ?></strong>
+                                                    </div>
+                                                <?php endforeach; ?>
+                                            <?php endif; ?>
                                             <a href="github-login.php" class="mt-2 inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-gray-800 rounded-lg hover:bg-gray-900 focus:ring-4 focus:outline-none focus:ring-gray-300">
                                                 <svg class="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-                                                Link GitHub Account
+                                                Link <?= empty($githubAccounts) ? 'GitHub Account' : 'Another GitHub Account' ?>
                                             </a>
-                                        <?php endif; ?>
+                                        </div>
                                     </div>
                                 </div>
 
@@ -123,7 +143,7 @@ $projects = $user ? $projectModel->findByUserId($user['id']) : [];
                                                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
                                                     </a>
                                                 </div>
-                                                <p class="text-sm text-gray-500 mt-1">Linked GitHub Repository</p>
+                                                <p class="text-sm text-gray-500 mt-1">Linked as <?= htmlspecialchars($project['github_username']) ?></p>
                                                 <div class="mt-4">
                                                     <a href="project.php?id=<?= $project['id'] ?>" class="text-blue-600 hover:underline text-sm font-medium">View Project Details &rarr;</a>
                                                 </div>
@@ -132,13 +152,26 @@ $projects = $user ? $projectModel->findByUserId($user['id']) : [];
 
                                         <!-- Add Project Card -->
                                         <div class="p-4 bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg flex flex-col items-center justify-center">
-                                            <form method="POST" class="w-full">
-                                                <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
-                                                <div class="mb-2">
-                                                    <input type="text" name="github_repo" placeholder="owner/repo" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
-                                                </div>
-                                                <button type="submit" class="w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Link New Repository</button>
-                                            </form>
+                                            <?php if (empty($githubAccounts)): ?>
+                                                <p class="text-sm text-gray-500 text-center">Please link a GitHub account first.</p>
+                                            <?php else: ?>
+                                                <form method="POST" class="w-full">
+                                                    <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                                    <div class="mb-2">
+                                                        <label class="block mb-1 text-xs font-medium text-gray-900">GitHub Account</label>
+                                                        <select name="github_account_id" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                                            <?php foreach ($githubAccounts as $account): ?>
+                                                                <option value="<?= $account['id'] ?>"><?= htmlspecialchars($account['github_username']) ?></option>
+                                                            <?php endforeach; ?>
+                                                        </select>
+                                                    </div>
+                                                    <div class="mb-2">
+                                                        <label class="block mb-1 text-xs font-medium text-gray-900">Repository (owner/repo)</label>
+                                                        <input type="text" name="github_repo" placeholder="owner/repo" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                                    </div>
+                                                    <button type="submit" class="w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Link New Repository</button>
+                                                </form>
+                                            <?php endif; ?>
                                         </div>
                                     </div>
                                 </div>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -48,7 +48,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['trigger_agent'])) {
     if ($task && $task['project_id'] === $project['id']) {
         try {
             $logger->log($taskId, "Agent triggered by user " . $user['name']);
-            $githubToken = $user['github_token'] ?? null;
+            $githubToken = $project['github_token'] ?? null;
             $githubService = null;
             if ($githubToken) {
                 $githubService = new GitHubService(null, $githubToken);

--- a/src/sql/schema.sql
+++ b/src/sql/schema.sql
@@ -4,18 +4,28 @@ CREATE TABLE IF NOT EXISTS users (
     name VARCHAR(255) NOT NULL,
     email VARCHAR(255) UNIQUE NOT NULL,
     avatar VARCHAR(255),
-    github_token VARCHAR(255),
-    github_username VARCHAR(255),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS user_github_accounts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    github_username VARCHAR(255) NOT NULL,
+    github_token VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    UNIQUE KEY user_github (user_id, github_username)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS projects (
     id INT AUTO_INCREMENT PRIMARY KEY,
     user_id INT NOT NULL,
+    github_account_id INT NOT NULL,
     github_repo VARCHAR(255) NOT NULL,
     webhook_secret VARCHAR(255),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (github_account_id) REFERENCES user_github_accounts(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS tasks (

--- a/test/Integration/ProjectDBIntegrationTest.php
+++ b/test/Integration/ProjectDBIntegrationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Integration;
 use PHPUnit\Framework\TestCase;
 use App\Database;
 use App\Project;
+use App\User;
 use PDO;
 
 class ProjectDBIntegrationTest extends TestCase
@@ -12,6 +13,7 @@ class ProjectDBIntegrationTest extends TestCase
     private $db;
     private $pdo;
     private $projectModel;
+    private $userModel;
 
     protected function setUp(): void
     {
@@ -24,70 +26,83 @@ class ProjectDBIntegrationTest extends TestCase
             name VARCHAR(255) NOT NULL,
             email VARCHAR(255) UNIQUE NOT NULL,
             avatar VARCHAR(255),
-            github_token VARCHAR(255),
-            github_username VARCHAR(255),
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )");
+
+        $this->pdo->exec("CREATE TABLE user_github_accounts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INT NOT NULL,
+            github_username VARCHAR(255) NOT NULL,
+            github_token VARCHAR(255) NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            UNIQUE(user_id, github_username)
         )");
 
         $this->pdo->exec("CREATE TABLE projects (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INT NOT NULL,
+            github_account_id INT NOT NULL,
             github_repo VARCHAR(255) NOT NULL,
             webhook_secret VARCHAR(255),
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-        )");
-
-        $this->pdo->exec("CREATE TABLE tasks (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            project_id INT NOT NULL,
-            issue_number INT NOT NULL,
-            title VARCHAR(255) NOT NULL,
-            body TEXT,
-            status TEXT DEFAULT 'pending',
-            github_data TEXT,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
-            UNIQUE(project_id, issue_number)
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (github_account_id) REFERENCES user_github_accounts(id) ON DELETE CASCADE
         )");
 
         $this->db = $this->createMock(Database::class);
         $this->db->method('getConnection')->willReturn($this->pdo);
 
         $this->projectModel = new Project($this->db);
+        $this->userModel = new User($this->db);
+    }
+
+    private function setupUserAndAccount()
+    {
+        $this->userModel->createOrUpdate([
+            'google_id' => 'google-123',
+            'name' => 'Test User',
+            'email' => 'test@example.com'
+        ]);
+        $this->userModel->addGitHubAccount(1, 'token-123', 'github-user');
+        return 1; // github_account_id
     }
 
     public function testCreateProject()
     {
+        $accountId = $this->setupUserAndAccount();
         $userId = 1;
         $repo = 'owner/repo';
 
-        $result = $this->projectModel->create($userId, $repo);
+        $result = $this->projectModel->create($userId, $accountId, $repo);
         $this->assertTrue($result);
 
         $projects = $this->projectModel->findByUserId($userId);
         $this->assertCount(1, $projects);
         $this->assertEquals($repo, $projects[0]['github_repo']);
+        $this->assertEquals('github-user', $projects[0]['github_username']);
         $this->assertNotEmpty($projects[0]['webhook_secret']);
     }
 
     public function testFindByRepo()
     {
+        $accountId = $this->setupUserAndAccount();
         $userId = 1;
         $repo = 'owner/repo';
-        $this->projectModel->create($userId, $repo);
+        $this->projectModel->create($userId, $accountId, $repo);
 
         $projects = $this->projectModel->findByRepo($repo);
         $this->assertCount(1, $projects);
         $this->assertEquals($repo, $projects[0]['github_repo']);
+        $this->assertEquals('token-123', $projects[0]['github_token']);
     }
 
     public function testDeleteProject()
     {
+        $accountId = $this->setupUserAndAccount();
         $userId = 1;
         $repo = 'owner/repo';
-        $this->projectModel->create($userId, $repo);
+        $this->projectModel->create($userId, $accountId, $repo);
         $projects = $this->projectModel->findByUserId($userId);
         $projectId = $projects[0]['id'];
 
@@ -96,5 +111,24 @@ class ProjectDBIntegrationTest extends TestCase
 
         $projects = $this->projectModel->findByUserId($userId);
         $this->assertCount(0, $projects);
+    }
+
+    public function testCreateProjectWithUnauthorizedAccount()
+    {
+        $this->setupUserAndAccount(); // Sets up User 1 and Account 1
+
+        // Setup User 2
+        $this->userModel->createOrUpdate([
+            'google_id' => 'google-456',
+            'name' => 'User 2',
+            'email' => 'user2@example.com'
+        ]);
+        $userId2 = 2;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Invalid GitHub account selected.");
+
+        // User 2 tries to use Account 1
+        $this->projectModel->create($userId2, 1, 'user2/repo');
     }
 }

--- a/test/Integration/UserDBIntegrationTest.php
+++ b/test/Integration/UserDBIntegrationTest.php
@@ -27,6 +27,16 @@ class UserDBIntegrationTest extends TestCase
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
         )");
 
+        $this->pdo->exec("CREATE TABLE user_github_accounts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INT NOT NULL,
+            github_username VARCHAR(255) NOT NULL,
+            github_token VARCHAR(255) NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            UNIQUE(user_id, github_username)
+        )");
+
         $this->db = $this->createMock(Database::class);
         $this->db->method('getConnection')->willReturn($this->pdo);
 
@@ -52,30 +62,28 @@ class UserDBIntegrationTest extends TestCase
         $this->assertEquals('int@example.com', $foundUser['email']);
     }
 
-    public function testCreateOrUpdateUpdatesExistingUser()
+    public function testAddAndGetGitHubAccounts()
     {
-        $userData = [
+        $user = $this->userModel->createOrUpdate([
             'google_id' => 'google-int-123',
-            'name' => 'Original Name',
-            'email' => 'int@example.com',
-            'avatar' => 'avatar.jpg'
-        ];
+            'name' => 'Integration User',
+            'email' => 'int@example.com'
+        ]);
 
-        $this->userModel->createOrUpdate($userData);
+        $this->userModel->addGitHubAccount($user['id'], 'token1', 'user1');
+        $this->userModel->addGitHubAccount($user['id'], 'token2', 'user2');
 
-        $updatedData = [
-            'google_id' => 'google-int-123',
-            'name' => 'Updated Name',
-            'email' => 'int@example.com',
-            'avatar' => 'new_avatar.jpg'
-        ];
+        $accounts = $this->userModel->getGitHubAccounts($user['id']);
+        $this->assertCount(2, $accounts);
 
-        $user = $this->userModel->createOrUpdate($updatedData);
+        $this->userModel->addGitHubAccount($user['id'], 'token1-updated', 'user1');
+        $accounts = $this->userModel->getGitHubAccounts($user['id']);
+        $this->assertCount(2, $accounts);
 
-        $this->assertEquals('Updated Name', $user['name']);
-        $this->assertEquals('new_avatar.jpg', $user['avatar']);
-
-        $stmt = $this->pdo->query("SELECT COUNT(*) FROM users");
-        $this->assertEquals(1, $stmt->fetchColumn());
+        foreach ($accounts as $account) {
+            if ($account['github_username'] === 'user1') {
+                $this->assertEquals('token1-updated', $account['github_token']);
+            }
+        }
     }
 }

--- a/test/Integration/verify_project_ui.php
+++ b/test/Integration/verify_project_ui.php
@@ -25,18 +25,28 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS users (
     name VARCHAR(255) NOT NULL,
     email VARCHAR(255) UNIQUE NOT NULL,
     avatar VARCHAR(255),
-    github_token VARCHAR(255),
-    github_username VARCHAR(255),
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_github_accounts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    github_username VARCHAR(255) NOT NULL,
+    github_token VARCHAR(255) NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    UNIQUE(user_id, github_username)
 )");
 
 $pdo->exec("CREATE TABLE IF NOT EXISTS projects (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INT NOT NULL,
+    github_account_id INT NOT NULL,
     github_repo VARCHAR(255) NOT NULL,
     webhook_secret VARCHAR(255),
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (github_account_id) REFERENCES user_github_accounts(id) ON DELETE CASCADE
 )");
 
 $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -67,9 +77,13 @@ $userModel = new User($db);
 $pdo->exec("INSERT OR IGNORE INTO users (id, google_id, name, email) VALUES (1, 'google-123', 'Test User', 'test@example.com')");
 $_SESSION['user_id'] = 1;
 
+// Add GitHub account
+$userModel->addGitHubAccount(1, 'mock-token', 'mock-user');
+$githubAccountId = $pdo->lastInsertId();
+
 // Create a mock project
 $projectModel = new Project($db);
-$projectModel->create(1, 'owner/repo');
+$projectModel->create(1, $githubAccountId, 'owner/repo');
 $project = $projectModel->findByRepo('owner/repo')[0];
 
 // Create some tasks

--- a/test/Unit/UserGitHubAccountTest.php
+++ b/test/Unit/UserGitHubAccountTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\User;
+use PDO;
+use PDOStatement;
+
+class UserGitHubAccountTest extends TestCase
+{
+    private $db;
+    private $pdo;
+    private $userModel;
+
+    protected function setUp(): void
+    {
+        $this->pdo = $this->createMock(PDO::class);
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+        $this->userModel = new User($this->db);
+    }
+
+    public function testAddGitHubAccount()
+    {
+        $this->pdo->method('getAttribute')->with(PDO::ATTR_DRIVER_NAME)->willReturn('mysql');
+
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->expects($this->once())
+             ->method('execute')
+             ->with([1, 'token123', 'user123', 'token123'])
+             ->willReturn(true);
+
+        $this->pdo->expects($this->once())
+                  ->method('prepare')
+                  ->with($this->stringContains("INSERT INTO user_github_accounts"))
+                  ->willReturn($stmt);
+
+        $result = $this->userModel->addGitHubAccount(1, 'token123', 'user123');
+        $this->assertTrue($result);
+    }
+
+    public function testGetGitHubAccounts()
+    {
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->expects($this->once())
+             ->method('execute')
+             ->with([1]);
+        $stmt->expects($this->once())
+             ->method('fetchAll')
+             ->willReturn([
+                 ['id' => 1, 'user_id' => 1, 'github_username' => 'user1', 'github_token' => 'token1'],
+                 ['id' => 2, 'user_id' => 1, 'github_username' => 'user2', 'github_token' => 'token2']
+             ]);
+
+        $this->pdo->expects($this->once())
+                  ->method('prepare')
+                  ->with($this->stringContains("SELECT * FROM user_github_accounts"))
+                  ->willReturn($stmt);
+
+        $accounts = $this->userModel->getGitHubAccounts(1);
+        $this->assertCount(2, $accounts);
+        $this->assertEquals('user1', $accounts[0]['github_username']);
+        $this->assertEquals('user2', $accounts[1]['github_username']);
+    }
+}


### PR DESCRIPTION
This change implements the "Support for multiple GitHub accounts per ai-brain user" step from Phase 4 of the roadmap. 

Key changes:
1. **Schema Evolution**: Introduced a new table `user_github_accounts` and modified `projects` to use a foreign key `github_account_id`.
2. **Backend Logic**: 
   - `User::addGitHubAccount` and `User::getGitHubAccounts` now manage tokens in the new table.
   - `Project::create` now includes a mandatory check to ensure the chosen GitHub account belongs to the authenticated user.
   - Repository lookups now correctly join with the accounts table to retrieve the associated OAuth token.
3. **Frontend Enhancement**: 
   - The dashboard now lists all linked GitHub accounts.
   - Users can link additional accounts.
   - When adding a new repository, users must select which of their linked accounts to use.
4. **Verification**:
   - Comprehensive unit and integration tests (using SQLite in-memory) confirm the correctness of the new logic and the effectiveness of the security fix.
   - Playwright scripts verified the project details view remains functional.

Fixes #46

---
*PR created automatically by Jules for task [1843330296669826464](https://jules.google.com/task/1843330296669826464) started by @chatelao*