### PR TITLE
Automatically resync tasks on GitHub callback

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -104,6 +104,24 @@ class Task
         ]);
     }
 
+    public function syncProjectTasks(int $userId, int $projectId, string $repo, GitHubService $githubService): bool
+    {
+        $issues = $githubService->listIssues($repo);
+        $success = true;
+
+        foreach ($issues as $issue) {
+            // Check if it's really an issue (not a PR)
+            if (isset($issue['pull_request'])) {
+                continue;
+            }
+            if (!$this->upsert($userId, $projectId, $issue)) {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
     public function upsert(int $userId, int $projectId, array $issue): bool
     {
         $connection = $this->db->getConnection();

--- a/src/frontend/github-callback.php
+++ b/src/frontend/github-callback.php
@@ -4,6 +4,9 @@ use App\Auth;
 use App\GitHubAuth;
 use App\Database;
 use App\User;
+use App\Project;
+use App\Task;
+use App\GitHubService;
 use App\RateLimiter;
 
 $db = new Database();
@@ -28,6 +31,19 @@ if (isset($_GET['code']) && isset($_GET['state'])) {
     try {
         $githubData = $githubAuth->authenticate($_GET['code'], $_GET['state']);
         $userModel->addGitHubAccount($auth->getUserId(), $githubData['access_token'], $githubData['github_username']);
+
+        // Auto-resync tasks for all projects matching this GitHub account
+        $projectModel = new Project($db);
+        $taskModel = new Task($db);
+        $githubService = new GitHubService(null, $githubData['access_token']);
+        $projects = $projectModel->findByUserId($auth->getUserId());
+
+        foreach ($projects as $project) {
+            if ($project['github_username'] === $githubData['github_username']) {
+                $taskModel->syncProjectTasks($auth->getUserId(), $project['project_id'], $project['github_repo'], $githubService);
+            }
+        }
+
         header('Location: index.php?github=success');
         exit;
     } catch (Exception $e) {

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -169,15 +169,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
         }
 
         $githubService = new GitHubService(null, $githubToken);
-        $issues = $githubService->listIssues($project['github_repo']);
-
-        foreach ($issues as $issue) {
-            // Check if it's really an issue (not a PR)
-            if (isset($issue['pull_request'])) {
-                continue;
-            }
-            $taskModel->upsert($user['user_id'], $project['project_id'], $issue);
-        }
+        $taskModel->syncProjectTasks($user['user_id'], $project['project_id'], $project['github_repo'], $githubService);
 
         header("Location: project.php?id=$projectId&success=synced");
         exit;

--- a/test/Unit/Services/TaskTest.php
+++ b/test/Unit/Services/TaskTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Services;
 use PHPUnit\Framework\TestCase;
 use App\Database;
 use App\Task;
+use App\GitHubService;
 use PDO;
 use PDOStatement;
 
@@ -61,6 +62,34 @@ class TaskTest extends TestCase
         $this->pdo->method('prepare')->willReturn($stmt);
 
         $result = $this->taskModel->updateStatus($id, $status);
+        $this->assertTrue($result);
+    }
+
+    public function testSyncProjectTasks()
+    {
+        $userId = 1;
+        $projectId = 1;
+        $repo = 'owner/repo';
+
+        $issues = [
+            ['number' => 1, 'title' => 'Issue 1', 'body' => 'Body 1'],
+            ['number' => 2, 'title' => 'PR 1', 'body' => 'Body 2', 'pull_request' => []],
+            ['number' => 3, 'title' => 'Issue 2', 'body' => 'Body 3'],
+        ];
+
+        $githubService = $this->createMock(GitHubService::class);
+        $githubService->method('listIssues')->with($repo)->willReturn($issues);
+
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->method('execute')->willReturn(true);
+
+        $this->pdo->method('getAttribute')->with(PDO::ATTR_DRIVER_NAME)->willReturn('mysql');
+        $this->pdo->method('prepare')->willReturn($stmt);
+
+        // Expect 2 calls for issues, skip PR
+        $stmt->expects($this->exactly(2))->method('execute');
+
+        $result = $this->taskModel->syncProjectTasks($userId, $projectId, $repo, $githubService);
         $this->assertTrue($result);
     }
 }


### PR DESCRIPTION
This change automates task synchronization when a user connects or reconnects their GitHub account. By integrating the synchronization logic into the OAuth callback, we ensure that the local task list is immediately updated with the latest issues from GitHub without requiring manual intervention.

Key changes:
- `App\Task::syncProjectTasks`: New method to fetch and upsert issues.
- `src/frontend/github-callback.php`: Now iterates through matching projects and syncs them.
- `src/frontend/project.php`: Refactored to use the shared synchronization logic.
- `test/Unit/Services/TaskTest.php`: New test case to verify the synchronization process, including skipping pull requests.

Fixes #166

---
*PR created automatically by Jules for task [5867552768165386382](https://jules.google.com/task/5867552768165386382) started by @chatelao*