### PR TITLE
Improve Vagrant robustness and troubleshooting documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ If you prefer to use a virtualized environment, you can use Vagrant:
 If you encounter `VBoxManage.exe: error: Details: code E_ACCESSDENIED (0x80070005)` when running `vagrant up`:
 - **Dropbox/OneDrive:** This error often occurs if the project is located in a folder synced by Dropbox or OneDrive. These services lock files that VirtualBox needs to access.
   - **Solution:** Move the project to a non-synced folder (e.g., `C:\ws\ai-brain`) or temporarily pause syncing while using Vagrant.
+- **VM Name Collisions:** A VM with the same name might already exist in VirtualBox, causing registration conflicts.
+  - **Solution:** Open the VirtualBox GUI and check for any VMs named `ai-brain-dev-*`. Remove them if they are stale.
+- **Permissions:** Sometimes VirtualBox requires elevated permissions to manage VM sessions.
+  - **Solution:** Try running your terminal (Command Prompt or PowerShell) as **Administrator**.
 - **Stale VM Locks:** Sometimes VirtualBox background processes hang.
   - **Solution:** Kill all `VBoxSVC.exe` and `VBoxManage.exe` processes in Task Manager, delete the `.vagrant` folder in your project, and try again.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -114,11 +114,11 @@ systemctl restart php8.3-fpm
 systemctl restart nginx
 SCRIPT
 
-# Check for Dropbox path which often causes E_ACCESSDENIED (0x80070005)
-if Dir.pwd.downcase.include?('dropbox')
-  puts "WARNING: You are running Vagrant from a Dropbox folder."
-  puts "Dropbox file locking can cause 'E_ACCESSDENIED (0x80070005)' errors with VirtualBox."
-  puts "If 'vagrant up' fails, try pausing Dropbox sync or moving the project outside of Dropbox."
+# Check for Dropbox or OneDrive path which often causes E_ACCESSDENIED (0x80070005)
+if Dir.pwd.downcase.include?('dropbox') || Dir.pwd.downcase.include?('onedrive')
+  puts "WARNING: You are running Vagrant from a Dropbox or OneDrive folder."
+  puts "Cloud sync file locking can cause 'E_ACCESSDENIED (0x80070005)' errors with VirtualBox."
+  puts "If 'vagrant up' fails, try pausing sync or moving the project outside of these folders."
 end
 
 Vagrant.configure("2") do |config|
@@ -127,7 +127,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1", auto_correct: true
 
   config.vm.provider "virtualbox" do |vb|
-    vb.name = "ai-brain-dev"
+    vb.name = "ai-brain-dev-#{File.basename(Dir.pwd)}"
     vb.memory = "2048"
     vb.cpus = 2
     vb.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]


### PR DESCRIPTION
This change addresses the 'E_ACCESSDENIED (0x80070005)' error during 'vagrant up' by improving environment detection and providing clearer troubleshooting steps. The Vagrantfile now warns about OneDrive in addition to Dropbox and uses dynamic VM names. The README.md includes new sections for VM name collisions and running the terminal as Administrator.

Fixes #87

---
*PR created automatically by Jules for task [9229835413373624232](https://jules.google.com/task/9229835413373624232) started by @chatelao*