### PR TITLE
Switch deployment strategy from SFTP to SSH (rsync)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Manual SFTP Deploy
+name: Manual SSH Deploy
 
 on:
   workflow_dispatch:
@@ -21,16 +21,16 @@ jobs:
       - name: Install dependencies
         run: composer install --no-dev --optimize-autoloader
 
-      - name: Deploy via SFTP
+      - name: Deploy via SSH
         uses: wlixcc/SFTP-Deploy-Action@v1.2.6
         with:
-          server: ${{ secrets.SFTP_SERVER }}
-          username: ${{ secrets.SFTP_USERNAME }}
-          password: ${{ secrets.SFTP_PASSWORD }}
-          remote_path: ${{ secrets.SFTP_PATH }}
+          server: ${{ secrets.SSH_SERVER }}
+          username: ${{ secrets.SSH_USERNAME }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          remote_path: ${{ secrets.SSH_PATH }}
           port: 22
           local_path: './'
-          sftp_only: true
+          sftp_only: false
           rsyncArgs: >-
             --exclude=.git\*
             --exclude=.github/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -109,27 +109,26 @@ This is the recommended method if you have terminal access to your server.
 
 ---
 
-## b) Installation with SFTP
+## b) Manual Deployment via SSH (rsync)
 
-Use this method if you only have SFTP access and cannot run commands on the server.
+Use this method if you want to deploy from your local machine via SSH.
 
 1. **Build locally:**
    On your local machine, clone the repository and run:
    ```bash
-   composer install --no-dev
+   composer install --no-dev --optimize-autoloader
    ```
 
 2. **Upload files:**
-   Using an SFTP client (like FileZilla or WinSCP), upload the following to your server.
+   Use `rsync` to upload the production files to your server:
+   ```bash
+   rsync -avz --exclude='.git*' --exclude='.github/' --exclude='test/' \
+     --exclude='docs/' --exclude='specification/' --exclude='scripts/' \
+     --exclude='Vagrantfile' --exclude='*.sqlite' \
+     ./ user@your-server:/var/www/ai-brain/
+   ```
 
-   *Note for WinSCP users:* In the connection settings (Advanced > SSH > SFTP), ensure that **"Allow SCP fallback"** (SCP-Rückgriff erlauben) is **unchecked** to strictly adhere to the project's SFTP-only policy.
-
-   - `src/`
-   - `vendor/`
-   - `composer.json`
-   - `composer.lock`
-
-   *Note: You can skip `test/`, `.github/`, `docs/`, and other non-production files.*
+   *Note: Ensure the destination path matches your server configuration.*
 
 3. **Set up the database:**
    - Use a tool like **phpMyAdmin** provided by your hosting.
@@ -187,20 +186,20 @@ Use this method if you only have SFTP access and cannot run commands on the serv
 
 ---
 
-## c) Automated Deployment with GitHub Actions (SFTP)
+## c) Automated Deployment with GitHub Actions (SSH)
 
-If you have your own fork of this repository, you can use the included GitHub Action to automate the SFTP deployment.
+If you have your own fork of this repository, you can use the included GitHub Action to automate the SSH deployment.
 
 1. **Configure Secrets:**
    In your GitHub repository, go to **Settings > Secrets and variables > Actions** and add the following repository secrets:
-   - `SFTP_SERVER`: Your SFTP server hostname or IP address.
-   - `SFTP_USERNAME`: Your SFTP username.
-   - `SFTP_PASSWORD`: Your SFTP password.
-   - `SFTP_PATH`: The target folder on the remote server.
+   - `SSH_SERVER`: Your SSH server hostname or IP address.
+   - `SSH_USERNAME`: Your SSH username.
+   - `SSH_PASSWORD`: Your SSH password.
+   - `SSH_PATH`: The target folder on the remote server.
 
 2. **Trigger Deployment:**
    - Go to the **Actions** tab in your GitHub repository.
-   - Select the **Manual SFTP Deploy** workflow in the sidebar.
+   - Select the **Manual SSH Deploy** workflow in the sidebar.
    - Click the **Run workflow** dropdown and then **Run workflow**.
 
    *Note: For security, this workflow is configured to only be runnable by the repository owner.*
@@ -209,9 +208,7 @@ If you have your own fork of this repository, you can use the included GitHub Ac
    The workflow will:
    - Checkout your code.
    - Install production dependencies via Composer.
-   - Upload the application to your server via SFTP, excluding development and documentation files.
-
-   *Note: The workflow uses `sftp_only: true` which is recommended for most SFTP-only hosting environments.*
+   - Upload the application to your server via SSH (rsync), excluding development and documentation files.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A PHP application to control agents from Google Jules, coordinated by GitHub rep
 - Composer
 
 ### Installation
-See the [Installation Guide](INSTALL.md) for detailed instructions on how to install AI Brain on a web server using SSH or SFTP.
+See the [Installation Guide](INSTALL.md) for detailed instructions on how to install AI Brain on a web server using SSH.
 
 For quick local installation:
 1. Clone the repository.


### PR DESCRIPTION
This change transitions the application's deployment strategy from SFTP to SSH (using rsync) to improve efficiency and align with modern deployment practices.

Key modifications:
1. **GitHub Workflow**: `.github/workflows/deploy.yml` has been updated to use `wlixcc/SFTP-Deploy-Action` with `sftp_only: false`, which triggers `rsync` over SSH. Secrets have been renamed from `SFTP_*` to `SSH_*` for clarity.
2. **Installation Guide**: `INSTALL.md` now provides `rsync` command examples for manual deployment instead of SFTP client instructions. The section on automated deployment has been updated to reflect the new workflow and secret names.
3. **Readme**: `README.md` was updated to remove references to SFTP in the installation section.
4. **Testing**: All existing tests were run and passed to ensure no regressions were introduced.

Fixes #201

---
*PR created automatically by Jules for task [3285477363340501180](https://jules.google.com/task/3285477363340501180) started by @chatelao*