### PR TITLE
Add Read the Docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Agent Control PHP Application
+[![Documentation Status](https://readthedocs.org/projects/ai-brain/badge/?version=latest)](https://ai-brain.readthedocs.io/en/latest/?badge=latest)
 
 ## Overview
 A PHP application to control agents from Google Jules, coordinated by GitHub repositories and issues. It provides a centralized platform for managing AI agent workflows through a unified web interface.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,10 @@
 Welcome to AI Brain's documentation!
 ====================================
 
+.. image:: https://readthedocs.org/projects/ai-brain/badge/?version=latest
+   :target: https://ai-brain.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:


### PR DESCRIPTION
This PR adds the Read the Docs status badge to the project to provide visibility into the documentation's build status.

Key changes:
- Inserted Markdown badge in `README.md`.
- Inserted reStructuredText image directive in `docs/index.rst`.
- Verified the build status and badge rendering via local Sphinx build.

Fixes #65

---
*PR created automatically by Jules for task [11291971378396490348](https://jules.google.com/task/11291971378396490348) started by @chatelao*