### PR TITLE
Include release tag in release asset filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
 
       - name: Create ZIP archive
         run: |
-          zip -r agent-control-php.zip . -x "*.git*" ".github/*" "test/*" "docs/*" "specification/*" "scripts/*" ".gitignore" "Vagrantfile" "CONCEPT.md" "DESIGN.md" "GEMINI.md" "HOWTO.md" "INSTALL.md" "ROADMAP.md" ".readthedocs.yaml"
+          zip -r agent-control-php-${{ github.event.release.tag_name }}.zip . -x "*.git*" ".github/*" "test/*" "docs/*" "specification/*" "scripts/*" ".gitignore" "Vagrantfile" "CONCEPT.md" "DESIGN.md" "GEMINI.md" "HOWTO.md" "INSTALL.md" "ROADMAP.md" ".readthedocs.yaml"
 
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} agent-control-php.zip
+          gh release upload ${{ github.event.release.tag_name }} agent-control-php-${{ github.event.release.tag_name }}.zip


### PR DESCRIPTION
The release workflow now generates and uploads a ZIP archive with the version tag included in its filename. This was achieved by updating the `Create ZIP archive` and `Upload Release Asset` steps in `.github/workflows/release.yml` to use `agent-control-php-${{ github.event.release.tag_name }}.zip` instead of a static filename.

Fixes #156

---
*PR created automatically by Jules for task [14057097946368755220](https://jules.google.com/task/14057097946368755220) started by @chatelao*