### PR TITLE
Extend notification concept and design

### DIFF
--- a/NOTIF_CONCEPT.md
+++ b/NOTIF_CONCEPT.md
@@ -3,6 +3,10 @@
 ## Overview
 The notification system aims to keep users informed about critical events across their projects and tasks. It provides a multi-channel approach to ensure timely updates whether the user is actively using the dashboard or is on the move.
 
+## Business Cases
+-   **Reduced Cycle Times**: Real-time alerts for build failures and PR availability minimize "wait time" in the development lifecycle.
+-   **Improved Operational Awareness**: Provides stakeholders with immediate visibility into the progress and health of automated AI tasks without manual monitoring.
+
 ## Notification Channels
 1.  **In-App Inbox**: A centralized list of notifications within the web application dashboard.
 2.  **Active Browser Notifications**: Real-time push notifications or browser-level alerts when the dashboard is open.
@@ -14,6 +18,14 @@ Users can toggle notifications for the following event types:
 -   **PR Available**: Notification when a new Pull Request is created or requires attention.
 -   **Session Failed**: Error alerts when an AI agent (Jules) session fails or encounters an error.
 -   **Task Completed**: Success notification when a task or issue is resolved.
+
+## Use Cases
+-   **Jump to Source (Deep Linking)**: A user clicks on a "PR Available" notification and is immediately taken to the corresponding GitHub Pull Request page.
+-   **Immediate Build Failure Response**: A developer receives a "Build Failed" notification on Telegram and can quickly initiate a fix, even when away from their primary workstation.
+-   **Streamlined PR Review Workflow**: Reviewers are notified as soon as a new PR is ready for feedback, accelerating the path to merging.
+-   **Passive Progress Monitoring**: A developer receives a "Task Completed" notification when Jules finishes a long-running task, allowing them to switch contexts at the optimal time.
+-   **Noise Management for Experimental Projects**: A user mutes all notifications for a specific experimental repository to maintain focus on stable production repositories.
+-   **Unified Task Oversight**: A user scans their In-App Inbox to catch up on all completed and failed tasks across multiple projects in a single view.
 
 ## Configuration & Customization
 To avoid notification fatigue, users can customize their preferences at multiple levels:

--- a/NOTIF_DESIGN.md
+++ b/NOTIF_DESIGN.md
@@ -31,7 +31,7 @@ Stores the history of notifications for each user.
 - `type` (VARCHAR): e.g., `build_failed`, `pr_available`, `session_failed`, `task_completed`.
 - `title` (VARCHAR)
 - `message` (TEXT)
-- `data` (JSON): Additional context (e.g., `project_id`, `task_id`, `url`).
+- `data` (JSON): Additional context (e.g., `project_id`, `task_id`, `source_url`).
 - `is_read` (BOOLEAN): Default `false`.
 - `created_at` (TIMESTAMP)
 
@@ -61,6 +61,7 @@ Mute or prioritize specific tasks.
 - Notifications are fetched from the `notifications` table.
 - A notification bell in `navbar.php` displays the unread count.
 - A dropdown or dedicated page allows users to view and mark notifications as read.
+- **Deep Linking**: Each notification item in the inbox is rendered as a clickable link that directs the user to the `source_url` provided in the notification data.
 
 ### 2. Active Browser Notifications
 - Uses the `Web Notifications API`.
@@ -73,6 +74,14 @@ Mute or prioritize specific tasks.
 - Handled asynchronously to avoid blocking the main execution flow.
 
 ## Implementation Details
+
+### Deep Linking
+The `NotificationService` populates the `source_url` in the `data` payload based on the event context:
+-   **GitHub PR events**: URL of the Pull Request.
+-   **Jules Session events**: URL of the AI agent session.
+-   **Task/Issue events**: URL of the GitHub Issue.
+
+The frontend uses this URL to provide a direct "Jump to Source" action for each notification.
 
 ### Notification Service Dispatching
 ```php


### PR DESCRIPTION
I have extended the notification concept and design documentation.

Key changes:
- **`NOTIF_CONCEPT.md`**: Added two business cases ("Reduced Cycle Times" and "Improved Operational Awareness") and six use cases, including "Jump to Source (Deep Linking)", "Immediate Build Failure Response", and "Noise Management".
- **`NOTIF_DESIGN.md`**: Updated the `notifications` table schema to include `source_url` within the JSON `data` field. Added an "Implementation Details" section for Deep Linking, explaining how the `NotificationService` generates URLs for different event types. Specified that the In-App Inbox should render notifications as clickable links.

All tests passed, and the design is now aligned with the requirement for direct navigation from notifications to their source.

Fixes #227

---
*PR created automatically by Jules for task [11182405880259062279](https://jules.google.com/task/11182405880259062279) started by @chatelao*