### PR TITLE
Fix Vagrant E_ACCESSDENIED error and improve VM stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ If you prefer to use a virtualized environment, you can use Vagrant:
 3. The application will be accessible at `http://localhost:8080`.
 4. You may need to update the environment variables in `/etc/nginx/sites-available/aibrain` inside the VM if you want to use GitHub or Google SSO.
 
+### Troubleshooting Vagrant
+
+#### Error: E_ACCESSDENIED (0x80070005)
+If you encounter `VBoxManage.exe: error: Details: code E_ACCESSDENIED (0x80070005)` when running `vagrant up`:
+- **Dropbox/OneDrive:** This error often occurs if the project is located in a folder synced by Dropbox or OneDrive. These services lock files that VirtualBox needs to access.
+  - **Solution:** Move the project to a non-synced folder (e.g., `C:\ws\ai-brain`) or temporarily pause syncing while using Vagrant.
+- **Stale VM Locks:** Sometimes VirtualBox background processes hang.
+  - **Solution:** Kill all `VBoxSVC.exe` and `VBoxManage.exe` processes in Task Manager, delete the `.vagrant` folder in your project, and try again.
+
 ## Project Structure
 - `src/frontend/`: Web entry points (index.php, login.php, etc.) and frontend assets.
 - `src/backend/`: Core PHP logic and classes.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,12 @@ DB_NAME="aibrain"
 DB_USER="aibrain"
 DB_PASS="aibrain_pass"
 
+# Wait for MySQL to be ready
+echo "Waiting for MySQL to start..."
+while ! mysqladmin ping -h"localhost" --silent; do
+    sleep 1
+done
+
 mysql -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME};"
 mysql -e "CREATE USER IF NOT EXISTS '${DB_USER}'@'localhost' IDENTIFIED BY '${DB_PASS}';"
 mysql -e "GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO '${DB_USER}'@'localhost';"
@@ -108,14 +114,24 @@ systemctl restart php8.3-fpm
 systemctl restart nginx
 SCRIPT
 
+# Check for Dropbox path which often causes E_ACCESSDENIED (0x80070005)
+if Dir.pwd.downcase.include?('dropbox')
+  puts "WARNING: You are running Vagrant from a Dropbox folder."
+  puts "Dropbox file locking can cause 'E_ACCESSDENIED (0x80070005)' errors with VirtualBox."
+  puts "If 'vagrant up' fails, try pausing Dropbox sync or moving the project outside of Dropbox."
+end
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/jammy64"
 
-  config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1", auto_correct: true
 
   config.vm.provider "virtualbox" do |vb|
+    vb.name = "ai-brain-dev"
     vb.memory = "2048"
     vb.cpus = 2
+    vb.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]
+    vb.customize ["modifyvm", :id, "--audio", "none"]
   end
 
   config.vm.provision "shell", inline: $script


### PR DESCRIPTION
This change addresses the 'E_ACCESSDENIED (0x80070005)' error encountered during 'vagrant up' on Windows systems using cloud sync services like Dropbox. It introduces a proactive warning in the Vagrantfile, documents the issue in README.md, and enhances the overall stability and provisioning reliability of the Vagrant development environment.

Fixes #83

---
*PR created automatically by Jules for task [2515591688418709493](https://jules.google.com/task/2515591688418709493) started by @chatelao*