### PR TITLE
Relocate Connection Configuration to Account Settings Page

### DIFF
--- a/src/frontend/github-callback.php
+++ b/src/frontend/github-callback.php
@@ -28,13 +28,13 @@ if (isset($_GET['code']) && isset($_GET['state'])) {
     try {
         $githubData = $githubAuth->authenticate($_GET['code'], $_GET['state']);
         $userModel->addGitHubAccount($auth->getUserId(), $githubData['access_token'], $githubData['github_username']);
-        header('Location: index.php?github=success');
+        header('Location: settings.php?github=success');
         exit;
     } catch (Exception $e) {
-        header('Location: index.php?github=error&message=' . urlencode($e->getMessage()));
+        header('Location: settings.php?github=error&message=' . urlencode($e->getMessage()));
         exit;
     }
 } else {
-    header('Location: index.php');
+    header('Location: settings.php');
     exit;
 }

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -15,20 +15,6 @@ $projectModel = new Project($db);
 
 $user = $auth->isLoggedIn() ? $userModel->findById($auth->getUserId()) : null;
 
-// Handle Jules API Key Update
-if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_jules_key'])) {
-    if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
-        die("CSRF token validation failed.");
-    }
-    $apiKey = trim($_POST['jules_api_key']);
-    if ($userModel->updateJulesApiKey($user['user_id'], $apiKey)) {
-        header('Location: index.php?success=key_updated');
-        exit;
-    } else {
-        $errorMessage = "Failed to update Jules API Key.";
-    }
-}
-
 // Handle Project Creation
 if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['github_repo']) && isset($_POST['github_account_id'])) {
     if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
@@ -125,6 +111,7 @@ $errorMessage = $errorMessage ?? null;
                                 </button>
                             </div>
                             <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name']) ?></div>
+                            <a href="settings.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Settings</a>
                             <a href="templates.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Templates</a>
                             <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
                         </div>
@@ -140,22 +127,6 @@ $errorMessage = $errorMessage ?? null;
         <div id="main-content" class="relative w-full h-full overflow-y-auto bg-gray-50">
             <main>
                 <div class="px-4 pt-6">
-                    <?php if (isset($_GET['github']) && $_GET['github'] === 'success'): ?>
-                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
-                            <span class="font-medium">Success!</span> GitHub account linked correctly.
-                        </div>
-                    <?php endif; ?>
-                    <?php if (isset($_GET['success']) && $_GET['success'] === 'key_updated'): ?>
-                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
-                            <span class="font-medium">Success!</span> Jules API Key updated successfully.
-                        </div>
-                    <?php endif; ?>
-                    <?php if (isset($_GET['github']) && $_GET['github'] === 'error'): ?>
-                        <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
-                            <span class="font-medium">Error!</span> <?= htmlspecialchars($_GET['message'] ?? 'GitHub authentication failed.') ?>
-                        </div>
-                    <?php endif; ?>
-
                     <?php if ($errorMessage): ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
                             <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
@@ -207,37 +178,6 @@ $errorMessage = $errorMessage ?? null;
                                 <p class="text-2xl font-bold leading-none text-gray-900 sm:text-3xl">Dashboard</p>
                                 <div class="mt-4">
                                     <p class="text-gray-600">You are logged in as <strong><?= htmlspecialchars($user['email']) ?></strong>.</p>
-
-                                    <div class="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-                                        <h4 class="text-lg font-semibold text-blue-900 mb-2">Jules API Key (Private)</h4>
-                                        <p class="text-sm text-blue-700 mb-4">Your personal Google AI (Gemini) API key. This is required for agent features and is not shared with other users.</p>
-                                        <form method="POST" class="flex gap-2">
-                                            <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
-                                            <input type="password" name="jules_api_key" value="<?= htmlspecialchars($user['jules_api_key'] ?? '') ?>" placeholder="AI Studio API Key" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
-                                            <button type="submit" name="update_jules_key" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Save</button>
-                                        </form>
-                                    </div>
-
-
-                                    <div class="mt-6">
-                                        <h4 class="text-lg font-semibold text-gray-900">Linked GitHub Accounts</h4>
-                                        <div class="mt-2 space-y-2">
-                                            <?php if (empty($githubAccounts)): ?>
-                                                <p class="text-sm text-gray-500 italic">No GitHub accounts linked yet.</p>
-                                            <?php else: ?>
-                                                <?php foreach ($githubAccounts as $account): ?>
-                                                    <div class="flex items-center text-green-600">
-                                                        <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-                                                        Linked as&nbsp;<strong><?= htmlspecialchars($account['github_username']) ?></strong>
-                                                    </div>
-                                                <?php endforeach; ?>
-                                            <?php endif; ?>
-                                            <a href="github-login.php" class="mt-2 inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-gray-800 rounded-lg hover:bg-gray-900 focus:ring-4 focus:outline-none focus:ring-gray-300">
-                                                <svg class="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-                                                Link <?= empty($githubAccounts) ? 'GitHub Account' : 'Another GitHub Account' ?>
-                                            </a>
-                                        </div>
-                                    </div>
                                 </div>
 
                                 <div class="mt-8">

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -210,6 +210,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                     <div class="flex items-center ml-3">
                         <img class="w-8 h-8 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="user photo">
                         <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name']) ?></div>
+                        <a href="settings.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Settings</a>
+                        <a href="templates.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Templates</a>
                         <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
                     </div>
                 </div>

--- a/src/frontend/settings.php
+++ b/src/frontend/settings.php
@@ -1,0 +1,163 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Database;
+use App\Auth;
+use App\User;
+
+$auth = new Auth();
+$db = new Database();
+$userModel = new User($db);
+
+if (!$auth->isLoggedIn()) {
+    header('Location: login.php');
+    exit;
+}
+
+$user = $userModel->findById($auth->getUserId());
+$errorMessage = null;
+$successMessage = null;
+
+// Handle Jules API Key Update
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_jules_key'])) {
+    if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
+        die("CSRF token validation failed.");
+    }
+    $apiKey = trim($_POST['jules_api_key']);
+    if ($userModel->updateJulesApiKey($user['user_id'], $apiKey)) {
+        header('Location: settings.php?success=key_updated');
+        exit;
+    } else {
+        $errorMessage = "Failed to update Jules API Key.";
+    }
+}
+
+$githubAccounts = $userModel->getGitHubAccounts($user['user_id']);
+
+if (isset($_GET['success']) && $_GET['success'] === 'key_updated') {
+    $successMessage = "Jules API Key updated successfully.";
+}
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Account Settings - Agent Control</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body class="bg-gray-100 font-sans leading-normal tracking-normal">
+    <nav class="bg-white border-b border-gray-200 fixed w-full z-30 top-0">
+        <div class="px-3 py-3 lg:px-5 lg:pl-3">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center justify-start">
+                    <a href="index.php" class="text-xl font-bold flex items-center lg:ml-2.5">
+                        <span class="self-center whitespace-nowrap">Agent Control</span>
+                    </a>
+                </div>
+                <div class="flex items-center">
+                    <div class="flex items-center ml-3">
+                        <img class="w-8 h-8 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="user photo">
+                        <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name']) ?></div>
+                        <a href="index.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Dashboard</a>
+                        <a href="templates.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Templates</a>
+                        <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <div class="flex pt-16 overflow-hidden bg-gray-50">
+        <div id="main-content" class="relative w-full h-full overflow-y-auto bg-gray-50">
+            <main>
+                <div class="px-4 pt-6">
+                    <nav class="flex mb-5" aria-label="Breadcrumb">
+                        <ol class="inline-flex items-center space-x-1 md:space-x-2">
+                            <li class="inline-flex items-center">
+                                <a href="index.php" class="text-gray-700 hover:text-gray-900 inline-flex items-center">
+                                    <svg class="w-5 h-5 mr-2.5" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path></svg>
+                                    Dashboard
+                                </a>
+                            </li>
+                            <li>
+                                <div class="flex items-center">
+                                    <svg class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
+                                    <span class="text-gray-400 ml-1 md:ml-2 font-medium">Account Settings</span>
+                                </div>
+                            </li>
+                        </ol>
+                    </nav>
+
+                    <div class="mb-4">
+                        <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">Account Settings</h1>
+                    </div>
+
+                    <?php if ($errorMessage): ?>
+                        <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+                            <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if ($successMessage): ?>
+                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+                            <span class="font-medium">Success!</span> <?= htmlspecialchars($successMessage) ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if (isset($_GET['github']) && $_GET['github'] === 'success'): ?>
+                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+                            <span class="font-medium">Success!</span> GitHub account linked correctly.
+                        </div>
+                    <?php endif; ?>
+                    <?php if (isset($_GET['github']) && $_GET['github'] === 'error'): ?>
+                        <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+                            <span class="font-medium">Error!</span> <?= htmlspecialchars($_GET['message'] ?? 'GitHub authentication failed.') ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <div class="grid grid-cols-1 gap-4">
+                        <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm sm:p-6">
+                            <div class="space-y-6">
+                                <div class="p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                                    <h4 class="text-lg font-semibold text-blue-900 mb-2">Jules API Key (Private)</h4>
+                                    <p class="text-sm text-blue-700 mb-4">Your personal Google AI (Gemini) API key. This is required for agent features and is not shared with other users.</p>
+                                    <form method="POST" class="flex gap-2">
+                                        <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                        <input type="password" name="jules_api_key" value="<?= htmlspecialchars($user['jules_api_key'] ?? '') ?>" placeholder="AI Studio API Key" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                        <button type="submit" name="update_jules_key" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Save</button>
+                                    </form>
+                                </div>
+
+                                <div>
+                                    <h4 class="text-lg font-semibold text-gray-900">Linked GitHub Accounts</h4>
+                                    <div class="mt-2 space-y-2">
+                                        <?php if (empty($githubAccounts)): ?>
+                                            <p class="text-sm text-gray-500 italic">No GitHub accounts linked yet.</p>
+                                        <?php else: ?>
+                                            <?php foreach ($githubAccounts as $account): ?>
+                                                <div class="flex items-center text-green-600">
+                                                    <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+                                                    Linked as&nbsp;<strong><?= htmlspecialchars($account['github_username']) ?></strong>
+                                                </div>
+                                            <?php endforeach; ?>
+                                        <?php endif; ?>
+                                        <a href="github-login.php" class="mt-2 inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-gray-800 rounded-lg hover:bg-gray-900 focus:ring-4 focus:outline-none focus:ring-gray-300">
+                                            <svg class="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+                                            Link <?= empty($githubAccounts) ? 'GitHub Account' : 'Another GitHub Account' ?>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/frontend/templates.php
+++ b/src/frontend/templates.php
@@ -128,6 +128,7 @@ $templates = $templateModel->findByUserId($user['user_id']);
                     <div class="flex items-center ml-3">
                         <img class="w-8 h-8 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="user photo">
                         <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name']) ?></div>
+                        <a href="settings.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Settings</a>
                         <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
                     </div>
                 </div>


### PR DESCRIPTION
Relocated the Jules API Key configuration and Linked GitHub Accounts management from the main dashboard to a dedicated "Account Settings" page (`src/frontend/settings.php`). This clean up the main dashboard to focus on projects and tasks while providing a centralized location for account-level configurations. Navigation headers were updated globally to include a "Settings" link, and the GitHub OAuth flow now redirects users back to the settings page upon completion.

Fixes #164

---
*PR created automatically by Jules for task [2147088443461104783](https://jules.google.com/task/2147088443461104783) started by @chatelao*