### PR TITLE
Fix missing space in "Linked as" label

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -160,7 +160,7 @@ $errorMessage = $errorMessage ?? null;
                                                 <?php foreach ($githubAccounts as $account): ?>
                                                     <div class="flex items-center text-green-600">
                                                         <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-                                                        Linked as <strong><?= htmlspecialchars($account['github_username']) ?></strong>
+                                                        Linked as&nbsp;<strong><?= htmlspecialchars($account['github_username']) ?></strong>
                                                     </div>
                                                 <?php endforeach; ?>
                                             <?php endif; ?>
@@ -183,7 +183,7 @@ $errorMessage = $errorMessage ?? null;
                                                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
                                                     </a>
                                                 </div>
-                                                <p class="text-sm text-gray-500 mt-1">Linked as <?= htmlspecialchars($project['github_username']) ?></p>
+                                                <p class="text-sm text-gray-500 mt-1">Linked as&nbsp;<?= htmlspecialchars($project['github_username']) ?></p>
                                                 <div class="mt-4">
                                                     <a href="project.php?id=<?= $project['id'] ?>" class="text-blue-600 hover:underline text-sm font-medium">View Project Details &rarr;</a>
                                                 </div>


### PR DESCRIPTION
The "Linked as" label in the dashboard was missing a space before the GitHub username in certain UI scenarios. I've added a non-breaking space (`&nbsp;`) in `src/frontend/index.php` to ensure correct spacing is always rendered. I verified this change visually using Playwright and ran the existing test suite to ensure no regressions.

Fixes #118

---
*PR created automatically by Jules for task [2783790949743276928](https://jules.google.com/task/2783790949743276928) started by @chatelao*