### PR TITLE
Allow aliases for template parameters

### DIFF
--- a/src/backend/IssueTemplate.php
+++ b/src/backend/IssueTemplate.php
@@ -10,12 +10,12 @@ class IssueTemplate
     {
     }
 
-    public function create(int $userId, string $name, string $title, ?string $body): bool
+    public function create(int $userId, string $name, string $title, ?string $body, ?string $parameterConfig = null): bool
     {
         $stmt = $this->db->getConnection()->prepare(
-            "INSERT INTO issue_templates (user_id, name, title_template, body_template) VALUES (?, ?, ?, ?)"
+            "INSERT INTO issue_templates (user_id, name, title_template, body_template, parameter_config) VALUES (?, ?, ?, ?, ?)"
         );
-        return $stmt->execute([$userId, $name, $title, $body]);
+        return $stmt->execute([$userId, $name, $title, $body, $parameterConfig]);
     }
 
     public function findByUserId(int $userId): array

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -115,14 +115,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_from_template'
     }
 
     $templateId = (int)$_POST['template_id'];
-    $val1 = $_POST['val1'] ?? '';
-    $val2 = $_POST['val2'] ?? '';
-
     $template = $templateModel->findById($templateId);
     if ($template && $template['user_id'] === $user['id']) {
         try {
-            $title = str_replace(['%1', '%2'], [$val1, $val2], $template['title_template']);
-            $body = str_replace(['%1', '%2'], [$val1, $val2], $template['body_template']);
+            $title = $template['title_template'];
+            $body = $template['body_template'];
+
+            // Replace all %N placeholders
+            preg_match_all('/%(\d+)/', $title . $body, $matches);
+            if (!empty($matches[1])) {
+                $replacements = [];
+                $placeholders = array_unique($matches[1]);
+                foreach ($placeholders as $num) {
+                    $replacements['%' . $num] = $_POST['val' . $num] ?? '';
+                }
+                // Use strtr for single-pass replacement and to handle overlapping placeholders correctly (e.g., %1 vs %11)
+                $title = strtr($title, $replacements);
+                $body = strtr($body, $replacements);
+            }
 
             $githubToken = $project['github_token'] ?? null;
             if (!$githubToken) {
@@ -284,26 +294,60 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                 <?php if (empty($templates)): ?>
                                     <p class="text-sm text-gray-500 italic">No templates available. <a href="templates.php" class="text-blue-600 hover:underline">Create one first.</a></p>
                                 <?php else: ?>
-                                    <form method="POST">
-                                        <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
-                                        <div class="mb-4">
-                                            <label class="block mb-2 text-sm font-medium text-gray-900">Select Template</label>
-                                            <select name="template_id" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
-                                                <?php foreach ($templates as $tmpl): ?>
-                                                    <option value="<?= $tmpl['id'] ?>"><?= htmlspecialchars($tmpl['name']) ?></option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                        </div>
-                                        <div class="mb-4">
-                                            <label class="block mb-2 text-sm font-medium text-gray-900">%1 value</label>
-                                            <input type="text" name="val1" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
-                                        </div>
-                                        <div class="mb-4">
-                                            <label class="block mb-2 text-sm font-medium text-gray-900">%2 value</label>
-                                            <input type="text" name="val2" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
-                                        </div>
-                                        <button type="submit" name="create_from_template" class="text-white bg-green-600 hover:bg-green-700 focus:ring-4 focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 w-full focus:outline-none">Create Issue</button>
-                                    </form>
+                                    <div x-data="{
+                                        selectedTemplate: null,
+                                        templates: <?= htmlspecialchars(json_encode(array_map(function($t) {
+                                            preg_match_all('/%(\d+)/', $t['title_template'] . $t['body_template'], $matches);
+                                            $nums = !empty($matches[1]) ? array_unique($matches[1]) : [];
+                                            sort($nums);
+                                            $config = json_decode($t['parameter_config'] ?? '{}', true);
+                                            $aliases = $config['aliases'] ?? [];
+
+                                            $parameters = [];
+                                            foreach ($nums as $n) {
+                                                $parameters[] = [
+                                                    'num' => $n,
+                                                    'label' => $aliases[$n-1] ?? '%' . $n . ' value'
+                                                ];
+                                            }
+
+                                            return [
+                                                'id' => $t['id'],
+                                                'name' => $t['name'],
+                                                'parameters' => $parameters
+                                            ];
+                                        }, $templates))) ?>
+                                    }">
+                                        <form method="POST">
+                                            <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                            <div class="mb-4">
+                                                <label class="block mb-2 text-sm font-medium text-gray-900">Select Template</label>
+                                                <select
+                                                    name="template_id"
+                                                    x-model="selectedTemplate"
+                                                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                                                    required
+                                                >
+                                                    <option value="">Choose a template...</option>
+                                                    <template x-for="tmpl in templates" :key="tmpl.id">
+                                                        <option :value="tmpl.id" x-text="tmpl.name"></option>
+                                                    </template>
+                                                </select>
+                                            </div>
+
+                                            <template x-if="selectedTemplate">
+                                                <div>
+                                                    <template x-for="param in templates.find(t => t.id == selectedTemplate).parameters" :key="param.num">
+                                                        <div class="mb-4">
+                                                            <label class="block mb-2 text-sm font-medium text-gray-900" x-text="param.label"></label>
+                                                            <input type="text" :name="'val' + param.num" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                                        </div>
+                                                    </template>
+                                                    <button type="submit" name="create_from_template" class="text-white bg-green-600 hover:bg-green-700 focus:ring-4 focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 w-full focus:outline-none">Create Issue</button>
+                                                </div>
+                                            </template>
+                                        </form>
+                                    </div>
                                 <?php endif; ?>
                             </div>
                         </div>

--- a/src/frontend/templates.php
+++ b/src/frontend/templates.php
@@ -30,10 +30,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_template'])) {
     $name = trim($_POST['name']);
     $title = trim($_POST['title_template']);
     $body = trim($_POST['body_template']);
+    $aliases = trim($_POST['parameter_aliases'] ?? '');
+
+    $parameterConfig = null;
+    if (!empty($aliases)) {
+        $aliasArray = array_map('trim', explode(',', $aliases));
+        $parameterConfig = json_encode(['aliases' => $aliasArray]);
+    }
 
     if (!empty($name) && !empty($title)) {
         try {
-            $templateModel->create($user['id'], $name, $title, $body);
+            $templateModel->create($user['id'], $name, $title, $body, $parameterConfig);
             $successMessage = "Template created successfully.";
         } catch (Exception $e) {
             $errorMessage = $e->getMessage();
@@ -108,7 +115,7 @@ $templates = $templateModel->findByUserId($user['id']);
 
                     <div class="mb-4">
                         <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">Issue Templates</h1>
-                        <p class="text-sm text-gray-500 mt-1">Create reusable templates for GitHub issues. Use <strong>%1</strong> and <strong>%2</strong> as placeholders for dynamic content.</p>
+                        <p class="text-sm text-gray-500 mt-1">Create reusable templates for GitHub issues. Use <strong>%1</strong>, <strong>%2</strong>, etc. as placeholders for dynamic content.</p>
                     </div>
 
                     <?php if ($errorMessage): ?>
@@ -145,6 +152,14 @@ $templates = $templateModel->findByUserId($user['id']);
                                             <tr class="bg-white border-b">
                                                 <td class="px-6 py-4 font-medium text-gray-900">
                                                     <?= htmlspecialchars($template['name']) ?>
+                                                    <?php if ($template['parameter_config']): ?>
+                                                        <?php $config = json_decode($template['parameter_config'], true); ?>
+                                                        <?php if (!empty($config['aliases'])): ?>
+                                                            <div class="text-xs text-gray-400 mt-1">
+                                                                Aliases: <?= htmlspecialchars(implode(', ', $config['aliases'])) ?>
+                                                            </div>
+                                                        <?php endif; ?>
+                                                    <?php endif; ?>
                                                 </td>
                                                 <td class="px-6 py-4">
                                                     <?= htmlspecialchars($template['title_template']) ?>
@@ -174,6 +189,11 @@ $templates = $templateModel->findByUserId($user['id']);
                                 <div class="mb-4">
                                     <label class="block mb-2 text-sm font-medium text-gray-900">Body Template</label>
                                     <textarea name="body_template" rows="6" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500" placeholder="Description of the bug: %1&#10;Expected behavior: %2"></textarea>
+                                </div>
+                                <div class="mb-4">
+                                    <label class="block mb-2 text-sm font-medium text-gray-900">Parameter Aliases (optional, comma-separated)</label>
+                                    <input type="text" name="parameter_aliases" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" placeholder="Description, Expected">
+                                    <p class="mt-1 text-xs text-gray-500">Aliases for %1, %2, etc. in order.</p>
                                 </div>
                                 <button type="submit" name="create_template" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 w-full focus:outline-none">Create Template</button>
                             </form>

--- a/src/sql/patches/001_add_parameter_config_to_issue_templates.sql
+++ b/src/sql/patches/001_add_parameter_config_to_issue_templates.sql
@@ -1,0 +1,2 @@
+-- Add parameter_config column to issue_templates
+ALTER TABLE issue_templates ADD COLUMN parameter_config JSON AFTER body_template;

--- a/src/sql/schema.sql
+++ b/src/sql/schema.sql
@@ -75,6 +75,7 @@ CREATE TABLE IF NOT EXISTS issue_templates (
     name VARCHAR(255) NOT NULL,
     title_template VARCHAR(255) NOT NULL,
     body_template TEXT,
+    parameter_config JSON,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/test/Integration/IssueTemplateIntegrationTest.php
+++ b/test/Integration/IssueTemplateIntegrationTest.php
@@ -27,6 +27,7 @@ class IssueTemplateIntegrationTest extends TestCase
             name TEXT,
             title_template TEXT,
             body_template TEXT,
+            parameter_config TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id)
         )");

--- a/test/Unit/Services/IssueTemplateTest.php
+++ b/test/Unit/Services/IssueTemplateTest.php
@@ -25,6 +25,7 @@ class IssueTemplateTest extends TestCase
             name TEXT,
             title_template TEXT,
             body_template TEXT,
+            parameter_config TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id)
         )");
@@ -37,13 +38,25 @@ class IssueTemplateTest extends TestCase
     public function testCreateAndFindTemplate()
     {
         $userId = 1;
-        $result = $this->templateModel->create($userId, 'Bug Template', 'Bug: %1', 'Details: %2');
+        $config = json_encode(['aliases' => ['Feature', 'Description']]);
+        $result = $this->templateModel->create($userId, 'Bug Template', 'Bug: %1', 'Details: %2', $config);
         $this->assertTrue($result);
 
         $templates = $this->templateModel->findByUserId($userId);
         $this->assertCount(1, $templates);
         $this->assertEquals('Bug Template', $templates[0]['name']);
         $this->assertEquals('Bug: %1', $templates[0]['title_template']);
+        $this->assertEquals($config, $templates[0]['parameter_config']);
+    }
+
+    public function testCreateWithManyParameters()
+    {
+        $userId = 1;
+        $result = $this->templateModel->create($userId, 'Complex', '%1 %2 %3 %4 %5', 'Body');
+        $this->assertTrue($result);
+
+        $templates = $this->templateModel->findByUserId($userId);
+        $this->assertEquals('%1 %2 %3 %4 %5', $templates[0]['title_template']);
     }
 
     public function testFindById()


### PR DESCRIPTION
This change introduces support for human-readable aliases for issue template parameters. 

Previously, templates were limited to `%1` and `%2` placeholders with fixed labels. Now, any number of `%N` placeholders can be used, and users can define custom aliases (labels) for each in the template management view. 

Key changes:
- Database schema updated with a `parameter_config` JSON column.
- Frontend form for creating issues now uses Alpine.js to dynamically render input fields based on placeholders detected in the selected template.
- Backend replacement logic is now more robust against overlapping placeholders (e.g., `%1` and `%11`) by using `strtr`.

Fixes #132

---
*PR created automatically by Jules for task [11321578199242979533](https://jules.google.com/task/11321578199242979533) started by @chatelao*