### PR TITLE
Hide redundant 'Linked as' info on dashboard

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -216,7 +216,12 @@ $errorMessage = $errorMessage ?? null;
                                                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
                                                     </a>
                                                 </div>
-                                                <p class="text-sm text-gray-500 mt-1">Linked as&nbsp;<?= htmlspecialchars($project['github_username']) ?></p>
+                                                <?php
+                                                $repoParts = explode('/', $project['github_repo']);
+                                                $repoOwner = $repoParts[0] ?? '';
+                                                if (strcasecmp($repoOwner, $project['github_username']) !== 0): ?>
+                                                    <p class="text-sm text-gray-500 mt-1">Linked as&nbsp;<?= htmlspecialchars($project['github_username']) ?></p>
+                                                <?php endif; ?>
 
                                                 <div class="flex flex-wrap gap-2 mt-3">
                                                     <?php


### PR DESCRIPTION
This change modifies `src/frontend/index.php` to conditionally display the "Linked as [username]" label on project cards. If the repository owner (extracted from the `github_repo` field) matches the linked GitHub account username (case-insensitively), the label is hidden. This improves the UI by removing redundant information for projects owned by the linked account itself.

Fixes #222

---
*PR created automatically by Jules for task [15724739751446906217](https://jules.google.com/task/15724739751446906217) started by @chatelao*