### PR TITLE
Add manual SFTP deployment GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Manual SFTP Deploy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to Webserver
+    runs-on: ubuntu-latest
+    if: github.actor == github.repository_owner
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, xml, ctype, iconv, mysql
+
+      - name: Install dependencies
+        run: composer install --no-dev --optimize-autoloader
+
+      - name: Deploy via SFTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.SFTP_SERVER }}
+          username: ${{ secrets.SFTP_USERNAME }}
+          password: ${{ secrets.SFTP_PASSWORD }}
+          protocol: sftp
+          port: 22
+          exclude: |
+            **/.git*
+            **/.git*/**
+            **/.github/**
+            **/test/**
+            **/docs/**
+            **/specification/**
+            **/scripts/**
+            **/Vagrantfile
+            **/CONCEPT.md
+            **/DESIGN.md
+            **/GEMINI.md
+            **/HOWTO.md
+            **/INSTALL.md
+            **/ROADMAP.md
+            **/CONCEPT_UPGRADES.md
+            **/openapi.yaml
+            **/schema.puml
+            **/*.sqlite
+            **/.readthedocs.yaml
+            **/composer.json
+            **/composer.lock
+            **/phpunit.xml
+            **/README.md


### PR DESCRIPTION
This PR adds a new GitHub Action workflow for manual SFTP deployment to a webserver.

Key features:
- **Manual Trigger**: Uses `workflow_dispatch` for controlled deployments.
- **Security**: Restricted to the repository owner using `github.actor == github.repository_owner`. Uses secrets for all credentials.
- **Optimized for Production**: Performs `composer install --no-dev` before sync and excludes over 15 non-production files/directories (tests, docs, development configs, etc.).
- **Reliability**: Uses the proven `SamKirkland/FTP-Deploy-Action`.

Fixes #158

---
*PR created automatically by Jules for task [10351424188873015291](https://jules.google.com/task/10351424188873015291) started by @chatelao*