### PR TITLE
Fix premature task completion and improve status granularity

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -182,11 +182,11 @@ class Task
             return 'red';
         }
 
-        if (in_array($status, ['in_progress', 'coding', 'testing'])) {
+        if (in_array($status, ['in_progress', 'implemented', 'coding', 'testing'])) {
             return 'yellow';
         }
 
-        if (in_array($status, ['researching', 'planning', 'awaiting-plan-approval', 'awaiting-user-feedback'])) {
+        if (in_array($status, ['analyzed', 'researching', 'planning', 'awaiting-plan-approval', 'awaiting-user-feedback'])) {
             return 'blue';
         }
 
@@ -353,10 +353,12 @@ class Task
                     $mappedStatus = $task['status'];
                     $julesUrl = $julesData['url'] ?? null;
 
-                    if (in_array($newStatus, ['in-progress', 'coding', 'testing', 'researching', 'planning'])) {
+                    if (in_array($newStatus, ['coding', 'testing', 'researching', 'planning'])) {
+                        $mappedStatus = str_replace('-', '_', $newStatus);
+                    } elseif ($newStatus === 'in-progress') {
                         $mappedStatus = 'in_progress';
                     } elseif ($newStatus === 'completed' || $newStatus === 'finished') {
-                        $mappedStatus = 'completed';
+                        $mappedStatus = !empty($prUrl) ? 'completed' : 'implemented';
                     } elseif ($newStatus === 'failed' || $newStatus === 'error') {
                         $mappedStatus = 'failed';
                     }

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -235,9 +235,9 @@ $errorMessage = $errorMessage ?? null;
 
                                                         $emoji = '⏳';
                                                         if ($state === 'closed') $emoji = '✅';
-                                                        elseif ($task['status'] === 'failed') $emoji = '❌';
-                                                        elseif ($task['status'] === 'in_progress') $emoji = '🚧';
                                                         elseif ($task['status'] === 'completed') $emoji = '✅';
+                                                        elseif ($task['status'] === 'failed') $emoji = '❌';
+                                                        elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) $emoji = '🚧';
                                                     ?>
                                                         <div class="relative group">
                                                             <a href="project.php?id=<?= $project['project_id'] ?>"

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -88,8 +88,8 @@ $triggerAgent = function($taskId) use ($taskModel, $logger, $user, $project, $ju
             $lastAgentResponse = $julesService->triggerAgent($task);
             $logger->log($user['user_id'], $taskId, "Received response from Jules API");
 
-            $taskModel->updateAgentResponse($taskId, $lastAgentResponse, 'completed');
-            $logger->log($user['user_id'], $taskId, "Task agent response updated and status set to completed");
+            $taskModel->updateAgentResponse($taskId, $lastAgentResponse, 'analyzed');
+            $logger->log($user['user_id'], $taskId, "Task agent response updated and status set to analyzed");
 
             if ($githubService) {
                 $githubService->postComment($project['github_repo'], $task['issue_number'], "✅ Agent has completed the analysis:\n\n" . $lastAgentResponse);
@@ -469,11 +469,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                     <div class="text-xs text-gray-500"><?= htmlspecialchars(mb_substr($task['body'] ?? '', 0, 100)) ?>...</div>
                                                 </td>
                                                 <td class="px-6 py-4">
-                                                    <span class="px-2 py-1 text-xs font-medium rounded-full <?= $task['status'] === 'completed' ? 'bg-green-100 text-green-800' : ($task['status'] === 'in_progress' ? 'bg-blue-100 text-blue-800' : ($task['status'] === 'failed' ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-800')) ?>">
+                                                    <?php
+                                                    $statusColor = $taskModel->getStatusColor($task);
+                                                    $bgClass = 'bg-gray-100 text-gray-800';
+                                                    if ($statusColor === 'green') $bgClass = 'bg-green-100 text-green-800';
+                                                    elseif ($statusColor === 'yellow') $bgClass = 'bg-yellow-100 text-yellow-800';
+                                                    elseif ($statusColor === 'blue') $bgClass = 'bg-blue-100 text-blue-800';
+                                                    elseif ($statusColor === 'red') $bgClass = 'bg-red-100 text-red-800';
+                                                    elseif ($statusColor === 'purple') $bgClass = 'bg-purple-100 text-purple-800';
+                                                    ?>
+                                                    <span class="px-2 py-1 text-xs font-medium rounded-full <?= $bgClass ?>">
                                                         <?php
-                                                        if ($task['status'] === 'completed') echo '✅ ';
-                                                        elseif ($task['status'] === 'in_progress') echo '🚧 ';
+                                                        $githubData = json_decode($task['github_data'] ?? '{}', true);
+                                                        if (($githubData['state'] ?? 'open') === 'closed') echo '✅ ';
+                                                        elseif ($task['status'] === 'completed') echo '✅ ';
                                                         elseif ($task['status'] === 'failed') echo '❌ ';
+                                                        elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) echo '🚧 ';
                                                         else echo '⏳ ';
                                                         ?>
                                                         <?= htmlspecialchars($task['status']) ?>


### PR DESCRIPTION
The issue was that tasks were being prematurely marked as "completed" (and thus "done" in the UI) after the initial AI analysis or when a Jules session finished without yet posting a PR link.

I implemented a more robust state machine:
1. **Initial Analysis**: Now sets status to `analyzed` (displays as 🚧).
2. **Jules Sync**: Maps granular statuses (`coding`, `researching`, etc.) directly.
3. **Completion Logic**: A finished Jules session now maps to `implemented` (displays as 🚧) if no `pr_url` is found. It only becomes `completed` (displays as ✅) once a PR URL is extracted from GitHub comments.
4. **UI**: Updated status badges and dashboard squares to follow these semantics, ensuring open issues are never marked with a checkmark until they are truly finished (closed or PR'd).

Fixes #236

---
*PR created automatically by Jules for task [6362993636819410229](https://jules.google.com/task/6362993636819410229) started by @chatelao*