### PR TITLE
Show next unfinished task from roadmap

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -114,9 +114,23 @@ class GitHubService
                 if (is_array($contents)) {
                     foreach ($contents as $file) {
                         if ($file['type'] === 'file' && stripos($file['name'], 'ROADMAP') !== false) {
+                            $fullPath = ($path !== '.' ? $path . '/' : '') . $file['name'];
+
+                            $nextTask = null;
+                            try {
+                                $fileContentResponse = $this->client->api('repo')->contents()->show($username, $repository, $fullPath);
+                                if (isset($fileContentResponse['content'])) {
+                                    $decodedContent = base64_decode($fileContentResponse['content']);
+                                    $nextTask = $this->extractNextTask($decodedContent);
+                                }
+                            } catch (Exception $e) {
+                                // Ignore content fetching errors
+                            }
+
                             $roadmaps[] = [
-                                'name' => ($path !== '.' ? $path . '/' : '') . $file['name'],
-                                'html_url' => $file['html_url']
+                                'name' => $fullPath,
+                                'html_url' => $file['html_url'],
+                                'next_task' => $nextTask
                             ];
                         }
                     }
@@ -130,5 +144,18 @@ class GitHubService
         }
 
         return $roadmaps;
+    }
+
+    private function extractNextTask(string $content): ?string
+    {
+        $lines = explode("\n", $content);
+        foreach ($lines as $line) {
+            $line = trim($line);
+            // Match - [ ], * [ ] or + [ ]
+            if (preg_match('/^[-*+]\s*\[\s*\]\s*(.*)$/', $line, $matches)) {
+                return trim($matches[1]);
+            }
+        }
+        return null;
     }
 }

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -172,7 +172,7 @@ $errorMessage = $errorMessage ?? null;
                                                 </td>
                                                 <td class="px-6 py-4">
                                                     <span class="px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800">
-                                                        Active
+                                                        🚧 Active
                                                     </span>
                                                 </td>
                                             </tr>
@@ -215,13 +215,21 @@ $errorMessage = $errorMessage ?? null;
                                                     foreach ($tasks as $task):
                                                         $color = $taskModel->getStatusColor($task);
                                                         $isAutorepeat = $taskModel->hasAutorepeatLabel($task);
+                                                        $githubData = json_decode($task['github_data'] ?? '{}', true);
+                                                        $state = $githubData['state'] ?? 'open';
+
+                                                        $emoji = '⏳';
+                                                        if ($state === 'closed') $emoji = '✅';
+                                                        elseif ($task['status'] === 'failed') $emoji = '❌';
+                                                        elseif ($task['status'] === 'in_progress') $emoji = '🚧';
+                                                        elseif ($task['status'] === 'completed') $emoji = '✅';
                                                     ?>
                                                         <div class="relative group">
                                                             <a href="project.php?id=<?= $project['project_id'] ?>"
                                                                class="status-square <?= $color ?> <?= $isAutorepeat ? 'auto-repeat-tag' : '' ?>">
                                                             </a>
                                                             <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-[10px] rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
-                                                                #<?= htmlspecialchars($task['issue_number']) ?>: <?= htmlspecialchars(mb_substr($task['title'], 0, 30)) ?><?= mb_strlen($task['title']) > 30 ? '...' : '' ?>
+                                                                #<?= htmlspecialchars($task['issue_number']) ?>: <?= $emoji ?> <?= htmlspecialchars(mb_substr($task['title'], 0, 30)) ?><?= mb_strlen($task['title']) > 30 ? '...' : '' ?>
                                                             </div>
                                                         </div>
                                                     <?php endforeach; ?>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -302,7 +302,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                 </a>
                                                 <?php if (!empty($file['next_task'])): ?>
                                                     <span class="text-[10px] text-gray-500 ml-6 italic">
-                                                        Next: <?= htmlspecialchars($file['next_task']) ?>
+                                                        🚧 <?= htmlspecialchars($file['next_task']) ?>
                                                     </span>
                                                 <?php endif; ?>
                                             </li>
@@ -387,7 +387,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                     <div class="text-xs text-gray-500"><?= htmlspecialchars(mb_substr($task['body'] ?? '', 0, 100)) ?>...</div>
                                                 </td>
                                                 <td class="px-6 py-4">
-                                                    <span class="px-2 py-1 text-xs font-medium rounded-full <?= $task['status'] === 'completed' ? 'bg-green-100 text-green-800' : ($task['status'] === 'in_progress' ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-800') ?>">
+                                                    <span class="px-2 py-1 text-xs font-medium rounded-full <?= $task['status'] === 'completed' ? 'bg-green-100 text-green-800' : ($task['status'] === 'in_progress' ? 'bg-blue-100 text-blue-800' : ($task['status'] === 'failed' ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-800')) ?>">
+                                                        <?php
+                                                        if ($task['status'] === 'completed') echo '✅ ';
+                                                        elseif ($task['status'] === 'in_progress') echo '🚧 ';
+                                                        elseif ($task['status'] === 'failed') echo '❌ ';
+                                                        else echo '⏳ ';
+                                                        ?>
                                                         <?= htmlspecialchars($task['status']) ?>
                                                     </span>
                                                 </td>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -295,11 +295,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                 <?php else: ?>
                                     <ul class="space-y-2">
                                         <?php foreach ($roadmapFiles as $file): ?>
-                                            <li>
+                                            <li class="flex flex-col">
                                                 <a href="<?= htmlspecialchars($file['html_url']) ?>" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-600 hover:underline flex items-center">
                                                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
                                                     <?= htmlspecialchars($file['name']) ?>
                                                 </a>
+                                                <?php if (!empty($file['next_task'])): ?>
+                                                    <span class="text-[10px] text-gray-500 ml-6 italic">
+                                                        Next: <?= htmlspecialchars($file['next_task']) ?>
+                                                    </span>
+                                                <?php endif; ?>
                                             </li>
                                         <?php endforeach; ?>
                                     </ul>

--- a/test/Unit/Services/GitHubServiceTest.php
+++ b/test/Unit/Services/GitHubServiceTest.php
@@ -29,6 +29,12 @@ class GitHubServiceTest extends TestCase
                 ['chatelao', 'ai-brain', 'docs', null, [
                     ['type' => 'file', 'name' => 'roadmap.rst', 'html_url' => 'http://example.com/roadmap_rst'],
                     ['type' => 'file', 'name' => 'install.rst', 'html_url' => 'http://example.com/install']
+                ]],
+                ['chatelao', 'ai-brain', 'ROADMAP.md', null, [
+                    'content' => base64_encode("- [x] Done task\n- [ ] Next task\n- [ ] Another task")
+                ]],
+                ['chatelao', 'ai-brain', 'docs/roadmap.rst', null, [
+                    'content' => base64_encode("* [x] Already done\n* [ ] Still to do")
                 ]]
             ]);
 
@@ -37,6 +43,8 @@ class GitHubServiceTest extends TestCase
 
         $this->assertCount(2, $roadmaps);
         $this->assertEquals('ROADMAP.md', $roadmaps[0]['name']);
+        $this->assertEquals('Next task', $roadmaps[0]['next_task']);
         $this->assertEquals('docs/roadmap.rst', $roadmaps[1]['name']);
+        $this->assertEquals('Still to do', $roadmaps[1]['next_task']);
     }
 }


### PR DESCRIPTION
This change enhances the project overview by showing the next actionable item from any roadmap files found in the repository. It automatically parses Markdown task lists (`- [ ]`, `* [ ]`, `+ [ ]`) and displays the first unfinished task in small grey italic text below the roadmap filename.

Fixes #191

---
*PR created automatically by Jules for task [4349681017259925130](https://jules.google.com/task/4349681017259925130) started by @chatelao*