### PR TITLE
Update Issue Linking and Styling

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -161,9 +161,10 @@ $errorMessage = $errorMessage ?? null;
                                                         <?= htmlspecialchars($task['github_repo']) ?>
                                                     </a>
                                                 </td>
-                                                <td class="px-6 py-4">
+                                                <td class="px-6 py-4 font-normal">
+                                                    <a href="https://github.com/<?= htmlspecialchars($task['github_repo']) ?>/issues/<?= htmlspecialchars($task['issue_number']) ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">#<?= htmlspecialchars($task['issue_number']) ?></a>
                                                     <a href="<?= htmlspecialchars($taskModel->getTargetUrl($task)) ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
-                                                        #<?= htmlspecialchars($task['issue_number']) ?> <?= htmlspecialchars($task['title']) ?>
+                                                        <?= htmlspecialchars($task['title']) ?>
                                                     </a>
                                                 </td>
                                                 <td class="px-6 py-4">

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -421,9 +421,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                         <?php foreach ($tasks as $task): ?>
                                             <tr class="bg-white border-b">
                                                 <td class="px-6 py-4">
-                                                    <div class="text-base text-gray-900">
+                                                    <div class="text-base text-gray-900 font-normal">
+                                                        <a href="https://github.com/<?= htmlspecialchars($project['github_repo']) ?>/issues/<?= htmlspecialchars($task['issue_number']) ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">#<?= htmlspecialchars($task['issue_number']) ?></a>
                                                         <a href="<?= htmlspecialchars($taskModel->getTargetUrl($task, $project['github_repo'])) ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
-                                                            #<?= htmlspecialchars($task['issue_number']) ?> <?= htmlspecialchars($task['title']) ?>
+                                                            <?= htmlspecialchars($task['title']) ?>
                                                         </a>
                                                     </div>
                                                     <div class="text-xs text-gray-500"><?= htmlspecialchars(mb_substr($task['body'] ?? '', 0, 100)) ?>...</div>


### PR DESCRIPTION
This change updates the task list display in both the project details page and the dashboard's autorepeat tasks table. It separates the issue number from the title, making the issue number a direct link to GitHub. It also ensures the issue title is displayed with normal font weight (not bold) and maintains its dynamic linking to the most relevant resource (PR, Jules session, or GitHub issue).

Fixes #226

---
*PR created automatically by Jules for task [795024151874456822](https://jules.google.com/task/795024151874456822) started by @chatelao*