### PR TITLE
Show full issue title in dashboard tooltips

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -242,8 +242,8 @@ $errorMessage = $errorMessage ?? null;
                                                             <a href="task.php?id=<?= $task['task_id'] ?>"
                                                                class="status-square <?= $color ?> <?= $isAutorepeat ? 'auto-repeat-tag' : '' ?>">
                                                             </a>
-                                                            <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-[10px] rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
-                                                                #<?= htmlspecialchars($task['issue_number']) ?>: <?= $emoji ?> <?= htmlspecialchars(mb_substr($task['title'], 0, 30)) ?><?= mb_strlen($task['title']) > 30 ? '...' : '' ?>
+                                                            <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-[10px] rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50 shadow-lg w-max max-w-[90vw] break-words text-center">
+                                                                #<?= htmlspecialchars($task['issue_number']) ?>: <?= $emoji ?> <?= htmlspecialchars($task['title']) ?>
                                                             </div>
                                                         </div>
                                                     <?php endforeach; ?>


### PR DESCRIPTION
This change improves the user experience on the dashboard by displaying the full issue title in the hover tooltips for project tasks. Previously, titles were hard-truncated at 30 characters in PHP.

Key changes:
- Modified `src/frontend/index.php` to output the full `htmlspecialchars($task['title'])`.
- Replaced `whitespace-nowrap` with `w-max`, `max-w-[90vw]`, and `break-words` in the tooltip's CSS classes to ensure it respects screen width and wraps text when necessary.
- Added `text-center` to the tooltip for better alignment.
- Verified the fix with Playwright screenshots showing both wide and narrow viewport behaviors.

Fixes #271

---
*PR created automatically by Jules for task [809922641702290878](https://jules.google.com/task/809922641702290878) started by @chatelao*