### PR TITLE
Automate production ZIP asset upload for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release Asset
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, xml, ctype, iconv, mysql
+
+      - name: Install dependencies
+        run: composer install --no-dev --optimize-autoloader
+
+      - name: Create ZIP archive
+        run: |
+          zip -r agent-control-php.zip . -x "*.git*" ".github/*" "test/*" "docs/*" "specification/*" "scripts/*" "phpunit.xml" ".gitignore" "Vagrantfile" "CONCEPT.md" "DESIGN.md" "GEMINI.md" "HOWTO.md" "INSTALL.md" "ROADMAP.md" ".readthedocs.yaml"
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} agent-control-php.zip


### PR DESCRIPTION
This change introduces an automated workflow to package the application for production and attach it as a ZIP asset to every new GitHub release. The workflow ensures that the asset includes only necessary production dependencies (via `composer install --no-dev`) and excludes development-only files such as tests, CI/CD configurations, and documentation source files.

Fixes #95

---
*PR created automatically by Jules for task [17726394638995765003](https://jules.google.com/task/17726394638995765003) started by @chatelao*