### PR TITLE
Automatically resync tasks in GitHub callback

### DIFF
--- a/src/frontend/github-callback.php
+++ b/src/frontend/github-callback.php
@@ -5,6 +5,9 @@ use App\GitHubAuth;
 use App\Database;
 use App\User;
 use App\RateLimiter;
+use App\Project;
+use App\Task;
+use App\GitHubService;
 
 $db = new Database();
 $rateLimiter = new RateLimiter($db);
@@ -27,7 +30,25 @@ $githubAuth = new GitHubAuth();
 if (isset($_GET['code']) && isset($_GET['state'])) {
     try {
         $githubData = $githubAuth->authenticate($_GET['code'], $_GET['state']);
-        $userModel->addGitHubAccount($auth->getUserId(), $githubData['access_token'], $githubData['github_username']);
+        $userId = $auth->getUserId();
+        $userModel->addGitHubAccount($userId, $githubData['access_token'], $githubData['github_username']);
+
+        // Sync tasks for all user projects matching this GitHub account
+        $projectModel = new Project($db);
+        $taskModel = new Task($db);
+        $projects = $projectModel->findByUserId($userId);
+
+        foreach ($projects as $project) {
+            if ($project['github_username'] === $githubData['github_username']) {
+                try {
+                    $githubService = new GitHubService(null, $githubData['access_token']);
+                    $taskModel->syncIssues($userId, $project['project_id'], $project['github_repo'], $githubService);
+                } catch (Exception $e) {
+                    // Ignore sync errors for individual projects
+                }
+            }
+        }
+
         header('Location: index.php?github=success');
         exit;
     } catch (Exception $e) {


### PR DESCRIPTION
This change enhances the GitHub OAuth callback flow by automatically synchronizing issues (tasks) for all of the user's projects that belong to the newly authenticated or updated GitHub account.

Key changes:
- Imported `App\Project`, `App\Task`, and `App\GitHubService` in `src/frontend/github-callback.php`.
- Added logic to fetch all user projects and filter them by the authenticated GitHub username.
- Iterates through matching projects and calls `$taskModel->syncIssues()` using the fresh access token.
- Wrapped individual project syncs in a `try-catch` block to ensure robustness.

Fixes #172

---
*PR created automatically by Jules for task [3323614024320636655](https://jules.google.com/task/3323614024320636655) started by @chatelao*