### PR TITLE
Switch CI/CD to MariaDB and Validate Queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:latest
+        env:
+          MARIADB_DATABASE: test_db
+          MARIADB_USER: test_user
+          MARIADB_PASSWORD: test_pass
+          MARIADB_ROOT_PASSWORD: root_pass
+        ports:
+          - 3306:3306
+        options: --health-cmd="mariadb-admin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
     - uses: actions/checkout@v4
 
@@ -43,6 +54,11 @@ jobs:
       run: ./test/install.sh
 
     - name: Run PHPUnit tests
+      env:
+        TEST_DB_HOST: 127.0.0.1
+        TEST_DB_NAME: test_db
+        TEST_DB_USER: test_user
+        TEST_DB_PASS: test_pass
       run: composer test
 
     - name: Run UI tests with screenshots

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -221,10 +221,11 @@ class Task
              FROM tasks t
              JOIN projects p ON t.project_id = p.project_id
              WHERE t.user_id = ?
-             AND (t.last_synced_at IS NULL OR t.last_synced_at < datetime('now', '-5 minutes'))
+             AND (t.last_synced_at IS NULL OR t.last_synced_at < ?)
              AND (t.status NOT IN ('completed', 'failed') OR t.jules_status NOT IN ('completed', 'failed'))"
         );
-        $stmt->execute([$userId]);
+        $fiveMinutesAgo = date('Y-m-d H:i:s', strtotime('-5 minutes'));
+        $stmt->execute([$userId, $fiveMinutesAgo]);
         $tasks = $stmt->fetchAll();
 
         $userStmt = $this->db->getConnection()->prepare("SELECT jules_api_key FROM users WHERE user_id = ?");
@@ -296,16 +297,16 @@ class Task
                     }
 
                     $updateStmt = $this->db->getConnection()->prepare(
-                        "UPDATE tasks SET jules_status = ?, status = ?, last_synced_at = datetime('now') WHERE task_id = ?"
+                        "UPDATE tasks SET jules_status = ?, status = ?, last_synced_at = ? WHERE task_id = ?"
                     );
-                    $updateStmt->execute([$newStatus, $mappedStatus, $task['task_id']]);
+                    $updateStmt->execute([$newStatus, $mappedStatus, date('Y-m-d H:i:s'), $task['task_id']]);
                 }
             } else {
                 // Still update last_synced_at even if no sessionId or apiKey to avoid constant retries
                 $updateStmt = $this->db->getConnection()->prepare(
-                    "UPDATE tasks SET last_synced_at = datetime('now') WHERE task_id = ?"
+                    "UPDATE tasks SET last_synced_at = ? WHERE task_id = ?"
                 );
-                $updateStmt->execute([$task['task_id']]);
+                $updateStmt->execute([date('Y-m-d H:i:s'), $task['task_id']]);
             }
         }
     }

--- a/test/E2E/FullFlowTest.php
+++ b/test/E2E/FullFlowTest.php
@@ -7,9 +7,12 @@ use GuzzleHttp\Client;
 use App\Database;
 use App\User;
 use PDO;
+use Tests\TestDatabaseTrait;
 
 class FullFlowTest extends TestCase
 {
+    use TestDatabaseTrait;
+
     private $pdo;
     private $db;
     private $serverProcess;
@@ -26,15 +29,21 @@ class FullFlowTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->pdo = new PDO('sqlite:test_e2e.sqlite');
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
         $this->pdo->exec("DROP TABLE IF EXISTS users");
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
+
         $this->pdo->exec("CREATE TABLE users (
-            user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id $pk,
             google_id VARCHAR(255) UNIQUE NOT NULL,
             name VARCHAR(255) NOT NULL,
             email VARCHAR(255) UNIQUE NOT NULL,
             avatar VARCHAR(255), role VARCHAR(20) DEFAULT 'user',
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            created_at $timestamp
         )");
 
         // We can use environmental variables to point the app to this test DB if we were running it
@@ -42,8 +51,10 @@ class FullFlowTest extends TestCase
 
     protected function tearDown(): void
     {
-        if (file_exists('test_e2e.sqlite')) {
-            unlink('test_e2e.sqlite');
+        if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            if (file_exists('test_e2e.sqlite')) {
+                unlink('test_e2e.sqlite');
+            }
         }
     }
 

--- a/test/Integration/DashboardDBIntegrationTest.php
+++ b/test/Integration/DashboardDBIntegrationTest.php
@@ -7,22 +7,32 @@ use App\Auth;
 use App\User;
 use App\Database;
 use PDO;
+use Tests\TestDatabaseTrait;
 
 class DashboardDBIntegrationTest extends TestCase
 {
+    use TestDatabaseTrait;
+
     private $pdo;
     private $db;
 
     protected function setUp(): void
     {
-        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $this->pdo->exec("DROP TABLE IF EXISTS users");
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
+
         $this->pdo->exec("CREATE TABLE users (
-            user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id $pk,
             google_id VARCHAR(255) UNIQUE NOT NULL,
             name VARCHAR(255) NOT NULL,
             email VARCHAR(255) UNIQUE NOT NULL,
             avatar VARCHAR(255), role VARCHAR(20) DEFAULT 'user',
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            created_at $timestamp
         )");
 
         $this->db = $this->createMock(Database::class);

--- a/test/Integration/ProjectDBIntegrationTest.php
+++ b/test/Integration/ProjectDBIntegrationTest.php
@@ -7,9 +7,12 @@ use App\Database;
 use App\Project;
 use App\User;
 use PDO;
+use Tests\TestDatabaseTrait;
 
 class ProjectDBIntegrationTest extends TestCase
 {
+    use TestDatabaseTrait;
+
     private $db;
     private $pdo;
     private $projectModel;
@@ -17,35 +20,42 @@ class ProjectDBIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $this->pdo->exec("DROP TABLE IF EXISTS projects");
+        $this->pdo->exec("DROP TABLE IF EXISTS user_github_accounts");
+        $this->pdo->exec("DROP TABLE IF EXISTS users");
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
 
         $this->pdo->exec("CREATE TABLE users (
-            user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id $pk,
             google_id VARCHAR(255) UNIQUE NOT NULL,
             name VARCHAR(255) NOT NULL,
             email VARCHAR(255) UNIQUE NOT NULL,
             avatar VARCHAR(255), role VARCHAR(20) DEFAULT 'user',
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            created_at $timestamp
         )");
 
         $this->pdo->exec("CREATE TABLE user_github_accounts (
-            github_account_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            github_account_id $pk,
             user_id INT NOT NULL,
             github_username VARCHAR(255) NOT NULL,
             github_token VARCHAR(255) NOT NULL,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            created_at $timestamp,
             FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
             UNIQUE(user_id, github_username)
         )");
 
         $this->pdo->exec("CREATE TABLE projects (
-            project_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id $pk,
             user_id INT NOT NULL,
             github_account_id INT NOT NULL,
             github_repo VARCHAR(255) NOT NULL,
             webhook_secret VARCHAR(255),
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            created_at $timestamp,
             FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
             FOREIGN KEY (github_account_id) REFERENCES user_github_accounts(github_account_id) ON DELETE CASCADE
         )");

--- a/test/Integration/TaskDBIntegrationTest.php
+++ b/test/Integration/TaskDBIntegrationTest.php
@@ -6,20 +6,28 @@ use PHPUnit\Framework\TestCase;
 use App\Database;
 use App\Task;
 use PDO;
+use Tests\TestDatabaseTrait;
 
 class TaskDBIntegrationTest extends TestCase
 {
+    use TestDatabaseTrait;
+
     private $db;
     private $pdo;
     private $taskModel;
 
     protected function setUp(): void
     {
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $this->pdo->exec("DROP TABLE IF EXISTS tasks");
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
 
         $this->pdo->exec("CREATE TABLE tasks (
-            task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id $pk,
             user_id INT NOT NULL,
             project_id INT NOT NULL,
             issue_number INT NOT NULL,
@@ -27,8 +35,8 @@ class TaskDBIntegrationTest extends TestCase
             body TEXT,
             status TEXT DEFAULT 'pending',
             github_data TEXT,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            created_at $timestamp,
+            updated_at $timestamp,
             UNIQUE(project_id, issue_number)
         )");
 

--- a/test/Integration/UserDBIntegrationTest.php
+++ b/test/Integration/UserDBIntegrationTest.php
@@ -6,33 +6,42 @@ use PHPUnit\Framework\TestCase;
 use App\Database;
 use App\User;
 use PDO;
+use Tests\TestDatabaseTrait;
 
 class UserDBIntegrationTest extends TestCase
 {
+    use TestDatabaseTrait;
+
     private $db;
     private $pdo;
     private $userModel;
 
     protected function setUp(): void
     {
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $this->pdo->exec("DROP TABLE IF EXISTS user_github_accounts");
+        $this->pdo->exec("DROP TABLE IF EXISTS users");
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
 
         $this->pdo->exec("CREATE TABLE users (
-            user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id $pk,
             google_id VARCHAR(255) UNIQUE NOT NULL,
             name VARCHAR(255) NOT NULL,
             email VARCHAR(255) UNIQUE NOT NULL,
             avatar VARCHAR(255), role VARCHAR(20) DEFAULT 'user',
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            created_at $timestamp
         )");
 
         $this->pdo->exec("CREATE TABLE user_github_accounts (
-            github_account_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            github_account_id $pk,
             user_id INT NOT NULL,
             github_username VARCHAR(255) NOT NULL,
             github_token VARCHAR(255) NOT NULL,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            created_at $timestamp,
             FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
             UNIQUE(user_id, github_username)
         )");

--- a/test/TestDatabaseTrait.php
+++ b/test/TestDatabaseTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests;
+
+use PDO;
+use App\Database;
+
+trait TestDatabaseTrait
+{
+    protected function getTestPdo(): PDO
+    {
+        $host = getenv('TEST_DB_HOST');
+        $dbName = getenv('TEST_DB_NAME');
+        $user = getenv('TEST_DB_USER');
+        $pass = getenv('TEST_DB_PASS');
+
+        if ($host && $dbName) {
+            $dsn = "mysql:host=$host;dbname=$dbName;charset=utf8mb4";
+            $pdo = new PDO($dsn, $user, $pass, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ]);
+            $pdo->exec("SET FOREIGN_KEY_CHECKS = 0");
+            return $pdo;
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        return $pdo;
+    }
+
+    protected function createTestDatabase(): Database
+    {
+        $host = getenv('TEST_DB_HOST');
+        $dbName = getenv('TEST_DB_NAME');
+        $user = getenv('TEST_DB_USER');
+        $pass = getenv('TEST_DB_PASS');
+
+        $db = new Database($host, $dbName, $user, $pass);
+        Database::resetConnection();
+        return $db;
+    }
+}

--- a/test/Unit/DB/SchemaTest.php
+++ b/test/Unit/DB/SchemaTest.php
@@ -4,38 +4,45 @@ namespace Tests\Unit\DB;
 
 use PHPUnit\Framework\TestCase;
 use PDO;
+use Tests\TestDatabaseTrait;
 
 class SchemaTest extends TestCase
 {
+    use TestDatabaseTrait;
+
     private $pdo;
 
     protected function setUp(): void
     {
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $this->pdo->exec("DROP TABLE IF EXISTS issue_templates");
+        $this->pdo->exec("DROP TABLE IF EXISTS user_telegram_accounts");
+        $this->pdo->exec("DROP TABLE IF EXISTS rate_limits");
+        $this->pdo->exec("DROP TABLE IF EXISTS task_logs");
+        $this->pdo->exec("DROP TABLE IF EXISTS tasks");
+        $this->pdo->exec("DROP TABLE IF EXISTS projects");
+        $this->pdo->exec("DROP TABLE IF EXISTS user_github_accounts");
+        $this->pdo->exec("DROP TABLE IF EXISTS users");
+        $this->pdo->exec("DROP TABLE IF EXISTS migrations");
 
         $schema = file_get_contents(__DIR__ . '/../../../src/sql/schema.sql');
-
-        // SQLite doesn't support some MySQL syntax like AUTO_INCREMENT (use AUTOINCREMENT)
-        // and ENGINE=InnoDB. We'll do some basic transformations for testing schema in SQLite
-        // or just verify it works if we avoid MySQL specificities in the SQL if possible.
-        // Actually, for a pure "Unit DB test" verifying the schema definition,
-        // we should ideally test against MySQL if that's the target.
-        // But since we only have SQLite, we'll verify it can at least be parsed or
-        // we verify the intent of the schema.
 
         $queries = explode(';', $schema);
         foreach ($queries as $query) {
             $query = trim($query);
             if (empty($query)) continue;
 
-            // Minimal transformation for SQLite compatibility in tests
-            $query = str_ireplace('AUTO_INCREMENT', '', $query);
-            $query = preg_replace('/ENGINE=InnoDB.*/i', '', $query);
-            $query = str_ireplace('TIMESTAMP DEFAULT CURRENT_TIMESTAMP', 'DATETIME DEFAULT CURRENT_TIMESTAMP', $query);
-            $query = preg_replace('/ENUM\([^)]+\)/i', 'TEXT', $query);
-            $query = str_ireplace('ON UPDATE CURRENT_TIMESTAMP', '', $query);
-            $query = preg_replace('/UNIQUE KEY \w+ \(/i', 'UNIQUE(', $query);
+            if ($driver === 'sqlite') {
+                // Minimal transformation for SQLite compatibility in tests
+                $query = str_ireplace('AUTO_INCREMENT', '', $query);
+                $query = preg_replace('/ENGINE=InnoDB.*/i', '', $query);
+                $query = str_ireplace('TIMESTAMP DEFAULT CURRENT_TIMESTAMP', 'DATETIME DEFAULT CURRENT_TIMESTAMP', $query);
+                $query = preg_replace('/ENUM\([^)]+\)/i', 'TEXT', $query);
+                $query = str_ireplace('ON UPDATE CURRENT_TIMESTAMP', '', $query);
+                $query = preg_replace('/UNIQUE KEY \w+ \(/i', 'UNIQUE(', $query);
+            }
 
             $this->pdo->exec($query);
         }
@@ -43,10 +50,15 @@ class SchemaTest extends TestCase
 
     public function testUsersTableHasCorrectColumns()
     {
-        $stmt = $this->pdo->query("PRAGMA table_info(users)");
-        $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-        $columnNames = array_column($columns, 'name');
+        if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql') {
+            $stmt = $this->pdo->query("DESCRIBE users");
+            $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $columnNames = array_column($columns, 'Field');
+        } else {
+            $stmt = $this->pdo->query("PRAGMA table_info(users)");
+            $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $columnNames = array_column($columns, 'name');
+        }
         $this->assertContains('user_id', $columnNames);
         $this->assertContains('google_id', $columnNames);
         $this->assertContains('name', $columnNames);
@@ -57,10 +69,15 @@ class SchemaTest extends TestCase
 
     public function testProjectsTableHasCorrectColumns()
     {
-        $stmt = $this->pdo->query("PRAGMA table_info(projects)");
-        $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-        $columnNames = array_column($columns, 'name');
+        if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql') {
+            $stmt = $this->pdo->query("DESCRIBE projects");
+            $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $columnNames = array_column($columns, 'Field');
+        } else {
+            $stmt = $this->pdo->query("PRAGMA table_info(projects)");
+            $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $columnNames = array_column($columns, 'name');
+        }
         $this->assertContains('project_id', $columnNames);
         $this->assertContains('user_id', $columnNames);
         $this->assertContains('github_repo', $columnNames);
@@ -70,10 +87,15 @@ class SchemaTest extends TestCase
 
     public function testTasksTableHasCorrectColumns()
     {
-        $stmt = $this->pdo->query("PRAGMA table_info(tasks)");
-        $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-        $columnNames = array_column($columns, 'name');
+        if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql') {
+            $stmt = $this->pdo->query("DESCRIBE tasks");
+            $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $columnNames = array_column($columns, 'Field');
+        } else {
+            $stmt = $this->pdo->query("PRAGMA table_info(tasks)");
+            $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $columnNames = array_column($columns, 'name');
+        }
         $this->assertContains('task_id', $columnNames);
         $this->assertContains('project_id', $columnNames);
         $this->assertContains('issue_number', $columnNames);


### PR DESCRIPTION
This change transitions the project's CI/CD pipeline from SQLite to MariaDB to better align with the production environment. It ensures that all database queries are validated against MariaDB while maintaining backward compatibility with SQLite for local development.

Key changes include:
- CI/CD workflow updates to include a MariaDB service.
- Refactoring of the test suite to support dynamic database drivers via environment variables.
- Logic updates in the backend to eliminate SQLite-specific function calls in favor of PHP-calculated values and driver-aware conditional blocks.
- Enhanced schema validation tests that execute against the active database engine.

Fixes #204

---
*PR created automatically by Jules for task [3471455522626963965](https://jules.google.com/task/3471455522626963965) started by @chatelao*