### PR TITLE
Add Automated DB Patch Workflow and Service Enhancements

### DIFF
--- a/.github/workflows/apply-patch.yml
+++ b/.github/workflows/apply-patch.yml
@@ -1,0 +1,66 @@
+name: Apply DB Patch
+
+on:
+  workflow_dispatch:
+    inputs:
+      patch:
+        description: 'Select patch to apply'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - 001_add_parameter_config_to_issue_templates.sql
+          - 002_rename_id_columns.sql
+          - 003_add_user_id_to_tasks_and_logs.sql
+          - 004_add_telegram_bot_config_to_users.sql
+          - 005_add_jules_session_columns_to_tasks.sql
+          - 005_change_task_status_to_varchar.sql
+      web_url:
+        description: 'Base URL of the application'
+        required: true
+        default: ''
+
+jobs:
+  apply-patch:
+    name: Apply DB Patch
+    runs-on: ubuntu-latest
+    if: github.actor == github.repository_owner
+    steps:
+      - name: Install SSHPass
+        run: sudo apt-get update && sudo apt-get install -y sshpass
+
+      - name: Extract DB_UPGRADE_SECRET and Trigger Upgrade
+        run: |
+          # 1. Extract secret via SSH
+          SECRET=$(sshpass -p "${{ secrets.SFTP_PASSWORD }}" ssh -o StrictHostKeyChecking=no ${{ secrets.SFTP_USERNAME }}@${{ secrets.SFTP_SERVER }} "grep 'SetEnv DB_UPGRADE_SECRET' ${{ secrets.SFTP_PATH }}/.htaccess | awk '{print \$3}'")
+
+          if [ -z "$SECRET" ]; then
+            echo "Error: DB_UPGRADE_SECRET not found in .htaccess"
+            exit 1
+          fi
+
+          # 2. Determine Web URL
+          WEB_URL="${{ github.event.inputs.web_url }}"
+          if [ -z "$WEB_URL" ]; then
+            WEB_URL="https://${{ secrets.SFTP_SERVER }}"
+          fi
+
+          echo "Triggering upgrade at $WEB_URL/upgrade.php"
+
+          # 3. Trigger Upgrade via Curl
+          RESPONSE=$(curl -s -X POST \
+            -F "secret=$SECRET" \
+            -F "patch=${{ github.event.inputs.patch }}" \
+            -F "run_migrations=1" \
+            "$WEB_URL/upgrade.php")
+
+          echo "Response from server:"
+          echo "$RESPONSE"
+
+          if echo "$RESPONSE" | grep -q "ERROR"; then
+            echo "Migration failed!"
+            exit 1
+          fi
+
+          echo "Migration triggered successfully."

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -179,6 +179,7 @@ Use this method if you want to deploy from your local machine via SSH.
    #
    SetEnv UPGRADE_ALLOWED_EMAIL   your_admin_email@example.com
    # SetEnv ENABLE_UPGRADE_PAGE     true
+   # SetEnv DB_UPGRADE_SECRET       your_secure_upgrade_secret
    ```
 
 5. **Document Root:**
@@ -233,3 +234,20 @@ The application requires several environment variables to be set in your web ser
 | `TELEGRAM_WEBHOOK_SECRET` | (Optional) Secret token for Telegram webhooks |
 | `UPGRADE_ALLOWED_EMAIL` | (Required for upgrades) Email address of the admin user authorized to trigger database migrations on the Admin Dashboard. |
 | `ENABLE_UPGRADE_PAGE` | (Optional) Set to `true` to enable the interactive database upgrade page at `/upgrade.php`. Useful for initial setup or maintenance. **Disable after use for security.** |
+| `DB_UPGRADE_SECRET` | (Optional) A secret token that allows automated database upgrades via the "Apply DB Patch" workflow. Should be set in `.htaccess` or server configuration. |
+
+---
+
+## Automated Database Upgrades
+
+If you have configured `DB_UPGRADE_SECRET` in your `.htaccess` file, you can use the **Apply DB Patch** workflow to apply pending SQL patches automatically.
+
+1. **Trigger the Workflow:**
+   - Go to the **Actions** tab in your GitHub repository.
+   - Select the **Apply DB Patch** workflow.
+   - Click **Run workflow**.
+2. **Parameters:**
+   - **Select patch to apply**: Choose 'all' to run all pending migrations, or select a specific `.sql` file.
+   - **Base URL of the application**: Enter the public URL of your application (e.g., `https://your-domain.com`).
+3. **Execution:**
+   - The workflow will SSH into your server, extract the `DB_UPGRADE_SECRET` from your `.htaccess`, and then send an authorized POST request to `/upgrade.php` to trigger the migration.

--- a/src/backend/MigrationService.php
+++ b/src/backend/MigrationService.php
@@ -67,30 +67,13 @@ class MigrationService
                 continue;
             }
 
-            $logs[] = "Applying patch: $patchName";
-            try {
-                $sql = file_get_contents($patchPath);
-                if ($sql === false) {
-                    throw new Exception("Could not read patch file: $patchName");
+            $logs = array_merge($logs, $this->applySinglePatch($connection, $patchPath));
+
+            // Check for error in logs
+            foreach ($logs as $log) {
+                if (str_starts_with($log, "ERROR")) {
+                    return $logs;
                 }
-
-                $connection->beginTransaction();
-
-                // Execute the SQL. Some drivers might not support multi-statement execute
-                // so we might need to split it if it becomes an issue.
-                $connection->exec($sql);
-
-                $stmt = $connection->prepare("INSERT INTO migrations (patch_name) VALUES (?)");
-                $stmt->execute([$patchName]);
-
-                $connection->commit();
-                $logs[] = "Successfully applied patch: $patchName";
-            } catch (Exception $e) {
-                if ($connection->inTransaction()) {
-                    $connection->rollBack();
-                }
-                $logs[] = "ERROR applying patch $patchName: " . $e->getMessage();
-                return $logs; // Stop execution on error
             }
         }
 
@@ -98,6 +81,66 @@ class MigrationService
             $logs[] = "Database is already up to date.";
         }
 
+        return $logs;
+    }
+
+    public function applyPatch(string $patchName): array
+    {
+        $logs = [];
+        $connection = $this->db->getConnection();
+        $this->ensureMigrationsTableExists($connection);
+
+        // Security check: prevent path traversal
+        if (str_contains($patchName, '/') || str_contains($patchName, '\\') || !str_ends_with($patchName, '.sql')) {
+            $logs[] = "ERROR: Invalid patch name: $patchName";
+            return $logs;
+        }
+
+        $patchPath = $this->patchesDir . $patchName;
+        if (!file_exists($patchPath)) {
+            $logs[] = "ERROR: Patch file not found: $patchName";
+            return $logs;
+        }
+
+        // Check if already applied
+        $stmt = $connection->prepare("SELECT COUNT(*) FROM migrations WHERE patch_name = ?");
+        $stmt->execute([$patchName]);
+        if ($stmt->fetchColumn() > 0) {
+            $logs[] = "Patch $patchName is already applied.";
+            return $logs;
+        }
+
+        return $this->applySinglePatch($connection, $patchPath);
+    }
+
+    private function applySinglePatch(PDO $connection, string $patchPath): array
+    {
+        $logs = [];
+        $patchName = basename($patchPath);
+        $logs[] = "Applying patch: $patchName";
+        try {
+            $sql = file_get_contents($patchPath);
+            if ($sql === false) {
+                throw new Exception("Could not read patch file: $patchName");
+            }
+
+            $connection->beginTransaction();
+
+            // Execute the SQL. Some drivers might not support multi-statement execute
+            // so we might need to split it if it becomes an issue.
+            $connection->exec($sql);
+
+            $stmt = $connection->prepare("INSERT INTO migrations (patch_name) VALUES (?)");
+            $stmt->execute([$patchName]);
+
+            $connection->commit();
+            $logs[] = "Successfully applied patch: $patchName";
+        } catch (Exception $e) {
+            if ($connection->inTransaction()) {
+                $connection->rollBack();
+            }
+            $logs[] = "ERROR applying patch $patchName: " . $e->getMessage();
+        }
         return $logs;
     }
 

--- a/src/frontend/admin/upgrade.php
+++ b/src/frontend/admin/upgrade.php
@@ -12,32 +12,53 @@ $auth = new Auth();
 $db = new Database();
 $userModel = new User($db);
 
-if (!$auth->isLoggedIn()) {
-    header('Location: ../login.php');
-    exit;
+// Check for secret bypass
+$providedSecret = $_REQUEST['secret'] ?? null;
+$configuredSecret = getenv('DB_UPGRADE_SECRET');
+$isSecretValid = !empty($configuredSecret) && $providedSecret === $configuredSecret;
+
+if (!$isSecretValid) {
+    if (!$auth->isLoggedIn()) {
+        header('Location: ../login.php');
+        exit;
+    }
+
+    if (!$auth->isAdmin()) {
+        die("Access denied. Admin privileges required.");
+    }
+
+    $currentUser = $userModel->findById($auth->getUserId());
+    $user = $currentUser;
+    $taskModel = new Task($db);
+    $allowedUpgradeEmail = getenv('UPGRADE_ALLOWED_EMAIL');
+
+    // Security check: only a specifically allowed admin can trigger upgrades
+    if (empty($allowedUpgradeEmail) || $currentUser['email'] !== $allowedUpgradeEmail) {
+        die("Access denied. You are not authorized to trigger system upgrades. Please check UPGRADE_ALLOWED_EMAIL configuration.");
+    }
+} else {
+    // For secret valid case, we still might need $currentUser for the template
+    // but the template might fail if we don't have it.
+    // However, if it's an automated call, the HTML output might not be strictly necessary
+    // but we should try to make it work.
+    $currentUser = ['name' => 'System (Secret Auth)', 'email' => 'system', 'avatar' => ''];
 }
 
-if (!$auth->isAdmin()) {
-    die("Access denied. Admin privileges required.");
-}
-
-$currentUser = $userModel->findById($auth->getUserId());
-$user = $currentUser;
-$taskModel = new Task($db);
-$allowedUpgradeEmail = getenv('UPGRADE_ALLOWED_EMAIL');
-
-// Security check: only a specifically allowed admin can trigger upgrades
-if (empty($allowedUpgradeEmail) || $currentUser['email'] !== $allowedUpgradeEmail) {
-    die("Access denied. You are not authorized to trigger system upgrades. Please check UPGRADE_ALLOWED_EMAIL configuration.");
-}
+$migrationService = new MigrationService($db);
+$status = $migrationService->getMigrationStatus();
+$pendingPatches = $status['pending'];
 
 $logs = [];
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['trigger_upgrade'])) {
-    if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? '')) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['trigger_upgrade']) || $isSecretValid)) {
+    if (!$isSecretValid && !$auth->validateCsrfToken($_POST['csrf_token'] ?? '')) {
         $logs[] = "ERROR: Invalid CSRF token.";
     } else {
-        $migrationService = new MigrationService($db);
-        $logs = $migrationService->migrate();
+        $patch = $_POST['patch'] ?? 'all';
+        if ($patch === 'all') {
+            $logs = $migrationService->migrate();
+        } else {
+            $logs = $migrationService->applyPatch($patch);
+        }
     }
 }
 
@@ -103,8 +124,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['trigger_upgrade'])) {
                                 <h3 class="text-base font-normal text-gray-500">Apply Database Patches</h3>
                                 <p class="text-sm text-gray-500 mb-4">This will scan the <code>src/sql/patches/</code> directory and apply any missing SQL patches to the database.</p>
 
-                                <form method="POST">
+                                <form method="POST" class="space-y-4">
                                     <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+
+                                    <div>
+                                        <label for="patch" class="block text-sm font-medium text-gray-700">Select Patch</label>
+                                        <select id="patch" name="patch" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md border">
+                                            <option value="all">Apply All Pending Patches</option>
+                                            <?php foreach ($pendingPatches as $patch): ?>
+                                                <option value="<?= htmlspecialchars($patch) ?>"><?= htmlspecialchars($patch) ?></option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </div>
+
                                     <button type="submit" name="trigger_upgrade" value="1" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 focus:outline-none">
                                         Run Migrations
                                     </button>

--- a/src/frontend/upgrade.php
+++ b/src/frontend/upgrade.php
@@ -13,6 +13,11 @@ $userModel = new User(new Database());
 // Security check: Only allow if ENABLE_UPGRADE_PAGE is true
 $enabledByEnv = getenv('ENABLE_UPGRADE_PAGE') === 'true';
 
+// Check for secret bypass
+$providedSecret = $_REQUEST['secret'] ?? null;
+$configuredSecret = getenv('DB_UPGRADE_SECRET');
+$isSecretValid = !empty($configuredSecret) && $providedSecret === $configuredSecret;
+
 // Also allow if the user is a logged-in admin authorized for upgrades
 $isAdminAuthorized = false;
 if ($auth->isLoggedIn() && $auth->isAdmin()) {
@@ -23,7 +28,7 @@ if ($auth->isLoggedIn() && $auth->isAdmin()) {
     }
 }
 
-if (!$enabledByEnv && !$isAdminAuthorized) {
+if (!$enabledByEnv && !$isAdminAuthorized && !$isSecretValid) {
     die("Access denied. Database upgrade page is currently disabled. To enable it, set the environment variable ENABLE_UPGRADE_PAGE=true in your .htaccess or web server configuration, or log in as an authorized administrator.");
 }
 
@@ -34,11 +39,16 @@ $logs = [];
 $successMessage = null;
 $errorMessage = null;
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['run_migrations'])) {
-    if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? '')) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['run_migrations']) || $isSecretValid)) {
+    if (!$isSecretValid && !$auth->validateCsrfToken($_POST['csrf_token'] ?? '')) {
         $errorMessage = "Invalid CSRF token.";
     } else {
-        $logs = $migrationService->migrate();
+        $patch = $_POST['patch'] ?? 'all';
+        if ($patch === 'all') {
+            $logs = $migrationService->migrate();
+        } else {
+            $logs = $migrationService->applyPatch($patch);
+        }
         $successMessage = "Migrations process completed.";
     }
 }
@@ -96,8 +106,19 @@ $appliedPatches = $status['applied'];
                     </div>
 
                     <?php if (!empty($pendingPatches)): ?>
-                        <form method="POST" class="mt-6">
+                        <form method="POST" class="mt-6 space-y-4">
                             <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+
+                            <div>
+                                <label for="patch" class="block text-sm font-medium text-gray-700">Select Patch</label>
+                                <select id="patch" name="patch" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md border">
+                                    <option value="all">Apply All Pending Patches</option>
+                                    <?php foreach ($pendingPatches as $patch): ?>
+                                        <option value="<?= htmlspecialchars($patch) ?>"><?= htmlspecialchars($patch) ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+
                             <button type="submit" name="run_migrations" value="1" class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
                                 Run Migrations
                             </button>

--- a/test/Unit/Services/MigrationServiceTest.php
+++ b/test/Unit/Services/MigrationServiceTest.php
@@ -81,4 +81,66 @@ class MigrationServiceTest extends TestCase
         $this->assertContains("Database is already up to date.", $logs);
         $this->assertNotContains("Applying patch: 001_test.sql", $logs);
     }
+
+    public function testApplySinglePatchByName(): void
+    {
+        file_put_contents($this->patchesDir . '001_test.sql', "CREATE TABLE test_table (id INTEGER PRIMARY KEY);");
+        file_put_contents($this->patchesDir . '002_test.sql', "INSERT INTO test_table (id) VALUES (1);");
+
+        $migrationService = new MigrationService($this->db, $this->patchesDir);
+
+        // Apply only the first patch
+        $logs = $migrationService->applyPatch('001_test.sql');
+
+        $this->assertContains("Applying patch: 001_test.sql", $logs);
+        $this->assertContains("Successfully applied patch: 001_test.sql", $logs);
+
+        $conn = $this->db->getConnection();
+        $stmt = $conn->query("SELECT name FROM sqlite_master WHERE type='table' AND name='test_table'");
+        $this->assertNotEmpty($stmt->fetch());
+
+        // Ensure second patch was NOT applied
+        $stmt = $conn->query("SELECT patch_name FROM migrations");
+        $applied = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertContains('001_test.sql', $applied);
+        $this->assertNotContains('002_test.sql', $applied);
+
+        // Apply the second patch
+        $logs = $migrationService->applyPatch('002_test.sql');
+        $this->assertContains("Applying patch: 002_test.sql", $logs);
+
+        $stmt = $conn->query("SELECT * FROM test_table");
+        $this->assertCount(1, $stmt->fetchAll());
+    }
+
+    public function testApplyPatchFileNotFound(): void
+    {
+        $migrationService = new MigrationService($this->db, $this->patchesDir);
+        $logs = $migrationService->applyPatch('non_existent.sql');
+        $this->assertContains("ERROR: Patch file not found: non_existent.sql", $logs);
+    }
+
+    public function testApplyPatchAlreadyApplied(): void
+    {
+        file_put_contents($this->patchesDir . '001_test.sql', "CREATE TABLE test_table (id INTEGER PRIMARY KEY);");
+        $migrationService = new MigrationService($this->db, $this->patchesDir);
+        $migrationService->applyPatch('001_test.sql');
+
+        $logs = $migrationService->applyPatch('001_test.sql');
+        $this->assertContains("Patch 001_test.sql is already applied.", $logs);
+    }
+
+    public function testApplyPatchPathTraversal(): void
+    {
+        $migrationService = new MigrationService($this->db, $this->patchesDir);
+
+        $logs = $migrationService->applyPatch('../outside.sql');
+        $this->assertContains("ERROR: Invalid patch name: ../outside.sql", $logs);
+
+        $logs = $migrationService->applyPatch('dir/patch.sql');
+        $this->assertContains("ERROR: Invalid patch name: dir/patch.sql", $logs);
+
+        $logs = $migrationService->applyPatch('patch.php');
+        $this->assertContains("ERROR: Invalid patch name: patch.php", $logs);
+    }
 }


### PR DESCRIPTION
This change implements a comprehensive solution for automated and manual database patching. Key improvements include:

1.  **Backend Enhancements:** `App\MigrationService` now supports applying specific SQL patches by name via the `applyPatch()` method. It includes a security check to prevent path traversal and ensures only `.sql` files can be applied.
2.  **UI Improvements:** The database upgrade pages (`/upgrade.php` and `/admin/upgrade.php`) now feature a dropdown menu allowing users to apply all pending patches or select a specific one.
3.  **Automated Patching:** A new GitHub Action workflow, `Apply DB Patch`, has been added. It securely extracts the `DB_UPGRADE_SECRET` from the server's `.htaccess` file via SSH and uses it to authorized an HTTPS POST request to the application's upgrade endpoint.
4.  **Security:** The `DB_UPGRADE_SECRET` environment variable provides a secure way to trigger migrations remotely without requiring a user session or CSRF token, while keeping the upgrade pages protected for normal users.
5.  **Documentation & Testing:** `INSTALL.md` has been updated with instructions for the new workflow and environment variable. New unit tests in `MigrationServiceTest` verify the individual patch application and path traversal protection.

Fixes #208

---
*PR created automatically by Jules for task [8673012847023498469](https://jules.google.com/task/8673012847023498469) started by @chatelao*