### PR TITLE
Add user-specific Telegram configuration to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,3 +33,6 @@
 - [x] Implement asynchronous processing using `fastcgi_finish_request()` for immediate Telegram acknowledgement.
 - [x] Connect Telegram interactions to the Google Jules orchestration engine.
 - [x] Enable agent-to-user communication and status updates via Telegram.
+
+## Phase 6: Customization
+- [ ] Enable user-specific Telegram configuration (custom bot tokens).


### PR DESCRIPTION
This change adds a new phase to the project roadmap focused on customization, specifically tracking the goal of allowing users to provide their own Telegram bot tokens for individual configurations.

Fixes #139

---
*PR created automatically by Jules for task [4958014935553234716](https://jules.google.com/task/4958014935553234716) started by @chatelao*