### PR TITLE
Implement Template Parameter Aliases

### DIFF
--- a/src/backend/IssueTemplate.php
+++ b/src/backend/IssueTemplate.php
@@ -10,12 +10,12 @@ class IssueTemplate
     {
     }
 
-    public function create(int $userId, string $name, string $title, ?string $body): bool
+    public function create(int $userId, string $name, string $title, ?string $body, ?string $parameterConfig = null): bool
     {
         $stmt = $this->db->getConnection()->prepare(
-            "INSERT INTO issue_templates (user_id, name, title_template, body_template) VALUES (?, ?, ?, ?)"
+            "INSERT INTO issue_templates (user_id, name, title_template, body_template, parameter_config) VALUES (?, ?, ?, ?, ?)"
         );
-        return $stmt->execute([$userId, $name, $title, $body]);
+        return $stmt->execute([$userId, $name, $title, $body, $parameterConfig]);
     }
 
     public function findByUserId(int $userId): array
@@ -24,7 +24,13 @@ class IssueTemplate
             "SELECT * FROM issue_templates WHERE user_id = ? ORDER BY created_at DESC"
         );
         $stmt->execute([$userId]);
-        return $stmt->fetchAll();
+        $templates = $stmt->fetchAll();
+
+        foreach ($templates as &$template) {
+            $template['parameter_config'] = $template['parameter_config'] ? json_decode($template['parameter_config'], true) : [];
+        }
+
+        return $templates;
     }
 
     public function findById(int $id): ?array
@@ -34,7 +40,13 @@ class IssueTemplate
         );
         $stmt->execute([$id]);
         $template = $stmt->fetch();
-        return $template ?: null;
+
+        if ($template) {
+            $template['parameter_config'] = $template['parameter_config'] ? json_decode($template['parameter_config'], true) : [];
+            return $template;
+        }
+
+        return null;
     }
 
     public function delete(int $id, int $userId): bool
@@ -45,11 +57,11 @@ class IssueTemplate
         return $stmt->execute([$id, $userId]);
     }
 
-    public function update(int $id, int $userId, string $name, string $title, ?string $body): bool
+    public function update(int $id, int $userId, string $name, string $title, ?string $body, ?string $parameterConfig = null): bool
     {
         $stmt = $this->db->getConnection()->prepare(
-            "UPDATE issue_templates SET name = ?, title_template = ?, body_template = ? WHERE id = ? AND user_id = ?"
+            "UPDATE issue_templates SET name = ?, title_template = ?, body_template = ?, parameter_config = ? WHERE id = ? AND user_id = ?"
         );
-        return $stmt->execute([$name, $title, $body, $id, $userId]);
+        return $stmt->execute([$name, $title, $body, $parameterConfig, $id, $userId]);
     }
 }

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -130,14 +130,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_from_template'
     }
 
     $templateId = (int)$_POST['template_id'];
-    $val1 = $_POST['val1'] ?? '';
-    $val2 = $_POST['val2'] ?? '';
+    $params = $_POST['params'] ?? [];
 
     $template = $templateModel->findById($templateId);
     if ($template && $template['user_id'] === $user['id']) {
         try {
-            $title = str_replace(['%1', '%2'], [$val1, $val2], $template['title_template']);
-            $body = str_replace(['%1', '%2'], [$val1, $val2], $template['body_template']);
+            $title = strtr($template['title_template'], $params);
+            $body = strtr($template['body_template'], $params);
 
             $githubToken = $project['github_token'] ?? null;
             if (!$githubToken) {
@@ -296,7 +295,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                 <?php endif; ?>
                             </div>
 
-                            <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+                            <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm" x-data="{
+                                templates: <?= htmlspecialchars(json_encode($templates)) ?>,
+                                selectedTemplateId: '<?= $templates[0]['id'] ?? '' ?>',
+                                get selectedTemplate() {
+                                    return this.templates.find(t => t.id == this.selectedTemplateId);
+                                },
+                                get placeholders() {
+                                    if (!this.selectedTemplate) return [];
+                                    const combined = this.selectedTemplate.title_template + ' ' + this.selectedTemplate.body_template;
+                                    const matches = combined.match(/%\d+/g) || [];
+                                    return [...new Set(matches)].sort((a, b) => parseInt(a.slice(1)) - parseInt(b.slice(1)));
+                                }
+                            }">
                                 <h3 class="text-lg font-bold text-gray-900 mb-4">Create Issue from Template</h3>
                                 <?php if (empty($templates)): ?>
                                     <p class="text-sm text-gray-500 italic">No templates available. <a href="templates.php" class="text-blue-600 hover:underline">Create one first.</a></p>
@@ -305,20 +316,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                         <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                         <div class="mb-4">
                                             <label class="block mb-2 text-sm font-medium text-gray-900">Select Template</label>
-                                            <select name="template_id" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                            <select name="template_id" x-model="selectedTemplateId" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                                 <?php foreach ($templates as $tmpl): ?>
                                                     <option value="<?= $tmpl['id'] ?>"><?= htmlspecialchars($tmpl['name']) ?></option>
                                                 <?php endforeach; ?>
                                             </select>
                                         </div>
-                                        <div class="mb-4">
-                                            <label class="block mb-2 text-sm font-medium text-gray-900">%1 value</label>
-                                            <input type="text" name="val1" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
-                                        </div>
-                                        <div class="mb-4">
-                                            <label class="block mb-2 text-sm font-medium text-gray-900">%2 value</label>
-                                            <input type="text" name="val2" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
-                                        </div>
+
+                                        <template x-for="p in placeholders" :key="p">
+                                            <div class="mb-4">
+                                                <label class="block mb-2 text-sm font-medium text-gray-900" x-text="(selectedTemplate.parameter_config[p] || p) + ' value'"></label>
+                                                <input type="text" :name="'params[' + p + ']'" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                            </div>
+                                        </template>
+
                                         <div class="flex items-center mb-4">
                                             <input id="add_jules_label" name="add_jules_label" type="checkbox" value="1" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 focus:ring-2" checked>
                                             <label for="add_jules_label" class="ms-2 text-sm font-medium text-gray-900">Add "Jules" label</label>

--- a/src/frontend/templates.php
+++ b/src/frontend/templates.php
@@ -30,10 +30,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_template'])) {
     $name = trim($_POST['name']);
     $title = trim($_POST['title_template']);
     $body = trim($_POST['body_template']);
+    $parameterConfig = $_POST['parameter_config'] ?? null;
 
     if (!empty($name) && !empty($title)) {
         try {
-            $templateModel->create($user['id'], $name, $title, $body);
+            $templateModel->create($user['id'], $name, $title, $body, $parameterConfig);
             $successMessage = "Template created successfully.";
         } catch (Exception $e) {
             $errorMessage = $e->getMessage();
@@ -53,10 +54,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_template'])) {
     $name = trim($_POST['name']);
     $title = trim($_POST['title_template']);
     $body = trim($_POST['body_template']);
+    $parameterConfig = $_POST['parameter_config'] ?? null;
 
     if ($id > 0 && !empty($name) && !empty($title)) {
         try {
-            $templateModel->update($id, $user['id'], $name, $title, $body);
+            $templateModel->update($id, $user['id'], $name, $title, $body, $parameterConfig);
             $successMessage = "Template updated successfully.";
         } catch (Exception $e) {
             $errorMessage = $e->getMessage();
@@ -94,15 +96,24 @@ $templates = $templateModel->findByUserId($user['id']);
         id: '',
         name: '',
         title_template: '',
-        body_template: ''
+        body_template: '',
+        parameter_config: {}
     },
     editTemplate(t) {
         this.editing = true;
         this.template = { ...t };
+        if (!this.template.parameter_config || Array.isArray(this.template.parameter_config)) {
+            this.template.parameter_config = {};
+        }
     },
     cancelEdit() {
         this.editing = false;
-        this.template = { id: '', name: '', title_template: '', body_template: '' };
+        this.template = { id: '', name: '', title_template: '', body_template: '', parameter_config: {} };
+    },
+    get placeholders() {
+        const combined = this.template.title_template + ' ' + this.template.body_template;
+        const matches = combined.match(/%\d+/g) || [];
+        return [...new Set(matches)].sort((a, b) => parseInt(a.slice(1)) - parseInt(b.slice(1)));
     }
 }">
     <nav class="bg-white border-b border-gray-200 fixed w-full z-30 top-0">
@@ -216,6 +227,20 @@ $templates = $templateModel->findByUserId($user['id']);
                                     <label class="block mb-2 text-sm font-medium text-gray-900">Body Template</label>
                                     <textarea name="body_template" x-model="template.body_template" rows="6" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500" placeholder="Description of the bug: %1&#10;Expected behavior: %2"></textarea>
                                 </div>
+
+                                <div class="mb-4" x-show="placeholders.length > 0">
+                                    <label class="block mb-2 text-sm font-medium text-gray-900">Parameter Aliases</label>
+                                    <div class="space-y-2">
+                                        <template x-for="p in placeholders" :key="p">
+                                            <div class="flex items-center gap-2">
+                                                <span class="text-sm font-mono bg-gray-100 px-2 py-1 rounded" x-text="p"></span>
+                                                <input type="text" :placeholder="'Alias for ' + p" x-model="template.parameter_config[p]" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2">
+                                            </div>
+                                        </template>
+                                    </div>
+                                    <input type="hidden" name="parameter_config" :value="JSON.stringify(template.parameter_config)">
+                                </div>
+
                                 <div class="flex gap-2">
                                     <button type="submit" :name="editing ? 'update_template' : 'create_template'" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 w-full focus:outline-none" x-text="editing ? 'Update Template' : 'Create Template'">Create Template</button>
                                     <button type="button" x-show="editing" @click="cancelEdit()" class="text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 font-medium rounded-lg text-sm px-5 py-2.5 w-full">Cancel</button>

--- a/src/sql/patches/001_add_parameter_config_to_issue_templates.sql
+++ b/src/sql/patches/001_add_parameter_config_to_issue_templates.sql
@@ -1,0 +1,1 @@
+ALTER TABLE issue_templates ADD COLUMN parameter_config TEXT AFTER body_template;

--- a/src/sql/schema.sql
+++ b/src/sql/schema.sql
@@ -75,6 +75,7 @@ CREATE TABLE IF NOT EXISTS issue_templates (
     name VARCHAR(255) NOT NULL,
     title_template VARCHAR(255) NOT NULL,
     body_template TEXT,
+    parameter_config TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/test/Integration/IssueTemplateIntegrationTest.php
+++ b/test/Integration/IssueTemplateIntegrationTest.php
@@ -27,6 +27,7 @@ class IssueTemplateIntegrationTest extends TestCase
             name TEXT,
             title_template TEXT,
             body_template TEXT,
+            parameter_config TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id)
         )");
@@ -42,10 +43,9 @@ class IssueTemplateIntegrationTest extends TestCase
         $this->templateModel->create($userId, 'Bug Template', 'Bug: %1 in %2', 'Found %1');
         $template = $this->templateModel->findByUserId($userId)[0];
 
-        $val1 = 'Crash';
-        $val2 = 'Login';
-        $renderedTitle = str_replace(['%1', '%2'], [$val1, $val2], $template['title_template']);
-        $renderedBody = str_replace(['%1', '%2'], [$val1, $val2], $template['body_template']);
+        $params = ['%1' => 'Crash', '%2' => 'Login'];
+        $renderedTitle = strtr($template['title_template'], $params);
+        $renderedBody = strtr($template['body_template'], $params);
 
         $this->assertEquals('Bug: Crash in Login', $renderedTitle);
         $this->assertEquals('Found Crash', $renderedBody);

--- a/test/Unit/Services/IssueTemplateTest.php
+++ b/test/Unit/Services/IssueTemplateTest.php
@@ -25,6 +25,7 @@ class IssueTemplateTest extends TestCase
             name TEXT,
             title_template TEXT,
             body_template TEXT,
+            parameter_config TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id)
         )");
@@ -86,5 +87,23 @@ class IssueTemplateTest extends TestCase
         $this->assertEquals('Updated Name', $template['name']);
         $this->assertEquals('Updated Title', $template['title_template']);
         $this->assertEquals('Updated Body', $template['body_template']);
+    }
+
+    public function testParameterConfig()
+    {
+        $userId = 1;
+        $config = json_encode(['%1' => 'Module', '%2' => 'Feature']);
+        $this->templateModel->create($userId, 'Config Template', 'Bug in %1', 'Fix %2', $config);
+
+        $templates = $this->templateModel->findByUserId($userId);
+        $this->assertCount(1, $templates);
+        $this->assertEquals(['%1' => 'Module', '%2' => 'Feature'], $templates[0]['parameter_config']);
+
+        $id = $templates[0]['id'];
+        $newConfig = json_encode(['%1' => 'New Module']);
+        $this->templateModel->update($id, $userId, 'Config Template', 'Bug in %1', 'Fix %2', $newConfig);
+
+        $template = $this->templateModel->findById($id);
+        $this->assertEquals(['%1' => 'New Module'], $template['parameter_config']);
     }
 }


### PR DESCRIPTION
I have implemented parameter aliases for issue templates. 

Summary of changes:
1. **Database Schema**: Added `parameter_config` column to `issue_templates` and a corresponding migration patch.
2. **Backend**: Updated `IssueTemplate` model to support the new column.
3. **Frontend (Management)**: Modified `templates.php` to include an Alpine.js-powered alias editor that reacts to placeholders in the template text.
4. **Frontend (Usage)**: Updated `project.php` to display aliases as labels and use `strtr` for robust, multi-parameter replacement.
5. **Quality Assurance**: Updated existing tests and verified that all 85 tests in the suite pass.
6. **Cleanup**: Removed a leftover development database file and fixed a minor sorting logic typo identified during review.

Fixes #146

---
*PR created automatically by Jules for task [14472605105153200487](https://jules.google.com/task/14472605105153200487) started by @chatelao*