### PR TITLE
Discreet Sync Status Dot in Navbar

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -135,17 +135,6 @@ $errorMessage = $errorMessage ?? null;
         <div id="main-content" class="relative w-full h-full overflow-y-auto bg-gray-50">
             <main>
                 <div class="px-4 pt-6">
-                    <?php if (isset($_GET['github']) && $_GET['github'] === 'success'): ?>
-                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
-                            <span class="font-medium">Success!</span> GitHub account linked correctly.
-                        </div>
-                    <?php endif; ?>
-                    <?php if (isset($_GET['github']) && $_GET['github'] === 'error'): ?>
-                        <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
-                            <span class="font-medium">Error!</span> <?= htmlspecialchars($_GET['message'] ?? 'GitHub authentication failed.') ?>
-                        </div>
-                    <?php endif; ?>
-
                     <?php if ($errorMessage): ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
                             <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>

--- a/src/frontend/navbar-icons.php
+++ b/src/frontend/navbar-icons.php
@@ -26,9 +26,29 @@ if ($user) {
     $completedTasks = 0;
     $telegramConnected = false;
 }
+
+$syncStatus = null;
+$syncMessage = '';
+
+if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['github']) && $_GET['github'] === 'success')) {
+    $syncStatus = 'success';
+    $syncMessage = (isset($_GET['success']) && $_GET['success'] === 'synced') ? 'Issues synced from GitHub' : 'GitHub account linked correctly';
+} elseif (isset($_GET['github']) && $_GET['github'] === 'error') {
+    $syncStatus = 'error';
+    $syncMessage = 'GitHub error: ' . ($_GET['message'] ?? 'Authentication failed');
+} elseif (isset($_GET['error'])) {
+    $syncStatus = 'error';
+    $syncMessage = $_GET['error'];
+}
 ?>
 
 <div class="flex items-center space-x-4 mr-4">
+    <?php if ($syncStatus): ?>
+        <div class="flex items-center">
+            <div class="w-3 h-3 rounded-full <?= $syncStatus === 'success' ? 'bg-green-500' : 'bg-red-500' ?>" title="<?= htmlspecialchars($syncMessage) ?>"></div>
+        </div>
+    <?php endif; ?>
+
     <!-- GitHub Status -->
     <div class="flex items-center <?= $totalTasks > 0 ? 'text-black' : 'text-gray-300' ?>" title="GitHub Issues: Open / Total">
         <svg class="w-5 h-5 mr-1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -218,7 +218,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
         header("Location: project.php?id=$projectId&success=synced");
         exit;
     } catch (Exception $e) {
-        $errorMessage = "Error syncing issues: " . $e->getMessage();
+        header("Location: project.php?id=$projectId&error=" . urlencode("Error syncing issues: " . $e->getMessage()));
+        exit;
     }
 }
 
@@ -313,11 +314,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                         </div>
                     <?php endif; ?>
 
-                    <?php if (isset($_GET['success']) && $_GET['success'] === 'synced'): ?>
-                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
-                            <span class="font-medium">Success!</span> Issues synced from GitHub.
-                        </div>
-                    <?php endif; ?>
 
                     <?php if ($lastAgentResponse): ?>
                         <div class="p-4 mb-4 text-sm text-blue-800 rounded-lg bg-blue-50" role="alert">

--- a/src/frontend/settings.php
+++ b/src/frontend/settings.php
@@ -5,10 +5,12 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 use App\Database;
 use App\Auth;
 use App\User;
+use App\Task;
 
 $auth = new Auth();
 $db = new Database();
 $userModel = new User($db);
+$taskModel = new Task($db);
 
 if (!$auth->isLoggedIn()) {
     header('Location: login.php');
@@ -70,6 +72,9 @@ $errorMessage = $errorMessage ?? null;
                     </a>
                 </div>
                 <div class="flex items-center">
+                    <?php if ($user): ?>
+                        <?php include 'navbar-icons.php'; ?>
+                    <?php endif; ?>
                     <div class="flex items-center ml-3">
                         <img class="w-8 h-8 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="user photo">
                         <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name']) ?></div>
@@ -107,11 +112,6 @@ $errorMessage = $errorMessage ?? null;
                         <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">Account Settings</h1>
                     </div>
 
-                    <?php if (isset($_GET['github']) && $_GET['github'] === 'success'): ?>
-                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
-                            <span class="font-medium">Success!</span> GitHub account linked correctly.
-                        </div>
-                    <?php endif; ?>
                     <?php if (isset($_GET['success']) && $_GET['success'] === 'key_updated'): ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Jules API Key updated successfully.
@@ -120,11 +120,6 @@ $errorMessage = $errorMessage ?? null;
                     <?php if (isset($_GET['success']) && $_GET['success'] === 'telegram_updated'): ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Telegram configuration updated successfully.
-                        </div>
-                    <?php endif; ?>
-                    <?php if (isset($_GET['github']) && $_GET['github'] === 'error'): ?>
-                        <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
-                            <span class="font-medium">Error!</span> <?= htmlspecialchars($_GET['message'] ?? 'GitHub authentication failed.') ?>
                         </div>
                     <?php endif; ?>
 


### PR DESCRIPTION
The GitHub synchronization and linking status messages have been moved from large alert banners to a discreet colored dot in the top navigation bar. 

- **Discreet UI:** A small green or red dot now appears in the top bar after a sync action or GitHub account link.
- **On-mouseover details:** Hovering over the dot reveals the detailed status message (e.g., "Issues synced from GitHub" or error details).
- **Consistent Navigation:** The navigation bar icons and status indicator are now consistently displayed on the Account Settings page as well.
- **Cleaned up pages:** Removed the redundant full-width alert banners that previously pushed page content down.

Fixes #210

---
*PR created automatically by Jules for task [2671533340654591647](https://jules.google.com/task/2671533340654591647) started by @chatelao*