### PR TITLE
Move phpunit.xml to test directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Create ZIP archive
         run: |
-          zip -r agent-control-php.zip . -x "*.git*" ".github/*" "test/*" "docs/*" "specification/*" "scripts/*" "phpunit.xml" ".gitignore" "Vagrantfile" "CONCEPT.md" "DESIGN.md" "GEMINI.md" "HOWTO.md" "INSTALL.md" "ROADMAP.md" ".readthedocs.yaml"
+          zip -r agent-control-php.zip . -x "*.git*" ".github/*" "test/*" "docs/*" "specification/*" "scripts/*" ".gitignore" "Vagrantfile" "CONCEPT.md" "DESIGN.md" "GEMINI.md" "HOWTO.md" "INSTALL.md" "ROADMAP.md" ".readthedocs.yaml"
 
       - name: Upload Release Asset
         env:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^11.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit test"
+        "test": "vendor/bin/phpunit -c test/phpunit.xml"
     },
     "autoload": {
         "psr-4": {

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="../vendor/autoload.php"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
          beStrictAboutOutputDuringTests="true"
@@ -11,19 +11,19 @@
          failOnWarning="true">
     <testsuites>
         <testsuite name="Unit">
-            <directory>test/Unit</directory>
+            <directory>Unit</directory>
         </testsuite>
         <testsuite name="Integration">
-            <directory>test/Integration</directory>
+            <directory>Integration</directory>
         </testsuite>
         <testsuite name="E2E">
-            <directory>test/E2E</directory>
+            <directory>E2E</directory>
         </testsuite>
     </testsuites>
 
     <source restrictNotices="true" restrictWarnings="true">
         <include>
-            <directory>src/backend</directory>
+            <directory>../src/backend</directory>
         </include>
     </source>
 </phpunit>


### PR DESCRIPTION
This change relocates the PHPUnit configuration file from the root directory to the `test/` directory to keep the project root cleaner. All relevant paths within the configuration were updated, and the `composer test` script was adjusted to ensure continuous functionality of the test suite. Additionally, the release workflow was updated to remove a now-redundant file exclusion.

Fixes #123

---
*PR created automatically by Jules for task [10314923831175708944](https://jules.google.com/task/10314923831175708944) started by @chatelao*