### PR TITLE
Switch to Real SFTP Deployment Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,34 +22,35 @@ jobs:
         run: composer install --no-dev --optimize-autoloader
 
       - name: Deploy via SFTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        uses: wlixcc/SFTP-Deploy-Action@v1.2.6
         with:
           server: ${{ secrets.SFTP_SERVER }}
           username: ${{ secrets.SFTP_USERNAME }}
           password: ${{ secrets.SFTP_PASSWORD }}
-          protocol: sftp
+          remote_path: ${{ secrets.SFTP_PATH }}
           port: 22
-          exclude: |
-            **/.git*
-            **/.git*/**
-            **/.github/**
-            **/test/**
-            **/docs/**
-            **/specification/**
-            **/scripts/**
-            **/Vagrantfile
-            **/CONCEPT.md
-            **/DESIGN.md
-            **/GEMINI.md
-            **/HOWTO.md
-            **/INSTALL.md
-            **/ROADMAP.md
-            **/CONCEPT_UPGRADES.md
-            **/openapi.yaml
-            **/schema.puml
-            **/*.sqlite
-            **/.readthedocs.yaml
-            **/composer.json
-            **/composer.lock
-            **/phpunit.xml
-            **/README.md
+          local_path: './'
+          sftp_only: false
+          rsyncArgs: >-
+            --exclude='.git*'
+            --exclude='.github/'
+            --exclude='test/'
+            --exclude='docs/'
+            --exclude='specification/'
+            --exclude='scripts/'
+            --exclude='Vagrantfile'
+            --exclude='CONCEPT.md'
+            --exclude='DESIGN.md'
+            --exclude='GEMINI.md'
+            --exclude='HOWTO.md'
+            --exclude='INSTALL.md'
+            --exclude='ROADMAP.md'
+            --exclude='CONCEPT_UPGRADES.md'
+            --exclude='openapi.yaml'
+            --exclude='schema.puml'
+            --exclude='*.sqlite'
+            --exclude='.readthedocs.yaml'
+            --exclude='composer.json'
+            --exclude='composer.lock'
+            --exclude='phpunit.xml'
+            --exclude='README.md'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -188,6 +188,7 @@ If you have your own fork of this repository, you can use the included GitHub Ac
    - `SFTP_SERVER`: Your SFTP server hostname or IP address.
    - `SFTP_USERNAME`: Your SFTP username.
    - `SFTP_PASSWORD`: Your SFTP password.
+   - `SFTP_PATH`: The target folder on the remote server.
 
 2. **Trigger Deployment:**
    - Go to the **Actions** tab in your GitHub repository.


### PR DESCRIPTION
The deployment workflow has been updated to use `wlixcc/SFTP-Deploy-Action`, which provides better support for SFTP and rsync-based exclusions. The `SFTP_PATH` secret is now utilized for the target directory, and `INSTALL.md` has been updated accordingly. Tests were run to ensure no regressions in core functionality.

Fixes #176

---
*PR created automatically by Jules for task [960194142278714305](https://jules.google.com/task/960194142278714305) started by @chatelao*