### PR TITLE
Add Webhook Call Logs for Debugging

### DIFF
--- a/src/backend/WebhookLogger.php
+++ b/src/backend/WebhookLogger.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App;
+
+use PDO;
+
+class WebhookLogger
+{
+    public function __construct(private Database $db)
+    {
+    }
+
+    public function log(int $userId, string $endpoint, ?string $payload, ?string $headers, int $statusCode, ?string $errorMessage = null): bool
+    {
+        $conn = $this->db->getConnection();
+
+        $stmt = $conn->prepare(
+            "INSERT INTO webhook_logs (user_id, endpoint, payload, headers, status_code, error_message)
+             VALUES (?, ?, ?, ?, ?, ?)"
+        );
+        $result = $stmt->execute([$userId, $endpoint, $payload, $headers, $statusCode, $errorMessage]);
+
+        if ($result) {
+            $this->pruneLogs($userId, $endpoint);
+        }
+
+        return $result;
+    }
+
+    private function pruneLogs(int $userId, string $endpoint): void
+    {
+        $conn = $this->db->getConnection();
+
+        // Find the 5th newest log ID for this user and endpoint
+        $stmt = $conn->prepare(
+            "SELECT log_id FROM webhook_logs
+             WHERE user_id = ? AND endpoint = ?
+             ORDER BY created_at DESC, log_id DESC
+             LIMIT 1 OFFSET 4"
+        );
+        $stmt->execute([$userId, $endpoint]);
+        $fifthLogId = $stmt->fetchColumn();
+
+        if ($fifthLogId) {
+            // Delete all older logs
+            // Simplified approach: just delete logs with ID less than the fifth newest if we assume IDs are increasing.
+            // But if timestamps are identical, we need to be careful.
+
+            $stmt = $conn->prepare(
+                "DELETE FROM webhook_logs
+                 WHERE user_id = ? AND endpoint = ? AND log_id < ?"
+            );
+            $stmt->execute([$userId, $endpoint, $fifthLogId]);
+        }
+    }
+
+    public function getLogsByUser(int $userId): array
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "SELECT * FROM webhook_logs WHERE user_id = ? ORDER BY created_at DESC, log_id DESC"
+        );
+        $stmt->execute([$userId]);
+        return $stmt->fetchAll();
+    }
+}

--- a/src/frontend/settings.php
+++ b/src/frontend/settings.php
@@ -6,11 +6,13 @@ use App\Database;
 use App\Auth;
 use App\User;
 use App\Task;
+use App\WebhookLogger;
 
 $auth = new Auth();
 $db = new Database();
 $userModel = new User($db);
 $taskModel = new Task($db);
+$webhookLogger = new WebhookLogger($db);
 
 if (!$auth->isLoggedIn()) {
     header('Location: login.php');
@@ -49,6 +51,7 @@ if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_teleg
 }
 
 $githubAccounts = $user ? $userModel->getGitHubAccounts($user['user_id']) : [];
+$webhookLogs = $user ? $webhookLogger->getLogsByUser($user['user_id']) : [];
 $errorMessage = $errorMessage ?? null;
 
 ?>
@@ -61,6 +64,7 @@ $errorMessage = $errorMessage ?? null;
     <title>Account Settings - Agent Control</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <style>[x-cloak] { display: none !important; }</style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
     <nav class="bg-white border-b border-gray-200 fixed w-full z-30 top-0">
@@ -108,10 +112,21 @@ $errorMessage = $errorMessage ?? null;
                         </ol>
                     </nav>
 
-                    <div class="mb-4">
+                    <div class="mb-4 flex justify-between items-center">
                         <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">Account Settings</h1>
                     </div>
 
+                    <div class="mb-4 border-b border-gray-200" x-data="{ activeTab: '<?= htmlspecialchars($_GET['tab'] ?? 'general', ENT_QUOTES, 'UTF-8') ?>' }">
+                        <ul class="flex flex-wrap -mb-px text-sm font-medium text-center">
+                            <li class="mr-2">
+                                <button @click="activeTab = 'general'" :class="activeTab === 'general' ? 'text-blue-600 border-blue-600' : 'text-gray-500 border-transparent hover:text-gray-600 hover:border-gray-300'" class="inline-block p-4 border-b-2 rounded-t-lg">General</button>
+                            </li>
+                            <li class="mr-2">
+                                <button @click="activeTab = 'logging'" :class="activeTab === 'logging' ? 'text-blue-600 border-blue-600' : 'text-gray-500 border-transparent hover:text-gray-600 hover:border-gray-300'" class="inline-block p-4 border-b-2 rounded-t-lg">Logging</button>
+                            </li>
+                        </ul>
+
+                        <div x-show="activeTab === 'general'" class="pt-4">
                     <?php if (isset($_GET['success']) && $_GET['success'] === 'key_updated'): ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Jules API Key updated successfully.
@@ -179,6 +194,63 @@ $errorMessage = $errorMessage ?? null;
                             </div>
                         </div>
                     </div>
+                    </div> <!-- End General Tab -->
+
+                    <div x-show="activeTab === 'logging'" class="pt-4" x-cloak>
+                        <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm sm:p-6">
+                            <h3 class="text-lg font-semibold text-gray-900 mb-4">Webhook Call Logs (Last 5 per endpoint)</h3>
+                            <?php if (empty($webhookLogs)): ?>
+                                <p class="text-sm text-gray-500 italic">No webhook calls logged yet.</p>
+                            <?php else: ?>
+                                <div class="relative overflow-x-auto">
+                                    <table class="w-full text-sm text-left text-gray-500">
+                                        <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+                                            <tr>
+                                                <th scope="col" class="px-6 py-3">Time</th>
+                                                <th scope="col" class="px-6 py-3">Endpoint</th>
+                                                <th scope="col" class="px-6 py-3">Status</th>
+                                                <th scope="col" class="px-6 py-3">Details</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <?php foreach ($webhookLogs as $log): ?>
+                                                <tr class="bg-white border-b hover:bg-gray-50" x-data="{ open: false }">
+                                                    <td class="px-6 py-4 whitespace-nowrap"><?= htmlspecialchars($log['created_at']) ?></td>
+                                                    <td class="px-6 py-4 uppercase font-mono text-xs"><?= htmlspecialchars($log['endpoint']) ?></td>
+                                                    <td class="px-6 py-4">
+                                                        <span class="px-2.5 py-0.5 rounded-full text-xs font-medium <?= $log['status_code'] >= 200 && $log['status_code'] < 300 ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' ?>">
+                                                            <?= (int)$log['status_code'] ?>
+                                                        </span>
+                                                        <?php if ($log['error_message']): ?>
+                                                            <div class="text-xs text-red-600 mt-1"><?= htmlspecialchars($log['error_message']) ?></div>
+                                                        <?php endif; ?>
+                                                    </td>
+                                                    <td class="px-6 py-4">
+                                                        <button @click="open = !open" class="text-blue-600 hover:underline">View Payload</button>
+                                                        <div x-show="open" class="mt-2 p-2 bg-gray-900 text-green-400 rounded text-xs overflow-auto max-w-lg max-h-64" @click.away="open = false" x-cloak>
+                                                            <div class="mb-2 border-b border-gray-700 pb-1 text-gray-400">Headers:</div>
+                                                            <?php
+                                                            $headers = json_decode($log['headers'] ?? '{}', true);
+                                                            $headersJson = $headers ? json_encode($headers, JSON_PRETTY_PRINT) : ($log['headers'] ?? '');
+                                                            ?>
+                                                            <pre><?= htmlspecialchars($headersJson) ?></pre>
+                                                            <div class="mt-4 mb-2 border-b border-gray-700 pb-1 text-gray-400">Payload:</div>
+                                                            <?php
+                                                            $payload = json_decode($log['payload'] ?? '{}', true);
+                                                            $payloadJson = $payload ? json_encode($payload, JSON_PRETTY_PRINT) : ($log['payload'] ?? '');
+                                                            ?>
+                                                            <pre><?= htmlspecialchars($payloadJson) ?></pre>
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            <?php endforeach; ?>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                    </div> <!-- End Tab Content Wrapper -->
                 </div>
             </main>
         </div>

--- a/src/frontend/telegram-webhook.php
+++ b/src/frontend/telegram-webhook.php
@@ -6,11 +6,16 @@ use App\Database;
 use App\User;
 use App\TelegramService;
 use App\TelegramWebhookHandler;
+use App\WebhookLogger;
 
 $db = new Database();
 $userModel = new User($db);
+$logger = new WebhookLogger($db);
 
 $userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : null;
+$headers = getallheaders();
+$headersStr = json_encode($headers);
+$input = file_get_contents('php://input');
 $botToken = getenv('TELEGRAM_BOT_TOKEN') ?: '';
 $webhookSecret = getenv('TELEGRAM_WEBHOOK_SECRET') ?: '';
 
@@ -36,18 +41,27 @@ $handler = new TelegramWebhookHandler(
 $providedSecret = $_SERVER['HTTP_X_TELEGRAM_BOT_API_SECRET_TOKEN'] ?? '';
 
 if (!$handler->verifySecret($providedSecret)) {
+    if ($userId) {
+        $logger->log($userId, 'telegram', $input, $headersStr, 401, "Unauthorized");
+    }
     http_response_code(401);
     echo "Unauthorized";
     exit;
 }
 
-$input = file_get_contents('php://input');
 $update = json_decode($input, true);
 
 if (!$update) {
+    if ($userId) {
+        $logger->log($userId, 'telegram', $input, $headersStr, 400, "Invalid Request");
+    }
     http_response_code(400);
     echo "Invalid Request";
     exit;
+}
+
+if ($userId) {
+    $logger->log($userId, 'telegram', $input, $headersStr, 200);
 }
 
 // Acknowledge Telegram immediately

--- a/src/frontend/webhook.php
+++ b/src/frontend/webhook.php
@@ -7,10 +7,16 @@ use App\Project;
 use App\WebhookHandler;
 use App\GitHubService;
 use App\RateLimiter;
+use App\WebhookLogger;
 
 $db = new Database();
 $rateLimiter = new RateLimiter($db);
 $ip = $rateLimiter->getIpAddress();
+$logger = new WebhookLogger($db);
+
+$headers = getallheaders();
+$headersStr = json_encode($headers);
+$payload = file_get_contents('php://input');
 
 if (!$rateLimiter->check("webhook_$ip", 100, 60)) {
     http_response_code(429);
@@ -19,7 +25,6 @@ if (!$rateLimiter->check("webhook_$ip", 100, 60)) {
 $projectModel = new Project($db);
 $handler = new WebhookHandler($db);
 
-$payload = file_get_contents('php://input');
 $signature = $_SERVER['HTTP_X_HUB_SIGNATURE_256'] ?? '';
 $event = $_SERVER['HTTP_X_GITHUB_EVENT'] ?? '';
 
@@ -55,6 +60,10 @@ foreach ($projects as $project) {
 }
 
 if (!$verified) {
+    // Log failure for the first project found as a fallback if we can't verify any
+    if (!empty($projects)) {
+        $logger->log($projects[0]['user_id'], 'github', $payload, $headersStr, 401, 'Invalid signature');
+    }
     http_response_code(401);
     exit('Invalid signature');
 }
@@ -65,9 +74,11 @@ if (!empty($matchingProject['github_token'])) {
 }
 
 if ($handler->handle($matchingProject, $data, $githubService)) {
+    $logger->log($matchingProject['user_id'], 'github', $payload, $headersStr, 200);
     http_response_code(200);
     echo 'OK';
 } else {
+    $logger->log($matchingProject['user_id'], 'github', $payload, $headersStr, 500, 'Failed to process event');
     http_response_code(500);
     echo 'Failed to process event';
 }

--- a/src/sql/patches/008_create_webhook_logs_table.sql
+++ b/src/sql/patches/008_create_webhook_logs_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS webhook_logs (
+    log_id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    endpoint VARCHAR(50) NOT NULL,
+    payload TEXT,
+    headers TEXT,
+    status_code INT,
+    error_message TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/test/Unit/WebhookLoggerTest.php
+++ b/test/Unit/WebhookLoggerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\WebhookLogger;
+use App\Database;
+use PDO;
+use Tests\TestDatabaseTrait;
+
+class WebhookLoggerTest extends TestCase
+{
+    use TestDatabaseTrait;
+
+    private $db;
+    private $pdo;
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->db = new Database(null, ':memory:');
+        Database::resetConnection();
+        $this->pdo = $this->db->getConnection();
+
+        // Create table for testing
+        $this->pdo->exec("CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY AUTOINCREMENT)");
+        $this->pdo->exec("INSERT INTO users (user_id) VALUES (1)");
+
+        $this->pdo->exec("DROP TABLE IF EXISTS webhook_logs");
+        $this->pdo->exec("CREATE TABLE webhook_logs (
+            log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            endpoint TEXT NOT NULL,
+            payload TEXT,
+            headers TEXT,
+            status_code INTEGER,
+            error_message TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )");
+
+        $this->logger = new WebhookLogger($this->db);
+    }
+
+    public function testLog()
+    {
+        $result = $this->logger->log(1, 'github', '{"foo":"bar"}', '{"Content-Type":"application/json"}', 200);
+        $this->assertTrue($result);
+
+        $logs = $this->logger->getLogsByUser(1);
+        $this->assertCount(1, $logs);
+        $this->assertEquals('github', $logs[0]['endpoint']);
+        $this->assertEquals('{"foo":"bar"}', $logs[0]['payload']);
+        $this->assertEquals(200, $logs[0]['status_code']);
+    }
+
+    public function testPruning()
+    {
+        // Log 6 items
+        for ($i = 1; $i <= 6; $i++) {
+            $this->logger->log(1, 'github', "payload $i", "headers $i", 200);
+            // Sleep a bit to ensure different timestamps if needed,
+            // though we use IDs for pruning too.
+            usleep(1000);
+        }
+
+        $logs = $this->logger->getLogsByUser(1);
+        $this->assertCount(5, $logs);
+        // The oldest one (payload 1) should be gone.
+        // Since we order by created_at DESC, log_id DESC, the newest is first.
+        $this->assertEquals('payload 6', $logs[0]['payload']);
+        $this->assertEquals('payload 2', $logs[4]['payload']);
+    }
+}


### PR DESCRIPTION
This change introduces a webhook logging system to assist with debugging. It stores the last 5 calls for each endpoint (GitHub and Telegram) per user. The logs are accessible via a new "Logging" tab in the Account Settings page, featuring a collapsible viewer for request headers and payloads.

Fixes #248

---
*PR created automatically by Jules for task [11661476312886306438](https://jules.google.com/task/11661476312886306438) started by @chatelao*