### PR TITLE
Autorepeat GitHub Issues and Dashboard Overview

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -34,4 +34,45 @@ class GitHubService
             'body' => $comment
         ]);
     }
+
+    /**
+     * @throws Exception
+     */
+    public function createIssue(string $repo, string $title, ?string $body, array $labels): array
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+
+        return $this->client->api('issue')->create($username, $repository, [
+            'title' => $title,
+            'body' => $body,
+            'labels' => $labels
+        ]);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function removeLabel(string $repo, int $issueNumber, string $label): void
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+
+        try {
+            $this->client->api('issue')->labels()->remove($username, $repository, $issueNumber, $label);
+        } catch (Exception $e) {
+            // Ignore if label not found
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
+    }
 }

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -19,6 +19,36 @@ class Task
         return $stmt->fetchAll();
     }
 
+    public function getRunningAutorepeatTasks(int $userId): array
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "SELECT t.*, p.github_repo
+             FROM tasks t
+             JOIN projects p ON t.project_id = p.id
+             WHERE p.user_id = ?
+             ORDER BY t.created_at DESC"
+        );
+        $stmt->execute([$userId]);
+        $tasks = $stmt->fetchAll();
+
+        return array_filter($tasks, function($task) {
+            $githubData = json_decode($task['github_data'], true);
+            if (!$githubData) return false;
+
+            $isOpen = ($githubData['state'] ?? '') === 'open';
+            $hasAutorepeat = false;
+            $labels = $githubData['labels'] ?? [];
+            foreach ($labels as $label) {
+                if (($label['name'] ?? '') === 'autorepeat') {
+                    $hasAutorepeat = true;
+                    break;
+                }
+            }
+
+            return $isOpen && $hasAutorepeat;
+        });
+    }
+
     public function findById(int $id): ?array
     {
         $stmt = $this->db->getConnection()->prepare(

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -16,12 +16,12 @@ class WebhookHandler
         return hash_equals($hash, $signature);
     }
 
-    public function handle(int $projectId, array $event): bool
+    public function handle(int $projectId, array $event, ?GitHubService $githubService = null): bool
     {
         $action = $event['action'] ?? '';
         $issue = $event['issue'] ?? null;
 
-        if (!$issue || !in_array($action, ['opened', 'reopened', 'edited'])) {
+        if (!$issue || !in_array($action, ['opened', 'reopened', 'edited', 'closed', 'labeled', 'unlabeled'])) {
             return false;
         }
 
@@ -46,7 +46,7 @@ class WebhookHandler
 
         $stmt = $connection->prepare($sql);
 
-        return $stmt->execute([
+        $result = $stmt->execute([
             $projectId,
             $issue['number'],
             $issue['title'],
@@ -54,5 +54,28 @@ class WebhookHandler
             json_encode($issue),
             'pending'
         ]);
+
+        if ($result && $action === 'closed' && $githubService) {
+            $stateReason = $issue['state_reason'] ?? '';
+            $labels = $issue['labels'] ?? [];
+            $hasAutorepeat = false;
+            foreach ($labels as $label) {
+                if (($label['name'] ?? '') === 'autorepeat') {
+                    $hasAutorepeat = true;
+                    break;
+                }
+            }
+
+            if ($stateReason === 'completed' && $hasAutorepeat) {
+                $labelNames = array_map(fn($l) => $l['name'], $labels);
+                $repo = $event['repository']['full_name'] ?? '';
+                if ($repo) {
+                    $githubService->createIssue($repo, $issue['title'], $issue['body'], $labelNames);
+                    $githubService->removeLabel($repo, $issue['number'], 'autorepeat');
+                }
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -6,6 +6,7 @@ use App\Database;
 use App\Auth;
 use App\User;
 use App\Project;
+use App\Task;
 
 $auth = new Auth();
 $db = new Database();
@@ -44,6 +45,7 @@ if ($user && isset($_GET['delete_project'])) {
 
 $projects = $user ? $projectModel->findByUserId($user['id']) : [];
 $githubAccounts = $user ? $userModel->getGitHubAccounts($user['id']) : [];
+$autorepeatTasks = $user ? (new Task($db))->getRunningAutorepeatTasks($user['id']) : [];
 
 $errorMessage = $errorMessage ?? null;
 
@@ -101,6 +103,42 @@ $errorMessage = $errorMessage ?? null;
                     <?php if ($errorMessage): ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
                             <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if ($user && !empty($autorepeatTasks)): ?>
+                        <div class="mb-4 p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+                            <h3 class="text-lg font-bold text-gray-900 mb-4">Running Autorepeat Tasks</h3>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-sm text-left text-gray-500">
+                                    <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+                                        <tr>
+                                            <th scope="col" class="px-6 py-3">Project</th>
+                                            <th scope="col" class="px-6 py-3">Issue</th>
+                                            <th scope="col" class="px-6 py-3">Status</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <?php foreach ($autorepeatTasks as $task): ?>
+                                            <tr class="bg-white border-b">
+                                                <td class="px-6 py-4 font-medium text-gray-900">
+                                                    <?= htmlspecialchars($task['github_repo']) ?>
+                                                </td>
+                                                <td class="px-6 py-4">
+                                                    <a href="project.php?id=<?= $task['project_id'] ?>" class="text-blue-600 hover:underline font-semibold">
+                                                        #<?= htmlspecialchars($task['issue_number']) ?> <?= htmlspecialchars($task['title']) ?>
+                                                    </a>
+                                                </td>
+                                                <td class="px-6 py-4">
+                                                    <span class="px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800">
+                                                        Active
+                                                    </span>
+                                                </td>
+                                            </tr>
+                                        <?php endforeach; ?>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     <?php endif; ?>
 

--- a/src/frontend/webhook.php
+++ b/src/frontend/webhook.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 use App\Database;
 use App\Project;
 use App\WebhookHandler;
+use App\GitHubService;
 use App\RateLimiter;
 
 $db = new Database();
@@ -58,7 +59,12 @@ if (!$verified) {
     exit('Invalid signature');
 }
 
-if ($handler->handle($matchingProject['id'], $data)) {
+$githubService = null;
+if (!empty($matchingProject['github_token'])) {
+    $githubService = new GitHubService(null, $matchingProject['github_token']);
+}
+
+if ($handler->handle($matchingProject['id'], $data, $githubService)) {
     http_response_code(200);
     echo 'OK';
 } else {

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -110,7 +110,7 @@ class WebhookHandlerTest extends TestCase
     {
         $projectId = 1;
         $event = [
-            'action' => 'labeled',
+            'action' => 'deleted',
             'issue' => [
                 'number' => 123,
                 'title' => 'Test Issue',

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -53,11 +53,75 @@ class WebhookHandlerTest extends TestCase
         $this->assertTrue($this->handler->handle($projectId, $event));
     }
 
-    public function testHandleUnsupportedAction()
+    public function testHandleClosedIssueWithAutorepeat()
     {
         $projectId = 1;
         $event = [
             'action' => 'closed',
+            'repository' => ['full_name' => 'owner/repo'],
+            'issue' => [
+                'number' => 123,
+                'title' => 'Test Issue',
+                'body' => 'Body',
+                'state_reason' => 'completed',
+                'labels' => [
+                    ['name' => 'autorepeat'],
+                    ['name' => 'bug']
+                ]
+            ]
+        ];
+
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->method('execute')->willReturn(true);
+
+        $this->pdo->method('getAttribute')->with(PDO::ATTR_DRIVER_NAME)->willReturn('mysql');
+        $this->pdo->method('prepare')->willReturn($stmt);
+
+        $githubService = $this->createMock(\App\GitHubService::class);
+        $githubService->expects($this->once())
+            ->method('createIssue')
+            ->with('owner/repo', 'Test Issue', 'Body', ['autorepeat', 'bug']);
+        $githubService->expects($this->once())
+            ->method('removeLabel')
+            ->with('owner/repo', 123, 'autorepeat');
+
+        $this->assertTrue($this->handler->handle($projectId, $event, $githubService));
+    }
+
+    public function testHandleClosedIssueWithoutAutorepeat()
+    {
+        $projectId = 1;
+        $event = [
+            'action' => 'closed',
+            'issue' => [
+                'number' => 123,
+                'title' => 'Test Issue',
+                'body' => 'Body',
+                'state_reason' => 'completed',
+                'labels' => [
+                    ['name' => 'bug']
+                ]
+            ]
+        ];
+
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->method('execute')->willReturn(true);
+
+        $this->pdo->method('getAttribute')->with(PDO::ATTR_DRIVER_NAME)->willReturn('mysql');
+        $this->pdo->method('prepare')->willReturn($stmt);
+
+        $githubService = $this->createMock(\App\GitHubService::class);
+        $githubService->expects($this->never())->method('createIssue');
+        $githubService->expects($this->never())->method('removeLabel');
+
+        $this->assertTrue($this->handler->handle($projectId, $event, $githubService));
+    }
+
+    public function testHandleUnsupportedAction()
+    {
+        $projectId = 1;
+        $event = [
+            'action' => 'deleted',
             'issue' => ['number' => 123]
         ];
 


### PR DESCRIPTION
This PR implements the "autorepeat" feature for GitHub issues. When an issue with the "autorepeat" label is closed as "completed" (e.g., via a merged PR), the system automatically creates a new issue with the same title, body, and labels, and removes the "autorepeat" label from the original (closed) issue. Additionally, a new section has been added to the main dashboard to provide an overview of all currently active autorepeat tasks across the user's projects.

Fixes #69

---
*PR created automatically by Jules for task [13959472407461882466](https://jules.google.com/task/13959472407461882466) started by @chatelao*