### PR TITLE
Fix SFTP deployment failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           local_path: './'
           sftp_only: true
           rsyncArgs: >-
-            --exclude=.git*
+            --exclude=.git\*
             --exclude=.github/
             --exclude=test/
             --exclude=docs/
@@ -48,7 +48,7 @@ jobs:
             --exclude=CONCEPT_UPGRADES.md
             --exclude=openapi.yaml
             --exclude=schema.puml
-            --exclude=*.sqlite
+            --exclude=\*.sqlite
             --exclude=.readthedocs.yaml
             --exclude=phpunit.xml
             --exclude=README.md


### PR DESCRIPTION
Fixed the SFTP deployment failure in `.github/workflows/deploy.yml` by escaping wildcard characters in the `rsyncArgs` parameter. This prevents premature shell expansion of patterns like `.git*` and `*.sqlite` within the `wlixcc/SFTP-Deploy-Action` entrypoint, ensuring they are correctly passed to `rsync` for filtering.

Fixes #184

---
*PR created automatically by Jules for task [15732871457387595617](https://jules.google.com/task/15732871457387595617) started by @chatelao*