### PR TITLE
Verify and Update SFTP Configuration Guidance

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,7 +120,10 @@ Use this method if you only have SFTP access and cannot run commands on the serv
    ```
 
 2. **Upload files:**
-   Using an SFTP client (like FileZilla or WinSCP), upload the following to your server:
+   Using an SFTP client (like FileZilla or WinSCP), upload the following to your server.
+
+   *Note for WinSCP users:* In the connection settings (Advanced > SSH > SFTP), ensure that **"Allow SCP fallback"** (SCP-Rückgriff erlauben) is **unchecked** to strictly adhere to the project's SFTP-only policy.
+
    - `src/`
    - `vendor/`
    - `composer.json`


### PR DESCRIPTION
I have verified the SFTP settings shown in the provided image. While most settings are correct, the **"Allow SCP fallback"** (SCP-Rückgriff erlauben) option is currently checked. To strictly follow the project's recommended SFTP-only configuration, I have:

1.  **Updated `INSTALL.md`**: Added a specific note advising WinSCP users to uncheck "Allow SCP fallback".
2.  **Verified System Integrity**: Ran the full test suite to ensure no regressions were introduced.

**Recommendation:** Please uncheck **"Allow SCP fallback"** in your WinSCP connection settings to ensure compatibility with the project's security and deployment standards.

Fixes #186

---
*PR created automatically by Jules for task [12949513601850572876](https://jules.google.com/task/12949513601850572876) started by @chatelao*