### PR TITLE
Automatic Task Resync on Project Page Load

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -104,6 +104,19 @@ class Task
         ]);
     }
 
+    public function syncIssues(int $userId, int $projectId, string $repo, GitHubService $githubService): void
+    {
+        $issues = $githubService->listIssues($repo);
+
+        foreach ($issues as $issue) {
+            // Check if it's really an issue (not a PR)
+            if (isset($issue['pull_request'])) {
+                continue;
+            }
+            $this->upsert($userId, $projectId, $issue);
+        }
+    }
+
     public function upsert(int $userId, int $projectId, array $issue): bool
     {
         $connection = $this->db->getConnection();

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -36,6 +36,21 @@ if (!$project || $project['user_id'] !== $user['user_id']) {
     die("Project not found or access denied.");
 }
 
+// Automatic Sync on Page Load
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && !isset($_GET['success']) && !isset($_GET['error'])) {
+    $githubToken = $project['github_token'] ?? null;
+    if ($githubToken) {
+        try {
+            $githubService = new GitHubService(null, $githubToken);
+            $taskModel->syncIssues($user['user_id'], $project['project_id'], $project['github_repo'], $githubService);
+            header("Location: project.php?id=$projectId&success=synced");
+            exit;
+        } catch (Exception $e) {
+            // Silently fail automatic sync to not disrupt the user
+        }
+    }
+}
+
 $templateModel = new IssueTemplate($db);
 $templates = $templateModel->findByUserId($user['user_id']);
 
@@ -169,15 +184,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
         }
 
         $githubService = new GitHubService(null, $githubToken);
-        $issues = $githubService->listIssues($project['github_repo']);
-
-        foreach ($issues as $issue) {
-            // Check if it's really an issue (not a PR)
-            if (isset($issue['pull_request'])) {
-                continue;
-            }
-            $taskModel->upsert($user['user_id'], $project['project_id'], $issue);
-        }
+        $taskModel->syncIssues($user['user_id'], $project['project_id'], $project['github_repo'], $githubService);
 
         header("Location: project.php?id=$projectId&success=synced");
         exit;


### PR DESCRIPTION
This change implements automatic task synchronization from GitHub whenever a user opens a project's details page. 

Key changes:
1.  **Backend Refactoring**: Added a `syncIssues` method to the `App\Task` class to encapsulate the logic of fetching issues from GitHub (using `GitHubService`), filtering out pull requests, and upserting them into the database.
2.  **Frontend Update**: Modified `src/frontend/project.php` to trigger `syncIssues` on initial page load (GET request) if no status messages are already being displayed.
3.  **User Experience**: After an automatic sync, the user is redirected to the same page with a `success=synced` parameter, which displays a confirmation message and prevents redundant syncs on page refresh.
4.  **Consistency**: Updated the manual "Sync Issues" button to use the same refactored logic, ensuring consistent behavior across both automatic and manual triggers.

All existing tests passed, and the new logic was verified through code review and manual inspection of the logic flow.

Fixes #165

---
*PR created automatically by Jules for task [10550117864648807468](https://jules.google.com/task/10550117864648807468) started by @chatelao*