### PR TITLE
Add complete .htaccess example to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -155,7 +155,17 @@ Use this method if you only have SFTP access and cannot run commands on the serv
    ```apache
    SetEnv DB_HOST localhost
    SetEnv DB_NAME your_db_name
-   # ... etc
+   SetEnv DB_USER your_user
+   SetEnv DB_PASS your_password
+   SetEnv GOOGLE_CLIENT_ID your_google_client_id
+   SetEnv GOOGLE_CLIENT_SECRET your_google_client_secret
+   SetEnv GOOGLE_REDIRECT_URI https://your-domain.com/callback.php
+   SetEnv GITHUB_CLIENT_ID your_github_client_id
+   SetEnv GITHUB_CLIENT_SECRET your_github_client_secret
+   SetEnv GITHUB_REDIRECT_URI https://your-domain.com/github-callback.php
+   SetEnv GOOGLE_JULES_API_KEY your_google_jules_api_key
+   SetEnv TELEGRAM_BOT_TOKEN your_telegram_bot_token
+   SetEnv TELEGRAM_WEBHOOK_SECRET your_telegram_webhook_secret
    ```
 
 5. **Document Root:**


### PR DESCRIPTION
The INSTALL.md file was updated to provide a complete .htaccess example for users installing the application on Apache web servers via SFTP. The updated example now includes SetEnv directives for all 13 environment variables:

- DB_HOST
- DB_NAME
- DB_USER
- DB_PASS
- GOOGLE_CLIENT_ID
- GOOGLE_CLIENT_SECRET
- GOOGLE_REDIRECT_URI
- GITHUB_CLIENT_ID
- GITHUB_CLIENT_SECRET
- GITHUB_REDIRECT_URI
- GOOGLE_JULES_API_KEY
- TELEGRAM_BOT_TOKEN
- TELEGRAM_WEBHOOK_SECRET

This ensures that users have a clear reference for setting up their environment without relying on CLI access. The documentation build was verified, and existing tests pass.

Fixes #102

---
*PR created automatically by Jules for task [14821273182304069890](https://jules.google.com/task/14821273182304069890) started by @chatelao*