### PR TITLE
Responsive tooltip title width on dashboard

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -242,8 +242,8 @@ $errorMessage = $errorMessage ?? null;
                                                             <a href="task.php?id=<?= $task['task_id'] ?>"
                                                                class="status-square <?= $color ?> <?= $isAutorepeat ? 'auto-repeat-tag' : '' ?>">
                                                             </a>
-                                                            <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-[10px] rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
-                                                                #<?= htmlspecialchars($task['issue_number']) ?>: <?= $emoji ?> <?= htmlspecialchars(mb_substr($task['title'], 0, 30)) ?><?= mb_strlen($task['title']) > 30 ? '...' : '' ?>
+                                                            <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-[10px] rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 shadow-lg max-w-[calc(100vw_-_2rem)] truncate">
+                                                                #<?= htmlspecialchars($task['issue_number']) ?>: <?= $emoji ?> <?= htmlspecialchars($task['title']) ?>
                                                             </div>
                                                         </div>
                                                     <?php endforeach; ?>


### PR DESCRIPTION
This change improves the usability of the dashboard by allowing users to see more of the issue title when hovering over task status squares. Previously, titles were arbitrarily truncated at 30 characters in the backend. Now, the full title is sent to the frontend, and CSS handles truncation based on the user's viewport width.

Key changes:
- Updated `src/frontend/index.php` to remove `mb_substr` truncation logic.
- Added Tailwind `truncate` and `max-w-[calc(100vw_-_2rem)]` classes to the tooltip container.
- Verified the fix across different viewport widths using Playwright.

Fixes #270

---
*PR created automatically by Jules for task [2005861066685523115](https://jules.google.com/task/2005861066685523115) started by @chatelao*