### PR TITLE
Review and fix GitHub webhook logic and update documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,19 @@ This guide explains how to install the AI Brain application on a web server.
 3.  Click **Create API key** (either in a new or existing Google Cloud project).
 4.  Copy the generated key for `GOOGLE_JULES_API_KEY`. (Note: Users can also provide their own keys in the application dashboard).
 
-### 4. Telegram Bot
+### 4. GitHub Webhook Configuration
+To receive real-time updates for issue events, you must configure a webhook for each repository you link.
+1.  In the application, go to the **Project Details** page for your linked repository.
+2.  Copy the **Payload URL** and **Secret** from the "Webhook Configuration" section.
+3.  In GitHub, navigate to your repository's **Settings > Webhooks**.
+4.  Click **Add webhook**.
+5.  Paste the **Payload URL**.
+6.  Set **Content type** to `application/json`.
+7.  Paste the **Secret**.
+8.  Select **Let me select individual events** and check **Issues**.
+9.  Ensure **Active** is checked and click **Add webhook**.
+
+### 5. Telegram Bot
 1.  Message [@BotFather](https://t.me/botfather) on Telegram.
 2.  Use the `/newbot` command and follow the instructions to get your **Bot Token**.
 3.  For `TELEGRAM_WEBHOOK_SECRET`, generate a random, secure string (e.g., using `openssl rand -hex 32`). This is used to verify that requests to your webhook are actually coming from Telegram.

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -22,7 +22,7 @@ class WebhookHandler
         $issue = $event['issue'] ?? null;
 
         if (!$issue) {
-            return false;
+            return true;
         }
 
         $taskModel = new Task($this->db);
@@ -32,7 +32,7 @@ class WebhookHandler
         }
 
         if (!in_array($action, ['opened', 'reopened', 'edited', 'closed', 'labeled', 'unlabeled'])) {
-            return false;
+            return true;
         }
 
         $result = $taskModel->upsert($project['user_id'], $project['project_id'], $issue);

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -390,6 +390,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                 <?php endif; ?>
                             </div>
 
+                            <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+                                <h3 class="text-lg font-bold text-gray-900 mb-4">Webhook Configuration</h3>
+                                <div class="space-y-3">
+                                    <div>
+                                        <label class="block text-xs font-medium text-gray-500 uppercase">Payload URL</label>
+                                        <div class="mt-1 flex">
+                                            <input type="text" readonly value="<?= ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] ?>/webhook.php" class="bg-gray-50 border border-gray-300 text-gray-900 text-xs rounded-lg block w-full p-2" id="webhook-url">
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <label class="block text-xs font-medium text-gray-500 uppercase">Secret</label>
+                                        <div class="mt-1 flex">
+                                            <input type="text" readonly value="<?= htmlspecialchars($project['webhook_secret']) ?>" class="bg-gray-50 border border-gray-300 text-gray-900 text-xs rounded-lg block w-full p-2" id="webhook-secret">
+                                        </div>
+                                    </div>
+                                    <p class="text-[10px] text-gray-500">
+                                        Configure this in your GitHub Repository <b>Settings > Webhooks</b>.
+                                        Set Content type to <b>application/json</b> and select <b>Issues</b> events.
+                                    </p>
+                                </div>
+                            </div>
+
                             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm" x-data="{
                                 templates: <?= htmlspecialchars(json_encode($templates)) ?>,
                                 selectedTemplateId: '<?= $templates[0]['issue_template_id'] ?? '' ?>',

--- a/src/frontend/webhook.php
+++ b/src/frontend/webhook.php
@@ -23,7 +23,7 @@ $payload = file_get_contents('php://input');
 $signature = $_SERVER['HTTP_X_HUB_SIGNATURE_256'] ?? '';
 $event = $_SERVER['HTTP_X_GITHUB_EVENT'] ?? '';
 
-if (empty($payload) || empty($signature) || $event !== 'issues') {
+if (empty($payload) || empty($signature) || !in_array($event, ['issues', 'ping'])) {
     http_response_code(400);
     exit('Invalid request');
 }
@@ -57,6 +57,11 @@ foreach ($projects as $project) {
 if (!$verified) {
     http_response_code(401);
     exit('Invalid signature');
+}
+
+if ($event === 'ping') {
+    http_response_code(200);
+    exit('PONG');
 }
 
 $githubService = null;

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -72,4 +72,35 @@ class WebhookHandlerTest extends TestCase
         $this->assertEquals('Issue description', $task['body']);
         $this->assertEquals('pending', $task['status']);
     }
+
+    public function testHandleAutorepeat()
+    {
+        $project = ['user_id' => 1, 'project_id' => 1];
+        $event = [
+            'action' => 'closed',
+            'issue' => [
+                'number' => 123,
+                'title' => 'Autorepeat Issue',
+                'body' => 'Description',
+                'state_reason' => 'completed',
+                'labels' => [
+                    ['name' => 'autorepeat']
+                ]
+            ],
+            'repository' => [
+                'full_name' => 'owner/repo'
+            ]
+        ];
+
+        $githubService = $this->createMock(\App\GitHubService::class);
+        $githubService->expects($this->once())
+            ->method('createIssue')
+            ->with('owner/repo', 'Autorepeat Issue', 'Description', ['autorepeat']);
+        $githubService->expects($this->once())
+            ->method('removeLabel')
+            ->with('owner/repo', 123, 'autorepeat');
+
+        $result = $this->handler->handle($project, $event, $githubService);
+        $this->assertTrue($result);
+    }
 }

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -141,7 +141,7 @@ class WebhookHandlerTest extends TestCase
             'issue' => ['number' => 123]
         ];
 
-        $this->assertFalse($this->handler->handle($project, $event));
+        $this->assertTrue($this->handler->handle($project, $event));
     }
 
     public function testHandleSqlite()


### PR DESCRIPTION
I have reviewed and improved the GitHub webhook logic to ensure better compatibility with GitHub and improved user experience.

Key changes:
1.  **GitHub Webhook Reliability**: Updated `webhook.php` and `WebhookHandler.php` to handle the `ping` event and return a 200 OK success response for validly signed but unhandled events. This prevents GitHub from disabling the webhook due to "failed" deliveries (500 errors).
2.  **Improved UI**: Added a new "Webhook Configuration" section to the Project Details page. This provides users with the exact **Payload URL** and **Secret** they need to configure the webhook in their GitHub repository settings.
3.  **Documentation Update**: Enhanced `INSTALL.md` with a new step-by-step guide for configuring GitHub webhooks, ensuring users can set up the integration correctly.
4.  **Testing**: Added a new integration test for the `autorepeat` logic and updated existing unit tests to align with the improved response handling. All 92 tests are passing.
5.  **Verification**: Visually verified the new UI section using a Playwright script.

Fixes #246

---
*PR created automatically by Jules for task [10505815676925396682](https://jules.google.com/task/10505815676925396682) started by @chatelao*