### PR TITLE
Add option to deploy workflow push only the front- and backendcode w/o vendor stuff

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,12 @@ name: Manual SSH Deploy
 
 on:
   workflow_dispatch:
+    inputs:
+      include_vendor:
+        description: 'Include vendor directory'
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   deploy:
@@ -13,12 +19,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PHP
+        if: ${{ inputs.include_vendor }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
           extensions: mbstring, xml, ctype, iconv, mysql
 
       - name: Install dependencies
+        if: ${{ inputs.include_vendor }}
         run: composer install --no-dev --optimize-autoloader
 
       - name: Deploy via SSH
@@ -32,6 +40,7 @@ jobs:
           local_path: './'
           sftp_only: false
           rsyncArgs: >-
+            ${{ inputs.include_vendor == false && '--exclude=vendor/' || '' }}
             --exclude=.git\*
             --exclude=.github/
             --exclude=test/


### PR DESCRIPTION
This change adds a new input `include_vendor` to the manual deployment workflow. This allows users to deploy only the application code (frontend and backend) without including or rebuilding the `vendor/` directory, which can significantly speed up deployments when dependencies haven't changed.

Fixes #239

---
*PR created automatically by Jules for task [482897417829088564](https://jules.google.com/task/482897417829088564) started by @chatelao*