### PR TITLE
Add Database Schema Diagram to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A PHP application to control agents from Google Jules, coordinated by GitHub rep
 ## Architecture
 ![Architecture](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ai-brain/main/specification/architecture.puml)
 
+### Database Schema
+![Database Schema](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ai-brain/main/schema.puml)
+
 ### Used APIs and Interfaces
 
 #### Production

--- a/schema.puml
+++ b/schema.puml
@@ -1,0 +1,93 @@
+@startuml
+!theme plain
+hide circle
+skinparam linetype ortho
+
+entity "users" {
+  * id : INT <<PK>>
+  --
+  * google_id : VARCHAR(255) <<UNIQUE>>
+  * name : VARCHAR(255)
+  * email : VARCHAR(255) <<UNIQUE>>
+  avatar : VARCHAR(255)
+  role : VARCHAR(20)
+  telegram_link_token : VARCHAR(255) <<UNIQUE>>
+  created_at : TIMESTAMP
+}
+
+entity "user_github_accounts" {
+  * id : INT <<PK>>
+  --
+  * user_id : INT <<FK>>
+  * github_username : VARCHAR(255)
+  * github_token : VARCHAR(255)
+  created_at : TIMESTAMP
+}
+
+entity "projects" {
+  * id : INT <<PK>>
+  --
+  * user_id : INT <<FK>>
+  * github_account_id : INT <<FK>>
+  * github_repo : VARCHAR(255)
+  webhook_secret : VARCHAR(255)
+  created_at : TIMESTAMP
+}
+
+entity "tasks" {
+  * id : INT <<PK>>
+  --
+  * project_id : INT <<FK>>
+  * issue_number : INT
+  * title : VARCHAR(255)
+  body : TEXT
+  status : ENUM
+  github_data : JSON
+  agent_response : TEXT
+  created_at : TIMESTAMP
+  updated_at : TIMESTAMP
+}
+
+entity "task_logs" {
+  * id : INT <<PK>>
+  --
+  * task_id : INT <<FK>>
+  level : VARCHAR(20)
+  * message : TEXT
+  created_at : TIMESTAMP
+}
+
+entity "rate_limits" {
+  * rate_key : VARCHAR(255) <<PK>>
+  --
+  request_count : INT
+  * reset_at : TIMESTAMP
+}
+
+entity "user_telegram_accounts" {
+  * id : INT <<PK>>
+  --
+  * user_id : INT <<FK>>
+  * telegram_chat_id : BIGINT <<UNIQUE>>
+  created_at : TIMESTAMP
+}
+
+entity "issue_templates" {
+  * id : INT <<PK>>
+  --
+  * user_id : INT <<FK>>
+  * name : VARCHAR(255)
+  * title_template : VARCHAR(255)
+  body_template : TEXT
+  created_at : TIMESTAMP
+}
+
+users ||--o{ user_github_accounts : "user_id"
+users ||--o{ projects : "user_id"
+users ||--o{ user_telegram_accounts : "user_id"
+users ||--o{ issue_templates : "user_id"
+user_github_accounts ||--o{ projects : "github_account_id"
+projects ||--o{ tasks : "project_id"
+tasks ||--o{ task_logs : "task_id"
+
+@enduml


### PR DESCRIPTION
This PR adds a visual representation of the database schema to the project documentation. It includes a new `schema.puml` file in the root directory, which defines the entities and their relationships using standard crow's foot notation. Additionally, the `README.md` has been updated to include a "Database Schema" section that renders this diagram using the PlantUML proxy service.

Fixes #96

---
*PR created automatically by Jules for task [11442715837307868255](https://jules.google.com/task/11442715837307868255) started by @chatelao*