### PR TITLE
Remove finished and deleted tasks from the overview

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -82,6 +82,14 @@ class Task
         return $task ?: null;
     }
 
+    public function deleteByIssueNumber(int $projectId, int $issueNumber): bool
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "DELETE FROM tasks WHERE project_id = ? AND issue_number = ?"
+        );
+        return $stmt->execute([$projectId, $issueNumber]);
+    }
+
     public function updateStatus(int $id, string $status): bool
     {
         $stmt = $this->db->getConnection()->prepare(
@@ -116,7 +124,7 @@ class Task
 
     public function syncIssues(int $userId, int $projectId, string $repo, GitHubService $githubService): void
     {
-        $issues = $githubService->listIssues($repo);
+        $issues = $githubService->listIssues($repo, 'all');
 
         foreach ($issues as $issue) {
             // Check if it's really an issue (not a PR)

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -21,11 +21,20 @@ class WebhookHandler
         $action = $event['action'] ?? '';
         $issue = $event['issue'] ?? null;
 
-        if (!$issue || !in_array($action, ['opened', 'reopened', 'edited', 'closed', 'labeled', 'unlabeled'])) {
+        if (!$issue) {
             return false;
         }
 
         $taskModel = new Task($this->db);
+
+        if ($action === 'deleted') {
+            return $taskModel->deleteByIssueNumber($project['project_id'], $issue['number']);
+        }
+
+        if (!in_array($action, ['opened', 'reopened', 'edited', 'closed', 'labeled', 'unlabeled'])) {
+            return false;
+        }
+
         $result = $taskModel->upsert($project['user_id'], $project['project_id'], $issue);
 
         if ($result && $action === 'closed' && $githubService) {

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -56,10 +56,16 @@ if ($user) {
 $autorepeatTasks = $user ? $taskModel->getRunningAutorepeatTasks($user['user_id']) : [];
 
 $projectTasks = [];
+$activeTasksCount = 0;
 if ($user) {
     $allTasks = $taskModel->findByUserProjects($user['user_id']);
     foreach ($allTasks as $task) {
-        $projectTasks[$task['project_id']][] = $task;
+        $githubData = json_decode($task['github_data'] ?? '{}', true);
+        $state = $githubData['state'] ?? 'open';
+        if ($state !== 'closed' && $task['status'] !== 'completed') {
+            $projectTasks[$task['project_id']][] = $task;
+            $activeTasksCount++;
+        }
     }
 }
 
@@ -192,8 +198,8 @@ $errorMessage = $errorMessage ?? null;
                                         <p class="text-xl font-bold text-purple-900"><?= count($githubAccounts) ?></p>
                                     </div>
                                     <div class="p-4 bg-green-50 border border-green-200 rounded-lg">
-                                        <p class="text-xs font-medium text-green-600 uppercase">Total Tasks</p>
-                                        <p class="text-xl font-bold text-green-900"><?= count($allTasks) ?></p>
+                                        <p class="text-xs font-medium text-green-600 uppercase">Active Tasks</p>
+                                        <p class="text-xl font-bold text-green-900"><?= $activeTasksCount ?></p>
                                     </div>
                                     <div class="p-4 bg-orange-50 border border-orange-200 rounded-lg">
                                         <p class="text-xs font-medium text-orange-600 uppercase">Autorepeat Tasks</p>

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -117,11 +117,27 @@ class WebhookHandlerTest extends TestCase
         $this->assertTrue($this->handler->handle($project, $event, $githubService));
     }
 
-    public function testHandleUnsupportedAction()
+    public function testHandleDeletedIssue()
     {
         $project = ['user_id' => 1, 'project_id' => 1];
         $event = [
             'action' => 'deleted',
+            'issue' => ['number' => 123]
+        ];
+
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->method('execute')->willReturn(true);
+
+        $this->pdo->method('prepare')->with($this->stringContains('DELETE FROM tasks'))->willReturn($stmt);
+
+        $this->assertTrue($this->handler->handle($project, $event));
+    }
+
+    public function testHandleUnsupportedAction()
+    {
+        $project = ['user_id' => 1, 'project_id' => 1];
+        $event = [
+            'action' => 'unknown_action',
             'issue' => ['number' => 123]
         ];
 


### PR DESCRIPTION
This change ensures that the dashboard overview remains focused on active work by removing tasks that have been finished (either closed on GitHub or completed locally) or deleted on GitHub.

Key changes:
1.  **Backend Deletion Support:** Implemented `deleteByIssueNumber` in the `Task` model.
2.  **Webhook Integration:** Updated `WebhookHandler` to process `deleted` events from GitHub, ensuring real-time cleanup of the local database.
3.  **Improved Synchronization:** Adjusted `syncIssues` to retrieve both open and closed issues from the GitHub API. This allows the system to correctly identify and hide issues that were closed outside of the application (e.g., manually on GitHub).
4.  **Frontend Filtering:** Modified the dashboard (`index.php`) to filter the `projectTasks` array, displaying only tasks where the GitHub state is NOT 'closed' and the internal status is NOT 'completed'.
5.  **UI Clarification:** Renamed the "Total Tasks" statistic to "Active Tasks" to accurately reflect the filtered view.
6.  **Testing:** Added a new unit test case to `WebhookHandlerTest` to verify the handling of the `deleted` action.

Fixes #230

---
*PR created automatically by Jules for task [16798275640516443446](https://jules.google.com/task/16798275640516443446) started by @chatelao*