### PR TITLE
Add SQL Export Option for Issue Templates

### DIFF
--- a/src/backend/IssueTemplate.php
+++ b/src/backend/IssueTemplate.php
@@ -64,4 +64,31 @@ class IssueTemplate
         );
         return $stmt->execute([$name, $title, $body, $parameterConfig, $id, $userId]);
     }
+
+    public function exportToSql(int $userId): string
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "SELECT * FROM issue_templates WHERE user_id = ?"
+        );
+        $stmt->execute([$userId]);
+        $templates = $stmt->fetchAll();
+
+        if (empty($templates)) {
+            return "-- No templates found for user $userId\n";
+        }
+
+        $sql = "-- Issue Templates Export for User $userId\n";
+        $sql .= "-- Generated at: " . date('Y-m-d H:i:s') . "\n\n";
+
+        foreach ($templates as $t) {
+            $name = $this->db->getConnection()->quote($t['name']);
+            $title = $this->db->getConnection()->quote($t['title_template']);
+            $body = $t['body_template'] !== null ? $this->db->getConnection()->quote($t['body_template']) : 'NULL';
+            $paramConfig = $t['parameter_config'] !== null ? $this->db->getConnection()->quote($t['parameter_config']) : 'NULL';
+
+            $sql .= "INSERT INTO issue_templates (user_id, name, title_template, body_template, parameter_config) VALUES ($userId, $name, $title, $body, $paramConfig);\n";
+        }
+
+        return $sql;
+    }
 }

--- a/src/frontend/templates.php
+++ b/src/frontend/templates.php
@@ -23,6 +23,18 @@ $taskModel = new Task($db);
 $errorMessage = null;
 $successMessage = null;
 
+// Handle Export
+if (isset($_GET['export']) && $_GET['export'] === 'sql') {
+    if (!$auth->validateCsrfToken($_GET['csrf_token'] ?? null)) {
+        die("CSRF token validation failed.");
+    }
+    $sql = $templateModel->exportToSql($user['user_id']);
+    header('Content-Type: application/sql');
+    header('Content-Disposition: attachment; filename="issue_templates_export.sql"');
+    echo $sql;
+    exit;
+}
+
 // Handle Template Creation
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_template'])) {
     if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
@@ -161,9 +173,14 @@ $templates = $templateModel->findByUserId($user['user_id']);
                         </ol>
                     </nav>
 
-                    <div class="mb-4">
-                        <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">Issue Templates</h1>
-                        <p class="text-sm text-gray-500 mt-1">Create reusable templates for GitHub issues. Use <strong>%1</strong> and <strong>%2</strong> as placeholders for dynamic content.</p>
+                    <div class="mb-4 flex justify-between items-end">
+                        <div>
+                            <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">Issue Templates</h1>
+                            <p class="text-sm text-gray-500 mt-1">Create reusable templates for GitHub issues. Use <strong>%1</strong> and <strong>%2</strong> as placeholders for dynamic content.</p>
+                        </div>
+                        <div>
+                            <a href="?export=sql&csrf_token=<?= $auth->getCsrfToken() ?>" class="text-white bg-green-600 hover:bg-green-700 focus:ring-4 focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Export to SQL</a>
+                        </div>
                     </div>
 
                     <?php if ($errorMessage): ?>

--- a/test/Unit/Services/IssueTemplateTest.php
+++ b/test/Unit/Services/IssueTemplateTest.php
@@ -106,4 +106,20 @@ class IssueTemplateTest extends TestCase
         $template = $this->templateModel->findById($id);
         $this->assertEquals(['%1' => 'New Module'], $template['parameter_config']);
     }
+
+    public function testExportToSql()
+    {
+        $userId = 1;
+        $this->templateModel->create($userId, "O'Reilly Template", 'Bug: %1', 'Body with "quotes"');
+
+        $sql = $this->templateModel->exportToSql($userId);
+
+        $this->assertStringContainsString("-- Issue Templates Export for User $userId", $sql);
+        $this->assertStringContainsString("INSERT INTO issue_templates", $sql);
+        // SQLite quote for O'Reilly is O''Reilly, MySQL is 'O\'Reilly' or 'O''Reilly' depending on mode.
+        // PDO::quote for sqlite uses ''
+        $this->assertStringContainsString("'O''Reilly Template'", $sql);
+        $this->assertStringContainsString("'Bug: %1'", $sql);
+        $this->assertStringContainsString("'Body with \"quotes\"'", $sql);
+    }
 }


### PR DESCRIPTION
This PR adds a new feature that allows users to export their issue templates as an SQL script. 

### Changes:
- **Backend**: Added `exportToSql(int $userId)` method to the `App\IssueTemplate` class. It fetches all templates for a given user and generates a string of SQL `INSERT` statements. Values are properly escaped using `PDO::quote()`.
- **Frontend**: 
    - Added a handler in `src/frontend/templates.php` to process `?export=sql` requests. It validates the CSRF token before serving the SQL file.
    - Added an "Export to SQL" button in the templates management header.
- **Testing**: Added a unit test in `test/Unit/Services/IssueTemplateTest.php` to ensure the generated SQL is correct and safely handles special characters.

All 82 tests passed.

Fixes #192

---
*PR created automatically by Jules for task [1682107259243378059](https://jules.google.com/task/1682107259243378059) started by @chatelao*