### PR TITLE
Setup Read the Docs with MyST-Parser for Markdown embedding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,17 @@ jobs:
     - name: Run UI tests with screenshots
       run: python3 test/Integration/verify_ui.py
 
-    - name: Upload screenshots
+    - name: Install documentation dependencies
+      run: pip install -r docs/requirements.txt
+
+    - name: Build documentation
+      run: sphinx-build -b html docs docs/_build/html
+
+    - name: Upload artifacts
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: screenshots
-        path: test/screenshots/
+        name: all-artifacts
+        path: |
+          test/screenshots/
+          docs/_build/html/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .env
 *.log
 /test/screenshots/
+/docs/_build/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,0 +1,43 @@
+# HOWTO: Setup Read the Docs
+
+This guide explains how to set up and build the documentation for AI Brain using Sphinx and Read the Docs.
+
+## Local Setup
+
+To build the documentation locally, you need Python installed. Follow these steps:
+
+1. **Install dependencies:**
+   ```bash
+   pip install -r docs/requirements.txt
+   ```
+
+2. **Build HTML documentation:**
+   ```bash
+   sphinx-build -b html docs docs/_build/html
+   ```
+
+3. **View the documentation:**
+   Open `docs/_build/html/index.html` in your web browser.
+
+## Read the Docs Configuration
+
+The project is pre-configured for Read the Docs (RTD) using the following files:
+
+- `.readthedocs.yaml`: Defines the build environment (Ubuntu 22.04, Python 3.11) and points to the requirements file.
+- `docs/requirements.txt`: Lists necessary Python packages (`sphinx`, `sphinx-rtd-theme`, `myst-parser`).
+- `docs/conf.py`: Sphinx configuration file, including `myst_parser` setup for Markdown support.
+
+## Embedding Markdown
+
+We use the `myst_parser` to embed Markdown files into reStructuredText. This allows us to keep our main documentation in Markdown while using Sphinx's powerful features.
+
+To include a Markdown file in a `.rst` file, use the following syntax:
+
+```rst
+.. include:: ../FILENAME.md
+   :parser: myst_parser.sphinx_
+```
+
+## GitHub Actions Integration
+
+The documentation is automatically built during the CI/CD process. You can find the build steps in `.github/workflows/ci.yml`. The generated HTML is uploaded as a workflow artifact named `all-artifacts`.

--- a/docs/concept.rst
+++ b/docs/concept.rst
@@ -1,0 +1,5 @@
+CONCEPT
+=======
+
+.. include:: ../CONCEPT.md
+   :parser: myst_parser.sphinx_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,49 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'AI Brain'
+copyright = '2024, AI Brain Team'
+author = 'AI Brain Team'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'myst_parser',
+    'sphinx_rtd_theme',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+
+# -- MyST Parser configuration -----------------------------------------------
+myst_enable_extensions = [
+    "amsmath",
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "fieldlist",
+    "html_admonition",
+    "html_image",
+    "linkify",
+    "replacements",
+    "smartquotes",
+    "strikethrough",
+    "substitution",
+    "tasklist",
+]

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -1,0 +1,5 @@
+DESIGN
+======
+
+.. include:: ../DESIGN.md
+   :parser: myst_parser.sphinx_

--- a/docs/gemini.rst
+++ b/docs/gemini.rst
@@ -1,0 +1,5 @@
+GEMINI
+======
+
+.. include:: ../GEMINI.md
+   :parser: myst_parser.sphinx_

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -1,0 +1,5 @@
+HOWTO
+=====
+
+.. include:: ../HOWTO.md
+   :parser: myst_parser.sphinx_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Welcome to AI Brain's documentation!
    design
    roadmap
    gemini
+   howto
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,19 @@
+Welcome to AI Brain's documentation!
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   readme
+   concept
+   design
+   roadmap
+   gemini
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,0 +1,5 @@
+README
+======
+
+.. include:: ../README.md
+   :parser: myst_parser.sphinx_

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx-rtd-theme
+myst-parser[linkify]

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -1,0 +1,5 @@
+ROADMAP
+=======
+
+.. include:: ../ROADMAP.md
+   :parser: myst_parser.sphinx_


### PR DESCRIPTION
This change initializes a Sphinx documentation structure in the 'docs/' directory. It configures 'myst_parser' to allow embedding existing Markdown files (README.md, CONCEPT.md, etc.) into reStructuredText files using the requested ':parser: myst_parser.sphinx_' option. It also includes Read the Docs build configuration and updates '.gitignore' to exclude build artifacts.

Fixes #58

---
*PR created automatically by Jules for task [5016042511153960339](https://jules.google.com/task/5016042511153960339) started by @chatelao*