### PR TITLE
List ROADMAP files in Project Overview tile

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -92,4 +92,43 @@ class GitHubService
             'state' => $state
         ]);
     }
+
+    /**
+     * @throws Exception
+     */
+    public function getRoadmapFiles(string $repo): array
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+        $roadmaps = [];
+
+        $pathsToSearch = ['.', 'docs'];
+
+        foreach ($pathsToSearch as $path) {
+            try {
+                $contents = $this->client->api('repo')->contents()->show($username, $repository, $path === '.' ? '' : $path);
+                if (is_array($contents)) {
+                    foreach ($contents as $file) {
+                        if ($file['type'] === 'file' && stripos($file['name'], 'ROADMAP') !== false) {
+                            $roadmaps[] = [
+                                'name' => ($path !== '.' ? $path . '/' : '') . $file['name'],
+                                'html_url' => $file['html_url']
+                            ];
+                        }
+                    }
+                }
+            } catch (Exception $e) {
+                // Ignore if path not found or other errors for specific paths
+                if ($e->getCode() !== 404) {
+                    // Log or handle other errors if necessary, but don't fail the whole request
+                }
+            }
+        }
+
+        return $roadmaps;
+    }
 }

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -181,6 +181,7 @@ $errorMessage = $errorMessage ?? null;
                                         </form>
                                     </div>
 
+
                                     <div class="mt-6">
                                         <h4 class="text-lg font-semibold text-gray-900">Linked GitHub Accounts</h4>
                                         <div class="mt-2 space-y-2">

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -40,6 +40,17 @@ $tasks = $taskModel->findByProjectId($projectId);
 $lastAgentResponse = null;
 $errorMessage = null;
 
+$githubToken = $project['github_token'] ?? null;
+$roadmapFiles = [];
+if ($githubToken) {
+    try {
+        $githubService = new GitHubService(null, $githubToken);
+        $roadmapFiles = $githubService->getRoadmapFiles($project['github_repo']);
+    } catch (Exception $e) {
+        // Silently fail or log roadmap fetching
+    }
+}
+
 // Handle Agent Trigger
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['trigger_agent'])) {
     if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
@@ -212,7 +223,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                     </nav>
 
                     <div class="mb-4">
-                        <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl"><?= htmlspecialchars($project['github_repo']) ?></h1>
+                        <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl"><?= htmlspecialchars($project['github_repo']) ?> Overview</h1>
                     </div>
 
                     <?php if ($errorMessage): ?>
@@ -243,32 +254,52 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                     <?php endif; ?>
 
                     <div class="grid grid-cols-1 lg:grid-cols-4 gap-4 mb-4">
-                        <div class="lg:col-span-1 p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
-                            <h3 class="text-lg font-bold text-gray-900 mb-4">Create Issue from Template</h3>
-                            <?php if (empty($templates)): ?>
-                                <p class="text-sm text-gray-500 italic">No templates available. <a href="templates.php" class="text-blue-600 hover:underline">Create one first.</a></p>
-                            <?php else: ?>
-                                <form method="POST">
-                                    <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
-                                    <div class="mb-4">
-                                        <label class="block mb-2 text-sm font-medium text-gray-900">Select Template</label>
-                                        <select name="template_id" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
-                                            <?php foreach ($templates as $tmpl): ?>
-                                                <option value="<?= $tmpl['id'] ?>"><?= htmlspecialchars($tmpl['name']) ?></option>
-                                            <?php endforeach; ?>
-                                        </select>
-                                    </div>
-                                    <div class="mb-4">
-                                        <label class="block mb-2 text-sm font-medium text-gray-900">%1 value</label>
-                                        <input type="text" name="val1" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
-                                    </div>
-                                    <div class="mb-4">
-                                        <label class="block mb-2 text-sm font-medium text-gray-900">%2 value</label>
-                                        <input type="text" name="val2" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
-                                    </div>
-                                    <button type="submit" name="create_from_template" class="text-white bg-green-600 hover:bg-green-700 focus:ring-4 focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 w-full focus:outline-none">Create Issue</button>
-                                </form>
-                            <?php endif; ?>
+                        <div class="lg:col-span-1 space-y-4">
+                            <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+                                <h3 class="text-lg font-bold text-gray-900 mb-4">Project Overview</h3>
+                                <?php if (empty($roadmapFiles)): ?>
+                                    <p class="text-sm text-gray-500 italic">No roadmap files found in the repository.</p>
+                                <?php else: ?>
+                                    <ul class="space-y-2">
+                                        <?php foreach ($roadmapFiles as $file): ?>
+                                            <li>
+                                                <a href="<?= htmlspecialchars($file['html_url']) ?>" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-600 hover:underline flex items-center">
+                                                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                                                    <?= htmlspecialchars($file['name']) ?>
+                                                </a>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                <?php endif; ?>
+                            </div>
+
+                            <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+                                <h3 class="text-lg font-bold text-gray-900 mb-4">Create Issue from Template</h3>
+                                <?php if (empty($templates)): ?>
+                                    <p class="text-sm text-gray-500 italic">No templates available. <a href="templates.php" class="text-blue-600 hover:underline">Create one first.</a></p>
+                                <?php else: ?>
+                                    <form method="POST">
+                                        <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                        <div class="mb-4">
+                                            <label class="block mb-2 text-sm font-medium text-gray-900">Select Template</label>
+                                            <select name="template_id" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                                <?php foreach ($templates as $tmpl): ?>
+                                                    <option value="<?= $tmpl['id'] ?>"><?= htmlspecialchars($tmpl['name']) ?></option>
+                                                <?php endforeach; ?>
+                                            </select>
+                                        </div>
+                                        <div class="mb-4">
+                                            <label class="block mb-2 text-sm font-medium text-gray-900">%1 value</label>
+                                            <input type="text" name="val1" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                        </div>
+                                        <div class="mb-4">
+                                            <label class="block mb-2 text-sm font-medium text-gray-900">%2 value</label>
+                                            <input type="text" name="val2" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                        </div>
+                                        <button type="submit" name="create_from_template" class="text-white bg-green-600 hover:bg-green-700 focus:ring-4 focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 w-full focus:outline-none">Create Issue</button>
+                                    </form>
+                                <?php endif; ?>
+                            </div>
                         </div>
 
                         <div class="lg:col-span-3 p-4 bg-white border border-gray-200 rounded-lg shadow-sm">

--- a/test/Unit/Services/GitHubServiceTest.php
+++ b/test/Unit/Services/GitHubServiceTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\GitHubService;
+use Github\Client;
+use Github\Api\Repo;
+use Github\Api\Repository\Contents;
+use PHPUnit\Framework\TestCase;
+
+class GitHubServiceTest extends TestCase
+{
+    public function testGetRoadmapFiles(): void
+    {
+        $mockClient = $this->createMock(Client::class);
+        $mockRepo = $this->createMock(Repo::class);
+        $mockContents = $this->createMock(Contents::class);
+
+        $mockClient->method('api')->with('repo')->willReturn($mockRepo);
+        $mockRepo->method('contents')->willReturn($mockContents);
+
+        // Mock contents for root directory
+        $mockContents->method('show')
+            ->willReturnMap([
+                ['chatelao', 'ai-brain', '', null, [
+                    ['type' => 'file', 'name' => 'README.md', 'html_url' => 'http://example.com/readme'],
+                    ['type' => 'file', 'name' => 'ROADMAP.md', 'html_url' => 'http://example.com/roadmap']
+                ]],
+                ['chatelao', 'ai-brain', 'docs', null, [
+                    ['type' => 'file', 'name' => 'roadmap.rst', 'html_url' => 'http://example.com/roadmap_rst'],
+                    ['type' => 'file', 'name' => 'install.rst', 'html_url' => 'http://example.com/install']
+                ]]
+            ]);
+
+        $service = new GitHubService($mockClient);
+        $roadmaps = $service->getRoadmapFiles('chatelao/ai-brain');
+
+        $this->assertCount(2, $roadmaps);
+        $this->assertEquals('ROADMAP.md', $roadmaps[0]['name']);
+        $this->assertEquals('docs/roadmap.rst', $roadmaps[1]['name']);
+    }
+}


### PR DESCRIPTION
This change adds a "Project Overview" tile to the project details page that automatically discovers and lists roadmap files from the linked GitHub repository.

Key changes:
- `App\GitHubService`: Added `getRoadmapFiles` method to fetch files with "ROADMAP" in their name from root and `docs/` via GitHub API.
- `src/frontend/project.php`: Integrated roadmap fetching and added a new UI card for project overview. Updated the page title to "Overview".
- `test/Unit/Services/GitHubServiceTest.php`: Added unit tests for the new roadmap discovery logic.

Fixes #124

---
*PR created automatically by Jules for task [3935962886491019276](https://jules.google.com/task/3935962886491019276) started by @chatelao*