### PR TITLE
Implement GitHub issue synchronization

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -75,4 +75,21 @@ class GitHubService
             }
         }
     }
+
+    /**
+     * @throws Exception
+     */
+    public function listIssues(string $repo, string $state = 'open'): array
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+
+        return $this->client->api('issue')->all($username, $repository, [
+            'state' => $state
+        ]);
+    }
 }

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -90,6 +90,39 @@ class Task
         ]);
     }
 
+    public function upsert(int $projectId, array $issue): bool
+    {
+        $connection = $this->db->getConnection();
+        $driver = $connection->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $sql = "INSERT INTO tasks (project_id, issue_number, title, body, github_data, status)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(project_id, issue_number) DO UPDATE SET
+                        title = excluded.title,
+                        body = excluded.body,
+                        github_data = excluded.github_data";
+        } else {
+            $sql = "INSERT INTO tasks (project_id, issue_number, title, body, github_data, status)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON DUPLICATE KEY UPDATE
+                        title = VALUES(title),
+                        body = VALUES(body),
+                        github_data = VALUES(github_data)";
+        }
+
+        $stmt = $connection->prepare($sql);
+
+        return $stmt->execute([
+            $projectId,
+            $issue['number'],
+            $issue['title'],
+            $issue['body'],
+            json_encode($issue),
+            'pending'
+        ]);
+    }
+
     public function getLogs(int $taskId): array
     {
         $logger = new Logger($this->db);

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -25,35 +25,8 @@ class WebhookHandler
             return false;
         }
 
-        $connection = $this->db->getConnection();
-        $driver = $connection->getAttribute(PDO::ATTR_DRIVER_NAME);
-
-        if ($driver === 'sqlite') {
-            $sql = "INSERT INTO tasks (project_id, issue_number, title, body, github_data, status)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(project_id, issue_number) DO UPDATE SET
-                        title = excluded.title,
-                        body = excluded.body,
-                        github_data = excluded.github_data";
-        } else {
-            $sql = "INSERT INTO tasks (project_id, issue_number, title, body, github_data, status)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                    ON DUPLICATE KEY UPDATE
-                        title = VALUES(title),
-                        body = VALUES(body),
-                        github_data = VALUES(github_data)";
-        }
-
-        $stmt = $connection->prepare($sql);
-
-        $result = $stmt->execute([
-            $projectId,
-            $issue['number'],
-            $issue['title'],
-            $issue['body'],
-            json_encode($issue),
-            'pending'
-        ]);
+        $taskModel = new Task($this->db);
+        $result = $taskModel->upsert($projectId, $issue);
 
         if ($result && $action === 'closed' && $githubService) {
             $stateReason = $issue['state_reason'] ?? '';

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -129,6 +129,36 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_from_template'
     }
 }
 
+// Handle Sync Issues
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
+    if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
+        die("CSRF token validation failed.");
+    }
+
+    try {
+        $githubToken = $project['github_token'] ?? null;
+        if (!$githubToken) {
+            throw new Exception("GitHub token not found for this project.");
+        }
+
+        $githubService = new GitHubService(null, $githubToken);
+        $issues = $githubService->listIssues($project['github_repo']);
+
+        foreach ($issues as $issue) {
+            // Check if it's really an issue (not a PR)
+            if (isset($issue['pull_request'])) {
+                continue;
+            }
+            $taskModel->upsert($project['id'], $issue);
+        }
+
+        header("Location: project.php?id=$projectId&success=synced");
+        exit;
+    } catch (Exception $e) {
+        $errorMessage = "Error syncing issues: " . $e->getMessage();
+    }
+}
+
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -196,6 +226,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_from_template'
                         </div>
                     <?php endif; ?>
 
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'synced'): ?>
+                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+                            <span class="font-medium">Success!</span> Issues synced from GitHub.
+                        </div>
+                    <?php endif; ?>
+
                     <?php if ($lastAgentResponse): ?>
                         <div class="p-4 mb-4 text-sm text-blue-800 rounded-lg bg-blue-50" role="alert">
                             <span class="font-medium">Agent Response:</span>
@@ -235,7 +271,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_from_template'
                         </div>
 
                         <div class="lg:col-span-3 p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
-                            <h3 class="text-lg font-bold text-gray-900 mb-4">Tasks synced from GitHub</h3>
+                            <div class="flex justify-between items-center mb-4">
+                                <h3 class="text-lg font-bold text-gray-900">Tasks synced from GitHub</h3>
+                                <form method="POST">
+                                    <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                    <button type="submit" name="sync_issues" class="text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none">Sync Issues</button>
+                                </form>
+                            </div>
                             <div class="overflow-x-auto">
                                 <table class="w-full text-sm text-left text-gray-500">
                                     <thead class="text-xs text-gray-700 uppercase bg-gray-50">

--- a/test/Integration/IssueSyncIntegrationTest.php
+++ b/test/Integration/IssueSyncIntegrationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\Task;
+use PDO;
+
+class IssueSyncIntegrationTest extends TestCase
+{
+    private $db;
+    private $pdo;
+    private $taskModel;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->pdo->exec("CREATE TABLE tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id INT NOT NULL,
+            issue_number INT NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            body TEXT,
+            status TEXT DEFAULT 'pending',
+            github_data TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(project_id, issue_number)
+        )");
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        $this->taskModel = new Task($this->db);
+    }
+
+    public function testUpsertNewIssue()
+    {
+        $projectId = 1;
+        $issue = [
+            'number' => 1,
+            'title' => 'Initial Issue',
+            'body' => 'Initial Body'
+        ];
+
+        $this->taskModel->upsert($projectId, $issue);
+
+        $stmt = $this->pdo->prepare("SELECT * FROM tasks WHERE project_id = ? AND issue_number = ?");
+        $stmt->execute([$projectId, 1]);
+        $task = $stmt->fetch();
+
+        $this->assertNotFalse($task);
+        $this->assertEquals('Initial Issue', $task['title']);
+    }
+
+    public function testUpsertExistingIssue()
+    {
+        $projectId = 1;
+        $issue1 = [
+            'number' => 1,
+            'title' => 'Initial Issue',
+            'body' => 'Initial Body'
+        ];
+
+        $this->taskModel->upsert($projectId, $issue1);
+
+        $issue2 = [
+            'number' => 1,
+            'title' => 'Updated Issue',
+            'body' => 'Updated Body'
+        ];
+
+        $this->taskModel->upsert($projectId, $issue2);
+
+        $stmt = $this->pdo->prepare("SELECT COUNT(*) FROM tasks WHERE project_id = ? AND issue_number = ?");
+        $stmt->execute([$projectId, 1]);
+        $count = $stmt->fetchColumn();
+
+        $this->assertEquals(1, $count);
+
+        $stmt = $this->pdo->prepare("SELECT * FROM tasks WHERE project_id = ? AND issue_number = ?");
+        $stmt->execute([$projectId, 1]);
+        $task = $stmt->fetch();
+
+        $this->assertEquals('Updated Issue', $task['title']);
+        $this->assertEquals('Updated Body', $task['body']);
+    }
+}


### PR DESCRIPTION
Existing GitHub issues were not being fetched upon repository linking, as the application relied solely on webhooks for task creation. This change introduces a "Sync Issues" button on the project details page and a robust `upsert` mechanism in the backend to allow users to manually synchronize all open issues from GitHub into the application's task list.

Key changes:
- `App\GitHubService::listIssues()`: New method to fetch open issues via the GitHub API.
- `App\Task::upsert()`: New method to insert or update tasks, ensuring no duplicates and cross-database compatibility (MySQL/SQLite).
- `App\WebhookHandler`: Refactored to use `Task::upsert()`, reducing code duplication.
- `src/frontend/project.php`: Added UI and logic for the synchronization feature.
- `test/Integration/IssueSyncIntegrationTest.php`: New test case to ensure the sync logic works as expected.

Fixes #108

---
*PR created automatically by Jules for task [1268386348038227593](https://jules.google.com/task/1268386348038227593) started by @chatelao*