### PR TITLE
Color status squares like chatelao/AI-Dashboard

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -166,15 +166,21 @@ class Task
             return 'purple';
         }
 
-        if ($task['status'] === 'failed') {
+        $status = $task['status'] ?? 'pending';
+
+        if ($status === 'failed') {
             return 'red';
         }
 
-        if ($task['status'] === 'in_progress') {
+        if (in_array($status, ['in_progress', 'coding', 'testing'])) {
             return 'yellow';
         }
 
-        if ($task['status'] === 'completed') {
+        if (in_array($status, ['researching', 'planning', 'awaiting-plan-approval', 'awaiting-user-feedback'])) {
+            return 'blue';
+        }
+
+        if ($status === 'completed') {
             return 'green';
         }
 

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -222,7 +222,7 @@ $errorMessage = $errorMessage ?? null;
                                                 </div>
                                                 <p class="text-sm text-gray-500 mt-1">Linked as&nbsp;<?= htmlspecialchars($project['github_username']) ?></p>
 
-                                                <div class="flex flex-wrap gap-1 mt-3">
+                                                <div class="flex flex-wrap gap-2 mt-3">
                                                     <?php
                                                     $tasks = $projectTasks[$project['project_id']] ?? [];
                                                     foreach ($tasks as $task):

--- a/src/sql/patches/005_change_task_status_to_varchar.sql
+++ b/src/sql/patches/005_change_task_status_to_varchar.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tasks MODIFY COLUMN status VARCHAR(50) DEFAULT 'pending';


### PR DESCRIPTION
Align the status square coloring logic and UI styling with the `chatelao/AI-Dashboard` project.

Changes:
- Modified `src/backend/Task.php` to map more granular task statuses to specific colors (blue for planning phases, yellow for active coding/testing).
- Added a SQL migration `src/sql/patches/005_change_task_status_to_varchar.sql` to ensure the database can store these longer status strings.
- Updated `src/frontend/index.php` to increase the gap between status squares to match the reference UI.
- Verified logic with existing unit tests and visual inspection via Playwright.

Fixes #193

---
*PR created automatically by Jules for task [14945152193943391696](https://jules.google.com/task/14945152193943391696) started by @chatelao*