### PR TITLE
Add user_id to tasks and task_logs tables

### DIFF
--- a/schema.puml
+++ b/schema.puml
@@ -37,6 +37,7 @@ entity "projects" {
 entity "tasks" {
   * <color:grey><i>task_id</i></color> : INT <<PK>>
   --
+  * <color:grey><i>user_id</i></color> : INT <<FK>>
   * <color:grey><i>project_id</i></color> : INT <<FK>>
   * <color:grey>issue_number</color> : INT
   * title : VARCHAR(255)
@@ -51,6 +52,7 @@ entity "tasks" {
 entity "task_logs" {
   * <color:grey><i>task_log_id</i></color> : INT <<PK>>
   --
+  * <color:grey><i>user_id</i></color> : INT <<FK>>
   * <color:grey><i>task_id</i></color> : INT <<FK>>
   level : VARCHAR(20)
   * message : TEXT
@@ -84,6 +86,8 @@ entity "issue_templates" {
 
 users ||--o{ user_github_accounts : "user_id"
 users ||--o{ projects : "user_id"
+users ||--o{ tasks : "user_id"
+users ||--o{ task_logs : "user_id"
 users ||--o{ user_telegram_accounts : "user_id"
 users ||--o{ issue_templates : "user_id"
 user_github_accounts ||--o{ projects : "github_account_id"

--- a/src/backend/Logger.php
+++ b/src/backend/Logger.php
@@ -8,12 +8,12 @@ class Logger
     {
     }
 
-    public function log(int $taskId, string $message, string $level = 'info'): bool
+    public function log(int $userId, int $taskId, string $message, string $level = 'info'): bool
     {
         $stmt = $this->db->getConnection()->prepare(
-            "INSERT INTO task_logs (task_id, message, level) VALUES (?, ?, ?)"
+            "INSERT INTO task_logs (user_id, task_id, message, level) VALUES (?, ?, ?, ?)"
         );
-        return $stmt->execute([$taskId, $message, $level]);
+        return $stmt->execute([$userId, $taskId, $message, $level]);
     }
 
     public function getLogsByTaskId(int $taskId): array

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -91,9 +91,10 @@ class Task
     public function create(array $data): bool
     {
         $stmt = $this->db->getConnection()->prepare(
-            "INSERT INTO tasks (project_id, issue_number, title, body, github_data, status) VALUES (?, ?, ?, ?, ?, ?)"
+            "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status) VALUES (?, ?, ?, ?, ?, ?, ?)"
         );
         return $stmt->execute([
+            $data['user_id'],
             $data['project_id'],
             $data['issue_number'],
             $data['title'],
@@ -103,21 +104,21 @@ class Task
         ]);
     }
 
-    public function upsert(int $projectId, array $issue): bool
+    public function upsert(int $userId, int $projectId, array $issue): bool
     {
         $connection = $this->db->getConnection();
         $driver = $connection->getAttribute(PDO::ATTR_DRIVER_NAME);
 
         if ($driver === 'sqlite') {
-            $sql = "INSERT INTO tasks (project_id, issue_number, title, body, github_data, status)
-                    VALUES (?, ?, ?, ?, ?, ?)
+            $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(project_id, issue_number) DO UPDATE SET
                         title = excluded.title,
                         body = excluded.body,
                         github_data = excluded.github_data";
         } else {
-            $sql = "INSERT INTO tasks (project_id, issue_number, title, body, github_data, status)
-                    VALUES (?, ?, ?, ?, ?, ?)
+            $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                     ON DUPLICATE KEY UPDATE
                         title = VALUES(title),
                         body = VALUES(body),
@@ -127,6 +128,7 @@ class Task
         $stmt = $connection->prepare($sql);
 
         return $stmt->execute([
+            $userId,
             $projectId,
             $issue['number'],
             $issue['title'],

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -16,7 +16,7 @@ class WebhookHandler
         return hash_equals($hash, $signature);
     }
 
-    public function handle(int $projectId, array $event, ?GitHubService $githubService = null): bool
+    public function handle(array $project, array $event, ?GitHubService $githubService = null): bool
     {
         $action = $event['action'] ?? '';
         $issue = $event['issue'] ?? null;
@@ -26,7 +26,7 @@ class WebhookHandler
         }
 
         $taskModel = new Task($this->db);
-        $result = $taskModel->upsert($projectId, $issue);
+        $result = $taskModel->upsert($project['user_id'], $project['project_id'], $issue);
 
         if ($result && $action === 'closed' && $githubService) {
             $stateReason = $issue['state_reason'] ?? '';

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -65,7 +65,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['trigger_agent'])) {
 
     if ($task && $task['project_id'] === $project['project_id']) {
         try {
-            $logger->log($taskId, "Agent triggered by user " . $user['name']);
+            $logger->log($user['user_id'], $taskId, "Agent triggered by user " . $user['name']);
             $githubToken = $project['github_token'] ?? null;
             $githubService = null;
             if ($githubToken) {
@@ -74,27 +74,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['trigger_agent'])) {
 
             // Update status to in_progress
             $taskModel->updateStatus($taskId, 'in_progress');
-            $logger->log($taskId, "Task status updated to in_progress");
+            $logger->log($user['user_id'], $taskId, "Task status updated to in_progress");
 
             if ($githubService) {
                 $githubService->postComment($project['github_repo'], $task['issue_number'], "🤖 Agent has started processing this issue...");
-                $logger->log($taskId, "Posted 'started' comment to GitHub");
+                $logger->log($user['user_id'], $taskId, "Posted 'started' comment to GitHub");
             }
 
             if ($telegramChatId) {
                 $telegramService->sendMessage($telegramChatId, "🤖 <b>Agent Started</b>\nProject: {$project['github_repo']}\nIssue: #{$task['issue_number']} {$task['title']}");
             }
 
-            $logger->log($taskId, "Calling Jules API...");
+            $logger->log($user['user_id'], $taskId, "Calling Jules API...");
             $lastAgentResponse = $julesService->triggerAgent($task);
-            $logger->log($taskId, "Received response from Jules API");
+            $logger->log($user['user_id'], $taskId, "Received response from Jules API");
 
             $taskModel->updateAgentResponse($taskId, $lastAgentResponse, 'completed');
-            $logger->log($taskId, "Task agent response updated and status set to completed");
+            $logger->log($user['user_id'], $taskId, "Task agent response updated and status set to completed");
 
             if ($githubService) {
                 $githubService->postComment($project['github_repo'], $task['issue_number'], "✅ Agent has completed the analysis:\n\n" . $lastAgentResponse);
-                $logger->log($taskId, "Posted 'completed' comment to GitHub");
+                $logger->log($user['user_id'], $taskId, "Posted 'completed' comment to GitHub");
             }
 
             if ($telegramChatId) {
@@ -105,14 +105,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['trigger_agent'])) {
             $tasks = $taskModel->findByProjectId($projectId);
         } catch (\Exception $e) {
             $errorMessage = "Error triggering agent: " . $e->getMessage();
-            $logger->log($taskId, "Error: " . $e->getMessage(), "error");
+            $logger->log($user['user_id'], $taskId, "Error: " . $e->getMessage(), "error");
             $taskModel->updateStatus($taskId, 'failed');
             if (isset($githubService) && $githubService) {
                 try {
                     $githubService->postComment($project['github_repo'], $task['issue_number'], "❌ Agent failed to process this issue: " . $e->getMessage());
-                    $logger->log($taskId, "Posted 'failed' comment to GitHub");
+                    $logger->log($user['user_id'], $taskId, "Posted 'failed' comment to GitHub");
                 } catch (\Exception $ge) {
-                    $logger->log($taskId, "Failed to post error comment to GitHub: " . $ge->getMessage(), "error");
+                    $logger->log($user['user_id'], $taskId, "Failed to post error comment to GitHub: " . $ge->getMessage(), "error");
                 }
             }
 
@@ -176,7 +176,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
             if (isset($issue['pull_request'])) {
                 continue;
             }
-            $taskModel->upsert($project['project_id'], $issue);
+            $taskModel->upsert($user['user_id'], $project['project_id'], $issue);
         }
 
         header("Location: project.php?id=$projectId&success=synced");

--- a/src/frontend/webhook.php
+++ b/src/frontend/webhook.php
@@ -64,7 +64,7 @@ if (!empty($matchingProject['github_token'])) {
     $githubService = new GitHubService(null, $matchingProject['github_token']);
 }
 
-if ($handler->handle($matchingProject['project_id'], $data, $githubService)) {
+if ($handler->handle($matchingProject, $data, $githubService)) {
     http_response_code(200);
     echo 'OK';
 } else {

--- a/src/sql/patches/003_add_user_id_to_tasks_and_logs.sql
+++ b/src/sql/patches/003_add_user_id_to_tasks_and_logs.sql
@@ -1,0 +1,9 @@
+-- Add user_id to tasks
+ALTER TABLE tasks ADD COLUMN user_id INT;
+UPDATE tasks SET user_id = (SELECT user_id FROM projects WHERE projects.project_id = tasks.project_id);
+-- In some environments (like SQLite during tests), we might not be able to MODIFY or ADD CONSTRAINT easily.
+-- But the MigrationService uses these patches.
+
+-- Add user_id to task_logs
+ALTER TABLE task_logs ADD COLUMN user_id INT;
+UPDATE task_logs SET user_id = (SELECT user_id FROM tasks WHERE tasks.task_id = task_logs.task_id);

--- a/src/sql/schema.sql
+++ b/src/sql/schema.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS projects (
 
 CREATE TABLE IF NOT EXISTS tasks (
     task_id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
     project_id INT NOT NULL,
     issue_number INT NOT NULL,
     title VARCHAR(255) NOT NULL,
@@ -42,16 +43,19 @@ CREATE TABLE IF NOT EXISTS tasks (
     agent_response TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
     FOREIGN KEY (project_id) REFERENCES projects(project_id) ON DELETE CASCADE,
     UNIQUE KEY project_issue (project_id, issue_number)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS task_logs (
     task_log_id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
     task_id INT NOT NULL,
     level VARCHAR(20) DEFAULT 'info',
     message TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
     FOREIGN KEY (task_id) REFERENCES tasks(task_id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/test/Integration/IssueSyncIntegrationTest.php
+++ b/test/Integration/IssueSyncIntegrationTest.php
@@ -20,6 +20,7 @@ class IssueSyncIntegrationTest extends TestCase
 
         $this->pdo->exec("CREATE TABLE tasks (
             task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INT NOT NULL,
             project_id INT NOT NULL,
             issue_number INT NOT NULL,
             title VARCHAR(255) NOT NULL,
@@ -39,6 +40,7 @@ class IssueSyncIntegrationTest extends TestCase
 
     public function testUpsertNewIssue()
     {
+        $userId = 1;
         $projectId = 1;
         $issue = [
             'number' => 1,
@@ -46,7 +48,7 @@ class IssueSyncIntegrationTest extends TestCase
             'body' => 'Initial Body'
         ];
 
-        $this->taskModel->upsert($projectId, $issue);
+        $this->taskModel->upsert($userId, $projectId, $issue);
 
         $stmt = $this->pdo->prepare("SELECT * FROM tasks WHERE project_id = ? AND issue_number = ?");
         $stmt->execute([$projectId, 1]);
@@ -58,6 +60,7 @@ class IssueSyncIntegrationTest extends TestCase
 
     public function testUpsertExistingIssue()
     {
+        $userId = 1;
         $projectId = 1;
         $issue1 = [
             'number' => 1,
@@ -65,7 +68,7 @@ class IssueSyncIntegrationTest extends TestCase
             'body' => 'Initial Body'
         ];
 
-        $this->taskModel->upsert($projectId, $issue1);
+        $this->taskModel->upsert($userId, $projectId, $issue1);
 
         $issue2 = [
             'number' => 1,
@@ -73,7 +76,7 @@ class IssueSyncIntegrationTest extends TestCase
             'body' => 'Updated Body'
         ];
 
-        $this->taskModel->upsert($projectId, $issue2);
+        $this->taskModel->upsert($userId, $projectId, $issue2);
 
         $stmt = $this->pdo->prepare("SELECT COUNT(*) FROM tasks WHERE project_id = ? AND issue_number = ?");
         $stmt->execute([$projectId, 1]);

--- a/test/Integration/TaskDBIntegrationTest.php
+++ b/test/Integration/TaskDBIntegrationTest.php
@@ -20,6 +20,7 @@ class TaskDBIntegrationTest extends TestCase
 
         $this->pdo->exec("CREATE TABLE tasks (
             task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INT NOT NULL,
             project_id INT NOT NULL,
             issue_number INT NOT NULL,
             title VARCHAR(255) NOT NULL,
@@ -40,6 +41,7 @@ class TaskDBIntegrationTest extends TestCase
     public function testCreateAndFindTask()
     {
         $data = [
+            'user_id' => 1,
             'project_id' => 1,
             'issue_number' => 101,
             'title' => 'Test Issue',
@@ -61,6 +63,7 @@ class TaskDBIntegrationTest extends TestCase
     public function testUpdateStatus()
     {
         $data = [
+            'user_id' => 1,
             'project_id' => 1,
             'issue_number' => 101,
             'title' => 'Test Issue'

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -20,6 +20,7 @@ class WebhookHandlerTest extends TestCase
 
         $this->pdo->exec("CREATE TABLE tasks (
             task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INT NOT NULL,
             project_id INT NOT NULL,
             issue_number INT NOT NULL,
             title VARCHAR(255) NOT NULL,
@@ -49,7 +50,7 @@ class WebhookHandlerTest extends TestCase
 
     public function testHandleIssueOpened()
     {
-        $projectId = 1;
+        $project = ['user_id' => 1, 'project_id' => 1];
         $event = [
             'action' => 'opened',
             'issue' => [
@@ -59,11 +60,11 @@ class WebhookHandlerTest extends TestCase
             ]
         ];
 
-        $result = $this->handler->handle($projectId, $event);
+        $result = $this->handler->handle($project, $event);
         $this->assertTrue($result);
 
         $stmt = $this->pdo->prepare("SELECT * FROM tasks WHERE project_id = ? AND issue_number = ?");
-        $stmt->execute([$projectId, 123]);
+        $stmt->execute([$project['project_id'], 123]);
         $task = $stmt->fetch();
 
         $this->assertNotFalse($task);

--- a/test/Integration/verify_project_ui.php
+++ b/test/Integration/verify_project_ui.php
@@ -54,6 +54,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS projects (
 
 $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
     project_id INT NOT NULL,
     issue_number INT NOT NULL,
     title VARCHAR(255) NOT NULL,
@@ -76,6 +77,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS user_telegram_accounts (
 
 $pdo->exec("CREATE TABLE IF NOT EXISTS task_logs (
     task_log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
     task_id INT NOT NULL,
     level VARCHAR(20) DEFAULT 'info',
     message TEXT NOT NULL,
@@ -111,6 +113,7 @@ $project = $projectModel->findByRepo('owner/repo')[0];
 // Create some tasks
 $taskModel = new Task($db);
 $taskModel->create([
+    'user_id' => 1,
     'project_id' => $project['project_id'],
     'issue_number' => 101,
     'title' => 'Sample Issue #1',
@@ -120,9 +123,10 @@ $taskModel->create([
 
 // Add some logs to task 1
 $logger = new \App\Logger($db);
-$logger->log(1, "Mock log entry 1 for task 101");
-$logger->log(1, "Mock error log entry 2 for task 101", "error");
+$logger->log(1, 1, "Mock log entry 1 for task 101");
+$logger->log(1, 1, "Mock error log entry 2 for task 101", "error");
 $taskModel->create([
+    'user_id' => 1,
     'project_id' => $project['project_id'],
     'issue_number' => 102,
     'title' => 'Another Bug #2',

--- a/test/Unit/Services/LoggerTest.php
+++ b/test/Unit/Services/LoggerTest.php
@@ -22,15 +22,16 @@ class LoggerTest extends TestCase
     private function createSchema(): void
     {
         $pdo = $this->db->getConnection();
-        $pdo->exec("CREATE TABLE tasks (task_id INTEGER PRIMARY KEY, project_id INTEGER, issue_number INTEGER, title TEXT, status TEXT)");
-        $pdo->exec("CREATE TABLE task_logs (task_log_id INTEGER PRIMARY KEY, task_id INTEGER, level TEXT, message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
+        $pdo->exec("CREATE TABLE tasks (task_id INTEGER PRIMARY KEY, user_id INTEGER, project_id INTEGER, issue_number INTEGER, title TEXT, status TEXT)");
+        $pdo->exec("CREATE TABLE task_logs (task_log_id INTEGER PRIMARY KEY, user_id INTEGER, task_id INTEGER, level TEXT, message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
     }
 
     public function testLogAndGetLogs(): void
     {
+        $userId = 1;
         $taskId = 1;
-        $this->logger->log($taskId, "Test message 1", "info");
-        $this->logger->log($taskId, "Test message 2", "error");
+        $this->logger->log($userId, $taskId, "Test message 1", "info");
+        $this->logger->log($userId, $taskId, "Test message 2", "error");
 
         $logs = $this->logger->getLogsByTaskId($taskId);
 

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -34,7 +34,7 @@ class WebhookHandlerTest extends TestCase
 
     public function testHandleOpenedIssue()
     {
-        $projectId = 1;
+        $project = ['user_id' => 1, 'project_id' => 1];
         $event = [
             'action' => 'opened',
             'issue' => [
@@ -50,12 +50,12 @@ class WebhookHandlerTest extends TestCase
         $this->pdo->method('getAttribute')->with(PDO::ATTR_DRIVER_NAME)->willReturn('mysql');
         $this->pdo->method('prepare')->willReturn($stmt);
 
-        $this->assertTrue($this->handler->handle($projectId, $event));
+        $this->assertTrue($this->handler->handle($project, $event));
     }
 
     public function testHandleClosedIssueWithAutorepeat()
     {
-        $projectId = 1;
+        $project = ['user_id' => 1, 'project_id' => 1];
         $event = [
             'action' => 'closed',
             'repository' => ['full_name' => 'owner/repo'],
@@ -85,12 +85,12 @@ class WebhookHandlerTest extends TestCase
             ->method('removeLabel')
             ->with('owner/repo', 123, 'autorepeat');
 
-        $this->assertTrue($this->handler->handle($projectId, $event, $githubService));
+        $this->assertTrue($this->handler->handle($project, $event, $githubService));
     }
 
     public function testHandleClosedIssueWithoutAutorepeat()
     {
-        $projectId = 1;
+        $project = ['user_id' => 1, 'project_id' => 1];
         $event = [
             'action' => 'closed',
             'issue' => [
@@ -114,23 +114,23 @@ class WebhookHandlerTest extends TestCase
         $githubService->expects($this->never())->method('createIssue');
         $githubService->expects($this->never())->method('removeLabel');
 
-        $this->assertTrue($this->handler->handle($projectId, $event, $githubService));
+        $this->assertTrue($this->handler->handle($project, $event, $githubService));
     }
 
     public function testHandleUnsupportedAction()
     {
-        $projectId = 1;
+        $project = ['user_id' => 1, 'project_id' => 1];
         $event = [
             'action' => 'deleted',
             'issue' => ['number' => 123]
         ];
 
-        $this->assertFalse($this->handler->handle($projectId, $event));
+        $this->assertFalse($this->handler->handle($project, $event));
     }
 
     public function testHandleSqlite()
     {
-        $projectId = 1;
+        $project = ['user_id' => 1, 'project_id' => 1];
         $event = [
             'action' => 'opened',
             'issue' => [
@@ -149,6 +149,6 @@ class WebhookHandlerTest extends TestCase
             return $stmt;
         });
 
-        $this->assertTrue($this->handler->handle($projectId, $event));
+        $this->assertTrue($this->handler->handle($project, $event));
     }
 }


### PR DESCRIPTION
This task involved adding a `user_id` column to the `tasks` and `task_logs` tables to establish direct ownership and improve data isolation. I implemented a database migration to add and populate these columns, updated the baseline schema and PlantUML diagrams, and refactored the backend models (`Task` and `Logger`) and their callers (Webhook handler and frontend) to consistently use and persist the user ID. All existing tests were updated and verified to pass.

Fixes #154

---
*PR created automatically by Jules for task [12470916162921709147](https://jules.google.com/task/12470916162921709147) started by @chatelao*