### PR TITLE
Link repository names to GitHub root

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -124,7 +124,9 @@ $errorMessage = $errorMessage ?? null;
                                         <?php foreach ($autorepeatTasks as $task): ?>
                                             <tr class="bg-white border-b">
                                                 <td class="px-6 py-4 font-medium text-gray-900">
-                                                    <?= htmlspecialchars($task['github_repo']) ?>
+                                                    <a href="https://github.com/<?= htmlspecialchars($task['github_repo']) ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
+                                                        <?= htmlspecialchars($task['github_repo']) ?>
+                                                    </a>
                                                 </td>
                                                 <td class="px-6 py-4">
                                                     <a href="project.php?id=<?= $task['project_id'] ?>" class="text-blue-600 hover:underline font-semibold">
@@ -178,7 +180,11 @@ $errorMessage = $errorMessage ?? null;
                                         <?php foreach ($projects as $project): ?>
                                             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                                                 <div class="flex justify-between items-start">
-                                                    <h5 class="text-lg font-bold text-gray-900 truncate"><?= htmlspecialchars($project['github_repo']) ?></h5>
+                                                    <h5 class="text-lg font-bold text-gray-900 truncate">
+                                                        <a href="https://github.com/<?= htmlspecialchars($project['github_repo']) ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
+                                                            <?= htmlspecialchars($project['github_repo']) ?>
+                                                        </a>
+                                                    </h5>
                                                     <a href="?delete_project=<?= $project['id'] ?>&csrf_token=<?= $auth->getCsrfToken() ?>" class="text-red-600 hover:text-red-800" onclick="return confirm('Are you sure?')">
                                                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
                                                     </a>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -205,14 +205,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                             <li>
                                 <div class="flex items-center">
                                     <svg class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
-                                    <span class="text-gray-400 ml-1 md:ml-2 font-medium"><?= htmlspecialchars($project['github_repo']) ?></span>
+                                    <a href="https://github.com/<?= htmlspecialchars($project['github_repo']) ?>" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-gray-900 ml-1 md:ml-2 font-medium hover:underline">
+                                        <?= htmlspecialchars($project['github_repo']) ?>
+                                    </a>
                                 </div>
                             </li>
                         </ol>
                     </nav>
 
                     <div class="mb-4">
-                        <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl"><?= htmlspecialchars($project['github_repo']) ?></h1>
+                        <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">
+                            <a href="https://github.com/<?= htmlspecialchars($project['github_repo']) ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
+                                <?= htmlspecialchars($project['github_repo']) ?>
+                            </a>
+                        </h1>
                     </div>
 
                     <?php if ($errorMessage): ?>


### PR DESCRIPTION
This change makes GitHub repository names clickable throughout the application's dashboard and project detail views. Clicking a repository name now opens the corresponding repository's root page on GitHub in a new tab.

Key changes:
- In `index.php` (Overview), repository names in the "Running Autorepeat Tasks" table and "Your Projects" grid are now links.
- In `project.php` (Project Details), the repository name in the breadcrumb and the main page heading are now links.
- All external links include `target="_blank"` and `rel="noopener noreferrer"` for security and performance.
- Visual styling uses Tailwind's `hover:underline` to indicate the links are interactive.

Fixes #116

---
*PR created automatically by Jules for task [4255523830724630822](https://jules.google.com/task/4255523830724630822) started by @chatelao*