### PR TITLE
Optimize project loading and task statistics

### DIFF
--- a/scripts/backfill_github_state.php
+++ b/scripts/backfill_github_state.php
@@ -1,0 +1,24 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\Database;
+
+$db = new Database();
+$pdo = $db->getConnection();
+
+$stmt = $pdo->query("SELECT task_id, github_data FROM tasks WHERE github_state IS NULL OR github_state = 'open'");
+$tasks = $stmt->fetchAll();
+
+echo "Starting backfill for " . count($tasks) . " tasks...\n";
+
+$updateStmt = $pdo->prepare("UPDATE tasks SET github_state = ? WHERE task_id = ?");
+
+foreach ($tasks as $task) {
+    $data = json_decode($task['github_data'] ?? '{}', true);
+    $state = $data['state'] ?? 'open';
+    $updateStmt->execute([$state, $task['task_id']]);
+    echo "Task #{$task['task_id']}: github_state set to $state\n";
+}
+
+echo "Backfill complete.\n";

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -10,26 +10,65 @@ class Task
     {
     }
 
-    public function findByProjectId(int $projectId): array
+    public function findByProjectId(int $projectId, bool $showAll = true): array
     {
-        $stmt = $this->db->getConnection()->prepare(
-            "SELECT * FROM tasks WHERE project_id = ? ORDER BY created_at DESC"
-        );
+        $sql = "SELECT * FROM tasks WHERE project_id = ?";
+        if (!$showAll) {
+            $sql .= " AND (github_state = 'open' OR status NOT IN ('completed', 'failed'))";
+        }
+        $sql .= " ORDER BY created_at DESC";
+
+        $stmt = $this->db->getConnection()->prepare($sql);
         $stmt->execute([$projectId]);
         return $stmt->fetchAll();
     }
 
-    public function findByUserProjects(int $userId): array
+    public function findActiveByProjectId(int $projectId, bool $all = false): array
     {
-        $stmt = $this->db->getConnection()->prepare(
-            "SELECT t.*, p.github_repo
+        return $this->findByProjectId($projectId, $all);
+    }
+
+    public function findByUserProjects(int $userId, bool $showAll = true): array
+    {
+        $sql = "SELECT t.*, p.github_repo
              FROM tasks t
              JOIN projects p ON t.project_id = p.project_id
-             WHERE p.user_id = ?
-             ORDER BY t.created_at DESC"
-        );
+             WHERE p.user_id = ?";
+
+        if (!$showAll) {
+            $sql .= " AND (t.github_state = 'open' OR t.status NOT IN ('completed', 'failed'))";
+        }
+
+        $sql .= " ORDER BY t.created_at DESC";
+
+        $stmt = $this->db->getConnection()->prepare($sql);
         $stmt->execute([$userId]);
         return $stmt->fetchAll();
+    }
+
+    public function findActiveByUserProjects(int $userId): array
+    {
+        return $this->findByUserProjects($userId, false);
+    }
+
+    public function getTaskCounts(int $userId): array
+    {
+        $sql = "SELECT
+                    COUNT(*) as total,
+                    SUM(CASE WHEN github_state = 'open' THEN 1 ELSE 0 END) as open_issues,
+                    SUM(CASE WHEN github_state = 'closed' OR status = 'completed' THEN 1 ELSE 0 END) as completed_tasks
+                FROM tasks
+                WHERE user_id = ?";
+
+        $stmt = $this->db->getConnection()->prepare($sql);
+        $stmt->execute([$userId]);
+        $counts = $stmt->fetch();
+
+        return [
+            'total' => (int)($counts['total'] ?? 0),
+            'open_issues' => (int)($counts['open_issues'] ?? 0),
+            'completed_tasks' => (int)($counts['completed_tasks'] ?? 0)
+        ];
     }
 
     public function getRunningAutorepeatTasks(int $userId): array
@@ -109,7 +148,7 @@ class Task
     public function create(array $data): bool
     {
         $stmt = $this->db->getConnection()->prepare(
-            "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status) VALUES (?, ?, ?, ?, ?, ?, ?)"
+            "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
         );
         return $stmt->execute([
             $data['user_id'],
@@ -118,7 +157,8 @@ class Task
             $data['title'],
             $data['body'] ?? '',
             $data['github_data'] ?? null,
-            $data['status'] ?? 'pending'
+            $data['status'] ?? 'pending',
+            $data['github_state'] ?? 'open'
         ]);
     }
 
@@ -141,19 +181,21 @@ class Task
         $driver = $connection->getAttribute(PDO::ATTR_DRIVER_NAME);
 
         if ($driver === 'sqlite') {
-            $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
+            $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(project_id, issue_number) DO UPDATE SET
                         title = excluded.title,
                         body = excluded.body,
-                        github_data = excluded.github_data";
+                        github_data = excluded.github_data,
+                        github_state = excluded.github_state";
         } else {
-            $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
+            $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     ON DUPLICATE KEY UPDATE
                         title = VALUES(title),
                         body = VALUES(body),
-                        github_data = VALUES(github_data)";
+                        github_data = VALUES(github_data),
+                        github_state = VALUES(github_state)";
         }
 
         $stmt = $connection->prepare($sql);
@@ -165,7 +207,8 @@ class Task
             $issue['title'],
             $issue['body'],
             json_encode($issue),
-            'pending'
+            'pending',
+            $issue['state'] ?? 'open'
         ]);
     }
 

--- a/src/frontend/ajax-sync.php
+++ b/src/frontend/ajax-sync.php
@@ -58,28 +58,15 @@ try {
     $updatedUser = $userModel->findById($userId);
 
     // Calculate updated counts
-    $allUserTasks = $taskModel->findByUserProjects($userId);
-    $totalTasks = count($allUserTasks);
-    $openIssues = 0;
-    $completedTasks = 0;
-
-    foreach ($allUserTasks as $t) {
-        $ghData = json_decode($t['github_data'] ?? '{}', true);
-        if (($ghData['state'] ?? '') === 'open') {
-            $openIssues++;
-        }
-        if (($ghData['state'] ?? '') === 'closed' || ($t['status'] ?? '') === 'completed') {
-            $completedTasks++;
-        }
-    }
+    $counts = $taskModel->getTaskCounts($userId);
 
     echo json_encode([
         'status' => 'success',
         'quota_usage' => $updatedUser['jules_quota_usage'] ?? 0,
         'quota_limit' => $updatedUser['jules_quota_limit'] ?? 0,
-        'total_tasks' => $totalTasks,
-        'open_issues' => $openIssues,
-        'completed_tasks' => $completedTasks
+        'total_tasks' => $counts['total'],
+        'open_issues' => $counts['open_issues'],
+        'completed_tasks' => $counts['completed_tasks']
     ]);
 } catch (Exception $e) {
     http_response_code(500);

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -76,13 +76,9 @@ $autorepeatTasks = $user ? $taskModel->getRunningAutorepeatTasks($user['user_id'
 
 $projectTasks = [];
 if ($user) {
-    $allTasks = $taskModel->findByUserProjects($user['user_id']);
-    foreach ($allTasks as $task) {
-        $githubData = json_decode($task['github_data'] ?? '{}', true);
-        $state = $githubData['state'] ?? 'open';
-        if ($state !== 'closed' && $task['status'] !== 'completed') {
-            $projectTasks[$task['project_id']][] = $task;
-        }
+    $activeTasks = $taskModel->findActiveByUserProjects($user['user_id']);
+    foreach ($activeTasks as $task) {
+        $projectTasks[$task['project_id']][] = $task;
     }
 }
 

--- a/src/frontend/navbar-icons.php
+++ b/src/frontend/navbar-icons.php
@@ -4,20 +4,10 @@
 /** @var App\Task $taskModel */
 
 if ($user) {
-    $allUserTasks = $taskModel->findByUserProjects($user['user_id']);
-    $totalTasks = count($allUserTasks);
-    $openIssues = 0;
-    $completedTasks = 0;
-
-    foreach ($allUserTasks as $t) {
-        $ghData = json_decode($t['github_data'] ?? '{}', true);
-        if (($ghData['state'] ?? '') === 'open') {
-            $openIssues++;
-        }
-        if (($ghData['state'] ?? '') === 'closed' || ($t['status'] ?? '') === 'completed') {
-            $completedTasks++;
-        }
-    }
+    $counts = $taskModel->getTaskCounts($user['user_id']);
+    $totalTasks = $counts['total'];
+    $openIssues = $counts['open_issues'];
+    $completedTasks = $counts['completed_tasks'];
 
     $telegramConnected = (bool)$userModel->getTelegramChatId($user['user_id']);
 } else {

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -41,7 +41,8 @@ if (!$project || $project['user_id'] !== $user['user_id']) {
 $templateModel = new IssueTemplate($db);
 $templates = $templateModel->findByUserId($user['user_id']);
 
-$tasks = $taskModel->findByProjectId($projectId);
+$showAll = isset($_GET['all']) && $_GET['all'] == '1';
+$tasks = $taskModel->findByProjectId($projectId, $showAll);
 $lastAgentResponse = null;
 $errorMessage = null;
 
@@ -86,7 +87,7 @@ $triggerAgent = function($taskId) use ($taskModel, $logger, $user, $project, $ju
             }
 
             // Refresh tasks
-            $tasks = $taskModel->findByProjectId($projectId);
+            $tasks = $taskModel->findByProjectId($projectId, $showAll);
         } catch (\Exception $e) {
             $errorMessage = "Error triggering agent: " . $e->getMessage();
             $logger->log($user['user_id'], $taskId, "Error: " . $e->getMessage(), "error");
@@ -442,7 +443,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
 
                         <div class="lg:col-span-3 p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                             <div class="flex justify-between items-center mb-4">
-                                <h3 class="text-lg font-bold text-gray-900">Tasks synced from GitHub</h3>
+                                <div class="flex items-center space-x-4">
+                                    <h3 class="text-lg font-bold text-gray-900">Tasks synced from GitHub</h3>
+                                    <a href="?id=<?= $projectId ?>&all=<?= $showAll ? '0' : '1' ?>" class="text-xs text-blue-600 hover:underline">
+                                        <?= $showAll ? 'Show Only Active' : 'Show All' ?>
+                                    </a>
+                                </div>
                                 <form method="POST">
                                     <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                     <button type="submit" name="sync_issues" class="text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none">Sync Issues</button>

--- a/src/sql/patches/009_add_github_state_to_tasks.sql
+++ b/src/sql/patches/009_add_github_state_to_tasks.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tasks ADD COLUMN github_state VARCHAR(20) DEFAULT 'open';
+CREATE INDEX idx_tasks_github_state ON tasks(github_state);
+CREATE INDEX idx_tasks_project_id ON tasks(project_id);
+CREATE INDEX idx_tasks_user_id ON tasks(user_id);

--- a/test/Integration/IssueSyncIntegrationTest.php
+++ b/test/Integration/IssueSyncIntegrationTest.php
@@ -26,6 +26,7 @@ class IssueSyncIntegrationTest extends TestCase
             title VARCHAR(255) NOT NULL,
             body TEXT,
             status TEXT DEFAULT 'pending',
+            github_state VARCHAR(20) DEFAULT 'open',
             github_data TEXT,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/test/Integration/TaskDBIntegrationTest.php
+++ b/test/Integration/TaskDBIntegrationTest.php
@@ -34,6 +34,7 @@ class TaskDBIntegrationTest extends TestCase
             title VARCHAR(255) NOT NULL,
             body TEXT,
             status TEXT DEFAULT 'pending',
+            github_state VARCHAR(20) DEFAULT 'open',
             github_data TEXT,
             created_at $timestamp,
             updated_at $timestamp,

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -26,6 +26,7 @@ class WebhookHandlerTest extends TestCase
             title VARCHAR(255) NOT NULL,
             body TEXT,
             status TEXT DEFAULT 'pending',
+            github_state VARCHAR(20) DEFAULT 'open',
             github_data TEXT,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/test/Integration/verify_project_ui.php
+++ b/test/Integration/verify_project_ui.php
@@ -60,6 +60,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     title VARCHAR(255) NOT NULL,
     body TEXT,
     status TEXT DEFAULT 'pending',
+    github_state VARCHAR(20) DEFAULT 'open',
     github_data TEXT,
     agent_response TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/test/Unit/Services/LoggerTest.php
+++ b/test/Unit/Services/LoggerTest.php
@@ -22,7 +22,7 @@ class LoggerTest extends TestCase
     private function createSchema(): void
     {
         $pdo = $this->db->getConnection();
-        $pdo->exec("CREATE TABLE tasks (task_id INTEGER PRIMARY KEY, user_id INTEGER, project_id INTEGER, issue_number INTEGER, title TEXT, status TEXT)");
+        $pdo->exec("CREATE TABLE tasks (task_id INTEGER PRIMARY KEY, user_id INTEGER, project_id INTEGER, issue_number INTEGER, title TEXT, status TEXT, github_state TEXT)");
         $pdo->exec("CREATE TABLE task_logs (task_log_id INTEGER PRIMARY KEY, user_id INTEGER, task_id INTEGER, level TEXT, message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
     }
 


### PR DESCRIPTION
This change significantly improves the performance of the dashboard and project details pages by reducing the amount of data fetched and processed. By adding a `github_state` column to the `tasks` table, we can now filter for active tasks directly in the database instead of decoding JSON in PHP. The dashboard now only shows active tasks in the project tiles, and the project page defaults to showing only open/incomplete tasks with an option to view the full history. Navigation bar statistics are now fetched using a single optimized SQL query.

Fixes #260

---
*PR created automatically by Jules for task [6912717637074537668](https://jules.google.com/task/6912717637074537668) started by @chatelao*