### PR TITLE
Fix PHP deprecation warnings for htmlspecialchars

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -137,7 +137,7 @@ $errorMessage = $errorMessage ?? null;
                                     <img class="w-8 h-8 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="user photo">
                                 </button>
                             </div>
-                            <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name']) ?></div>
+                            <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name'] ?? '') ?></div>
                             <a href="templates.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Templates</a>
                             <a href="settings.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Settings</a>
                             <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
@@ -156,7 +156,7 @@ $errorMessage = $errorMessage ?? null;
                 <div class="px-4 pt-6">
                     <?php if ($errorMessage): ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
-                            <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
+                            <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage ?? '') ?>
                         </div>
                     <?php endif; ?>
 
@@ -176,14 +176,14 @@ $errorMessage = $errorMessage ?? null;
                                         <?php foreach ($autorepeatTasks as $task): ?>
                                             <tr class="bg-white border-b">
                                                 <td class="px-6 py-4 font-medium text-gray-900">
-                                                    <a href="https://github.com/<?= htmlspecialchars($task['github_repo']) ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
-                                                        <?= htmlspecialchars($task['github_repo']) ?>
+                                                    <a href="https://github.com/<?= htmlspecialchars($task['github_repo'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
+                                                        <?= htmlspecialchars($task['github_repo'] ?? '') ?>
                                                     </a>
                                                 </td>
                                                 <td class="px-6 py-4 font-normal">
-                                                    <a href="https://github.com/<?= htmlspecialchars($task['github_repo']) ?>/issues/<?= htmlspecialchars($task['issue_number']) ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">#<?= htmlspecialchars($task['issue_number']) ?></a>
+                                                    <a href="https://github.com/<?= htmlspecialchars($task['github_repo'] ?? '') ?>/issues/<?= htmlspecialchars($task['issue_number'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">#<?= htmlspecialchars($task['issue_number'] ?? '') ?></a>
                                                     <a href="<?= htmlspecialchars($taskModel->getTargetUrl($task)) ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
-                                                        <?= htmlspecialchars($task['title']) ?>
+                                                        <?= htmlspecialchars($task['title'] ?? '') ?>
                                                     </a>
                                                 </td>
                                                 <td class="px-6 py-4">
@@ -208,8 +208,8 @@ $errorMessage = $errorMessage ?? null;
                                             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                                                 <div class="flex justify-between items-start">
                                                     <h5 class="text-lg font-bold text-gray-900 truncate">
-                                                        <a href="https://github.com/<?= htmlspecialchars($project['github_repo']) ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
-                                                            <?= htmlspecialchars($project['github_repo']) ?>
+                                                        <a href="https://github.com/<?= htmlspecialchars($project['github_repo'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
+                                                            <?= htmlspecialchars($project['github_repo'] ?? '') ?>
                                                         </a>
                                                     </h5>
                                                     <a href="?delete_project=<?= $project['project_id'] ?>&csrf_token=<?= $auth->getCsrfToken() ?>" class="text-red-600 hover:text-red-800" onclick="return confirm('Are you sure?')">
@@ -220,7 +220,7 @@ $errorMessage = $errorMessage ?? null;
                                                 $repoParts = explode('/', $project['github_repo']);
                                                 $repoOwner = $repoParts[0] ?? '';
                                                 if (strcasecmp($repoOwner, $project['github_username']) !== 0): ?>
-                                                    <p class="text-sm text-gray-500 mt-1">Linked as&nbsp;<?= htmlspecialchars($project['github_username']) ?></p>
+                                                    <p class="text-sm text-gray-500 mt-1">Linked as&nbsp;<?= htmlspecialchars($project['github_username'] ?? '') ?></p>
                                                 <?php endif; ?>
 
                                                 <div class="flex flex-wrap gap-2 mt-3">
@@ -243,7 +243,7 @@ $errorMessage = $errorMessage ?? null;
                                                                class="status-square <?= $color ?> <?= $isAutorepeat ? 'auto-repeat-tag' : '' ?>">
                                                             </a>
                                                             <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-[10px] rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
-                                                                #<?= htmlspecialchars($task['issue_number']) ?>: <?= $emoji ?> <?= htmlspecialchars(mb_substr($task['title'], 0, 30)) ?><?= mb_strlen($task['title']) > 30 ? '...' : '' ?>
+                                                                #<?= htmlspecialchars($task['issue_number'] ?? '') ?>: <?= $emoji ?> <?= htmlspecialchars(mb_substr($task['title'] ?? '', 0, 30)) ?><?= mb_strlen($task['title'] ?? '') > 30 ? '...' : '' ?>
                                                             </div>
                                                         </div>
                                                     <?php endforeach; ?>
@@ -266,7 +266,7 @@ $errorMessage = $errorMessage ?? null;
                                                         <label class="block mb-1 text-xs font-medium text-gray-900">GitHub Account</label>
                                                         <select name="github_account_id" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                                             <?php foreach ($githubAccounts as $account): ?>
-                                                                <option value="<?= $account['github_account_id'] ?>"><?= htmlspecialchars($account['github_username']) ?></option>
+                                                                <option value="<?= $account['github_account_id'] ?>"><?= htmlspecialchars($account['github_username'] ?? '') ?></option>
                                                             <?php endforeach; ?>
                                                         </select>
                                                     </div>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -272,7 +272,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                     <?php include 'navbar-icons.php'; ?>
                     <div class="flex items-center ml-3">
                         <img class="w-8 h-8 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="user photo">
-                        <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name']) ?></div>
+                        <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name'] ?? '') ?></div>
                         <a href="templates.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Templates</a>
                         <a href="settings.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Settings</a>
                         <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
@@ -297,8 +297,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                             <li>
                                 <div class="flex items-center">
                                     <svg class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
-                                    <a href="https://github.com/<?= htmlspecialchars($project['github_repo']) ?>" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-gray-900 ml-1 md:ml-2 font-medium hover:underline">
-                                        <?= htmlspecialchars($project['github_repo']) ?>
+                                    <a href="https://github.com/<?= htmlspecialchars($project['github_repo'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-gray-900 ml-1 md:ml-2 font-medium hover:underline">
+                                        <?= htmlspecialchars($project['github_repo'] ?? '') ?>
                                     </a>
                                 </div>
                             </li>
@@ -307,8 +307,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
 
                     <div class="mb-4">
                         <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">
-                            <a href="https://github.com/<?= htmlspecialchars($project['github_repo']) ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
-                                <?= htmlspecialchars($project['github_repo']) ?>
+                            <a href="https://github.com/<?= htmlspecialchars($project['github_repo'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
+                                <?= htmlspecialchars($project['github_repo'] ?? '') ?>
                             </a>
                         </h1>
                     </div>
@@ -323,7 +323,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
 
                     <?php if ($errorMessage): ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
-                            <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
+                            <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage ?? '') ?>
                         </div>
                     <?php endif; ?>
 
@@ -344,7 +344,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                         <div class="p-4 mb-4 text-sm text-blue-800 rounded-lg bg-blue-50" role="alert">
                             <span class="font-medium">Agent Response:</span>
                             <div class="mt-2 p-2 bg-white rounded border border-blue-200 whitespace-pre-wrap font-mono text-xs">
-                                <?= htmlspecialchars($lastAgentResponse) ?>
+                                <?= htmlspecialchars($lastAgentResponse ?? '') ?>
                             </div>
                         </div>
                     <?php endif; ?>
@@ -359,13 +359,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                     <ul class="space-y-2">
                                         <?php foreach ($roadmapFiles as $file): ?>
                                             <li class="flex flex-col">
-                                                <a href="<?= htmlspecialchars($file['html_url']) ?>" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-600 hover:underline flex items-center">
+                                                <a href="<?= htmlspecialchars($file['html_url'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-600 hover:underline flex items-center">
                                                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
-                                                    <?= htmlspecialchars($file['name']) ?>
+                                                    <?= htmlspecialchars($file['name'] ?? '') ?>
                                                 </a>
                                                 <?php if (!empty($file['next_task'])): ?>
                                                     <span class="text-[10px] text-gray-500 ml-6 italic">
-                                                        🚧 <?= htmlspecialchars($file['next_task']) ?>
+                                                        🚧 <?= htmlspecialchars($file['next_task'] ?? '') ?>
                                                     </span>
                                                 <?php endif; ?>
                                             </li>
@@ -386,7 +386,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                     <div>
                                         <label class="block text-xs font-medium text-gray-500 uppercase">Secret</label>
                                         <div class="mt-1 flex">
-                                            <input type="text" readonly value="<?= htmlspecialchars($project['webhook_secret']) ?>" class="bg-gray-50 border border-gray-300 text-gray-900 text-xs rounded-lg block w-full p-2" id="webhook-secret">
+                                            <input type="text" readonly value="<?= htmlspecialchars($project['webhook_secret'] ?? '') ?>" class="bg-gray-50 border border-gray-300 text-gray-900 text-xs rounded-lg block w-full p-2" id="webhook-secret">
                                         </div>
                                     </div>
                                     <p class="text-[10px] text-gray-500">
@@ -419,7 +419,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                             <label class="block mb-2 text-sm font-medium text-gray-900">Select Template</label>
                                             <select name="template_id" x-model="selectedTemplateId" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                                 <?php foreach ($templates as $tmpl): ?>
-                                                    <option value="<?= $tmpl['issue_template_id'] ?>"><?= htmlspecialchars($tmpl['name']) ?></option>
+                                                    <option value="<?= $tmpl['issue_template_id'] ?>"><?= htmlspecialchars($tmpl['name'] ?? '') ?></option>
                                                 <?php endforeach; ?>
                                             </select>
                                         </div>
@@ -474,9 +474,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                             <tr class="bg-white border-b">
                                                 <td class="px-6 py-4">
                                                     <div class="text-base text-gray-900 font-normal">
-                                                        <a href="task.php?id=<?= $task['task_id'] ?>" class="hover:underline">#<?= htmlspecialchars($task['issue_number']) ?></a>
+                                                        <a href="task.php?id=<?= $task['task_id'] ?>" class="hover:underline">#<?= htmlspecialchars($task['issue_number'] ?? '') ?></a>
                                                         <a href="<?= htmlspecialchars($taskModel->getTargetUrl($task, $project['github_repo'])) ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
-                                                            <?= htmlspecialchars($task['title']) ?>
+                                                            <?= htmlspecialchars($task['title'] ?? '') ?>
                                                         </a>
                                                     </div>
                                                     <div class="text-xs text-gray-500"><?= htmlspecialchars(mb_substr($task['body'] ?? '', 0, 100)) ?>...</div>
@@ -500,7 +500,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                         elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) echo '🚧 ';
                                                         else echo '⏳ ';
                                                         ?>
-                                                        <?= htmlspecialchars($task['status']) ?>
+                                                        <?= htmlspecialchars($task['status'] ?? '') ?>
                                                     </span>
                                                 </td>
                                                 <td class="px-6 py-4">
@@ -512,8 +512,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                         <?php else: ?>
                                                             <?php foreach ($taskLogs as $log): ?>
                                                                 <div class="mb-1">
-                                                                    <span class="text-gray-400">[<?= htmlspecialchars(date('H:i:s', strtotime($log['created_at']))) ?>]</span>
-                                                                    <span class="<?= $log['level'] === 'error' ? 'text-red-600 font-bold' : 'text-gray-700' ?>"><?= htmlspecialchars($log['message']) ?></span>
+                                                                    <span class="text-gray-400">[<?= htmlspecialchars(date('H:i:s', strtotime($log['created_at'] ?? 'now'))) ?>]</span>
+                                                                    <span class="<?= $log['level'] === 'error' ? 'text-red-600 font-bold' : 'text-gray-700' ?>"><?= htmlspecialchars($log['message'] ?? '') ?></span>
                                                                 </div>
                                                             <?php endforeach; ?>
                                                         <?php endif; ?>

--- a/src/frontend/settings.php
+++ b/src/frontend/settings.php
@@ -81,7 +81,7 @@ $errorMessage = $errorMessage ?? null;
                     <?php endif; ?>
                     <div class="flex items-center ml-3">
                         <img class="w-8 h-8 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="user photo">
-                        <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name']) ?></div>
+                        <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name'] ?? '') ?></div>
                         <a href="templates.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Templates</a>
                         <a href="settings.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Settings</a>
                         <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
@@ -140,7 +140,7 @@ $errorMessage = $errorMessage ?? null;
 
                     <?php if ($errorMessage): ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
-                            <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
+                            <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage ?? '') ?>
                         </div>
                     <?php endif; ?>
 
@@ -182,7 +182,7 @@ $errorMessage = $errorMessage ?? null;
                                         <?php foreach ($githubAccounts as $account): ?>
                                             <div class="flex items-center text-green-600">
                                                 <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-                                                Linked as&nbsp;<strong><?= htmlspecialchars($account['github_username']) ?></strong>
+                                                Linked as&nbsp;<strong><?= htmlspecialchars($account['github_username'] ?? '') ?></strong>
                                             </div>
                                         <?php endforeach; ?>
                                     <?php endif; ?>
@@ -215,14 +215,14 @@ $errorMessage = $errorMessage ?? null;
                                         <tbody>
                                             <?php foreach ($webhookLogs as $log): ?>
                                                 <tr class="bg-white border-b hover:bg-gray-50" x-data="{ open: false }">
-                                                    <td class="px-6 py-4 whitespace-nowrap"><?= htmlspecialchars($log['created_at']) ?></td>
-                                                    <td class="px-6 py-4 uppercase font-mono text-xs"><?= htmlspecialchars($log['endpoint']) ?></td>
+                                                    <td class="px-6 py-4 whitespace-nowrap"><?= htmlspecialchars($log['created_at'] ?? '') ?></td>
+                                                    <td class="px-6 py-4 uppercase font-mono text-xs"><?= htmlspecialchars($log['endpoint'] ?? '') ?></td>
                                                     <td class="px-6 py-4">
-                                                        <span class="px-2.5 py-0.5 rounded-full text-xs font-medium <?= $log['status_code'] >= 200 && $log['status_code'] < 300 ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' ?>">
-                                                            <?= (int)$log['status_code'] ?>
+                                                        <span class="px-2.5 py-0.5 rounded-full text-xs font-medium <?= ($log['status_code'] ?? 0) >= 200 && ($log['status_code'] ?? 0) < 300 ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' ?>">
+                                                            <?= (int)($log['status_code'] ?? 0) ?>
                                                         </span>
                                                         <?php if ($log['error_message']): ?>
-                                                            <div class="text-xs text-red-600 mt-1"><?= htmlspecialchars($log['error_message']) ?></div>
+                                                            <div class="text-xs text-red-600 mt-1"><?= htmlspecialchars($log['error_message'] ?? '') ?></div>
                                                         <?php endif; ?>
                                                     </td>
                                                     <td class="px-6 py-4">
@@ -233,13 +233,13 @@ $errorMessage = $errorMessage ?? null;
                                                             $headers = json_decode($log['headers'] ?? '{}', true);
                                                             $headersJson = $headers ? json_encode($headers, JSON_PRETTY_PRINT) : ($log['headers'] ?? '');
                                                             ?>
-                                                            <pre><?= htmlspecialchars($headersJson) ?></pre>
+                                                            <pre><?= htmlspecialchars($headersJson ?? '') ?></pre>
                                                             <div class="mt-4 mb-2 border-b border-gray-700 pb-1 text-gray-400">Payload:</div>
                                                             <?php
                                                             $payload = json_decode($log['payload'] ?? '{}', true);
                                                             $payloadJson = $payload ? json_encode($payload, JSON_PRETTY_PRINT) : ($log['payload'] ?? '');
                                                             ?>
-                                                            <pre><?= htmlspecialchars($payloadJson) ?></pre>
+                                                            <pre><?= htmlspecialchars($payloadJson ?? '') ?></pre>
                                                         </div>
                                                     </td>
                                                 </tr>

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -45,7 +45,7 @@ $logs = $taskModel->getLogs($taskId);
     <meta charset="UTF-8">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Task #<?= htmlspecialchars($task['issue_number']) ?> - Agent Control</title>
+    <title>Task #<?= htmlspecialchars($task['issue_number'] ?? '') ?> - Agent Control</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
@@ -61,7 +61,7 @@ $logs = $taskModel->getLogs($taskId);
                     <?php include 'navbar-icons.php'; ?>
                     <div class="flex items-center ml-3">
                         <img class="w-8 h-8 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="user photo">
-                        <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name']) ?></div>
+                        <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name'] ?? '') ?></div>
                         <a href="templates.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Templates</a>
                         <a href="settings.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Settings</a>
                         <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
@@ -87,14 +87,14 @@ $logs = $taskModel->getLogs($taskId);
                                 <div class="flex items-center">
                                     <svg class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
                                     <a href="project.php?id=<?= $project['project_id'] ?>" class="text-gray-700 hover:text-gray-900 ml-1 md:ml-2 font-medium">
-                                        <?= htmlspecialchars($project['github_repo']) ?>
+                                        <?= htmlspecialchars($project['github_repo'] ?? '') ?>
                                     </a>
                                 </div>
                             </li>
                             <li aria-current="page">
                                 <div class="flex items-center">
                                     <svg class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
-                                    <span class="text-gray-400 ml-1 md:ml-2 font-medium">Task #<?= htmlspecialchars($task['issue_number']) ?></span>
+                                    <span class="text-gray-400 ml-1 md:ml-2 font-medium">Task #<?= htmlspecialchars($task['issue_number'] ?? '') ?></span>
                                 </div>
                             </li>
                         </ol>
@@ -104,7 +104,7 @@ $logs = $taskModel->getLogs($taskId);
                         <div class="lg:col-span-2 space-y-4">
                             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                                 <div class="flex justify-between items-start mb-4">
-                                    <h1 class="text-2xl font-bold text-gray-900"><?= htmlspecialchars($task['title']) ?></h1>
+                                    <h1 class="text-2xl font-bold text-gray-900"><?= htmlspecialchars($task['title'] ?? '') ?></h1>
                                     <span class="px-3 py-1 text-sm font-medium rounded-full bg-<?= $statusColor ?>-100 text-<?= $statusColor ?>-800 flex items-center">
                                         <?php
                                         if ($task['status'] === 'completed') echo '✅ ';
@@ -113,27 +113,27 @@ $logs = $taskModel->getLogs($taskId);
                                         elseif (in_array($task['status'], ['researching', 'planning', 'awaiting-plan-approval', 'awaiting-user-feedback'])) echo '🔵 ';
                                         else echo '⏳ ';
                                         ?>
-                                        <?= htmlspecialchars($task['status']) ?>
+                                        <?= htmlspecialchars($task['status'] ?? '') ?>
                                     </span>
                                 </div>
 
                                 <div class="flex flex-wrap gap-2 mb-6">
                                     <?php foreach ($labels as $label): ?>
                                         <span class="px-2 py-1 text-xs font-semibold rounded" style="background-color: #<?= $label['color'] ?>; color: <?= (hexdec($label['color']) > 0xffffff/2) ? 'black' : 'white' ?>">
-                                            <?= htmlspecialchars($label['name']) ?>
+                                            <?= htmlspecialchars($label['name'] ?? '') ?>
                                         </span>
                                     <?php endforeach; ?>
                                 </div>
 
                                 <div class="prose max-w-none text-gray-700 whitespace-pre-wrap bg-gray-50 p-4 rounded-lg border border-gray-100 mb-6">
-                                    <?= htmlspecialchars($task['body']) ?>
+                                    <?= htmlspecialchars($task['body'] ?? '') ?>
                                 </div>
 
                                 <?php if (!empty($task['agent_response'])): ?>
                                     <div class="mt-8">
                                         <h3 class="text-lg font-bold text-gray-900 mb-4">Last Agent Response</h3>
                                         <div class="p-4 bg-blue-50 border border-blue-100 rounded-lg whitespace-pre-wrap font-mono text-sm text-blue-900">
-                                            <?= htmlspecialchars($task['agent_response']) ?>
+                                            <?= htmlspecialchars($task['agent_response'] ?? '') ?>
                                         </div>
                                     </div>
                                 <?php endif; ?>
@@ -147,8 +147,8 @@ $logs = $taskModel->getLogs($taskId);
                                     <?php else: ?>
                                         <?php foreach ($logs as $log): ?>
                                             <div class="flex items-start text-xs font-mono p-2 rounded <?= $log['level'] === 'error' ? 'bg-red-50 text-red-700' : 'bg-gray-50 text-gray-700' ?>">
-                                                <span class="text-gray-400 mr-3">[<?= htmlspecialchars($log['created_at']) ?>]</span>
-                                                <span class="flex-1"><?= htmlspecialchars($log['message']) ?></span>
+                                                <span class="text-gray-400 mr-3">[<?= htmlspecialchars($log['created_at'] ?? '') ?>]</span>
+                                                <span class="flex-1"><?= htmlspecialchars($log['message'] ?? '') ?></span>
                                             </div>
                                         <?php endforeach; ?>
                                     <?php endif; ?>
@@ -161,14 +161,14 @@ $logs = $taskModel->getLogs($taskId);
                                 <h3 class="text-lg font-bold text-gray-900 mb-4">Links & Status</h3>
                                 <ul class="space-y-3">
                                     <li>
-                                        <a href="https://github.com/<?= htmlspecialchars($project['github_repo']) ?>/issues/<?= htmlspecialchars($task['issue_number']) ?>" target="_blank" rel="noopener noreferrer" class="flex items-center text-blue-600 hover:underline">
+                                        <a href="https://github.com/<?= htmlspecialchars($project['github_repo'] ?? '') ?>/issues/<?= htmlspecialchars($task['issue_number'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="flex items-center text-blue-600 hover:underline">
                                             <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
                                             View on GitHub Issue
                                         </a>
                                     </li>
                                     <?php if (!empty($task['pr_url'])): ?>
                                         <li>
-                                            <a href="<?= htmlspecialchars($task['pr_url']) ?>" target="_blank" rel="noopener noreferrer" class="flex items-center text-green-600 hover:underline font-bold">
+                                            <a href="<?= htmlspecialchars($task['pr_url'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="flex items-center text-green-600 hover:underline font-bold">
                                                 <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24"><path d="M11 19.25c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM11 14.5c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM11 9.75c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 19.25c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 14.5c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 9.75c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM20.5 2h-17C2.673 2 2 2.673 2 3.5v17c0 .827.673 1.5 1.5 1.5h17c.827 0 1.5-.673 1.5-1.5v-17C22 2.673 21.327 2 20.5 2zM20 18H4V4h16v14z"/></svg>
                                                 View Pull Request
                                             </a>
@@ -176,7 +176,7 @@ $logs = $taskModel->getLogs($taskId);
                                     <?php endif; ?>
                                     <?php if (!empty($task['jules_url'])): ?>
                                         <li>
-                                            <a href="<?= htmlspecialchars($task['jules_url']) ?>" target="_blank" rel="noopener noreferrer" class="flex items-center text-purple-600 hover:underline">
+                                            <a href="<?= htmlspecialchars($task['jules_url'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="flex items-center text-purple-600 hover:underline">
                                                 <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .52 5.586 3.004 3.004 0 0 0 5.193 2.019A4 4 0 0 1 12 18c.35 0 .692.045 1.02.13a3.004 3.004 0 0 0 5.193-2.019 4 4 0 0 0 .52-5.586 4 4 0 0 0-2.526-5.77A3 3 0 1 0 12 5M9 14.5a2.5 2.5 0 0 0 2.46-2.019M15 14.5a2.5 2.5 0 0 1-2.46-2.019"/></svg>
                                                 View Jules Session
                                             </a>
@@ -186,10 +186,10 @@ $logs = $taskModel->getLogs($taskId);
 
                                 <div class="mt-6 pt-6 border-t border-gray-100">
                                     <div class="text-xs text-gray-500 space-y-1">
-                                        <p>Created: <?= htmlspecialchars($task['created_at']) ?></p>
+                                        <p>Created: <?= htmlspecialchars($task['created_at'] ?? '') ?></p>
                                         <p>Last Synced: <?= htmlspecialchars($task['last_synced_at'] ?? 'Never') ?></p>
                                         <?php if (!empty($task['jules_session_id'])): ?>
-                                            <p>Jules Session ID: <span class="font-mono"><?= htmlspecialchars($task['jules_session_id']) ?></span></p>
+                                            <p>Jules Session ID: <span class="font-mono"><?= htmlspecialchars($task['jules_session_id'] ?? '') ?></span></p>
                                         <?php endif; ?>
                                     </div>
                                 </div>
@@ -197,8 +197,8 @@ $logs = $taskModel->getLogs($taskId);
 
                             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                                 <h3 class="text-lg font-bold text-gray-900 mb-4">Project</h3>
-                                <p class="text-sm font-medium text-gray-900 mb-1"><?= htmlspecialchars($project['github_repo']) ?></p>
-                                <p class="text-xs text-gray-500 mb-4">Linked account: <?= htmlspecialchars($project['github_username']) ?></p>
+                                <p class="text-sm font-medium text-gray-900 mb-1"><?= htmlspecialchars($project['github_repo'] ?? '') ?></p>
+                                <p class="text-xs text-gray-500 mb-4">Linked account: <?= htmlspecialchars($project['github_username'] ?? '') ?></p>
                                 <a href="project.php?id=<?= $project['project_id'] ?>" class="text-blue-600 hover:underline text-sm font-medium">Back to Project &rarr;</a>
                             </div>
                         </div>


### PR DESCRIPTION
Added null coalescing operators (`?? ''`) to all `htmlspecialchars()` calls in frontend files (`index.php`, `project.php`, `settings.php`, `task.php`) to prevent PHP 8.1+ deprecation warnings when null values are passed from the database or optional fields. All 101 existing tests passed.

Fixes #265

---
*PR created automatically by Jules for task [12562219559056442800](https://jules.google.com/task/12562219559056442800) started by @chatelao*