### PR TITLE
Remove "Logs" column from project tasks table

### DIFF
--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -521,14 +521,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                         <tr>
                                             <th scope="col" class="px-6 py-3">Issue</th>
                                             <th scope="col" class="px-6 py-3">Status</th>
-                                            <th scope="col" class="px-6 py-3">Logs</th>
                                             <th scope="col" class="px-6 py-3">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         <?php if (empty($tasks)): ?>
                                             <tr class="bg-white border-b">
-                                                <td colspan="4" class="px-6 py-4 text-center">No tasks found. Open an issue on GitHub to see it here.</td>
+                                                <td colspan="3" class="px-6 py-4 text-center">No tasks found. Open an issue on GitHub to see it here.</td>
                                             </tr>
                                         <?php endif; ?>
                                         <?php foreach ($tasks as $task): ?>
@@ -563,22 +562,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                         ?>
                                                         <?= htmlspecialchars($task['status'] ?? '') ?>
                                                     </span>
-                                                </td>
-                                                <td class="px-6 py-4">
-                                                    <div class="max-h-32 overflow-y-auto text-[10px] font-mono bg-gray-50 p-2 rounded border border-gray-100">
-                                                        <?php
-                                                        $taskLogs = $taskModel->getLogs($task['task_id']);
-                                                        if (empty($taskLogs)): ?>
-                                                            <span class="text-gray-400 italic">No logs available.</span>
-                                                        <?php else: ?>
-                                                            <?php foreach ($taskLogs as $log): ?>
-                                                                <div class="mb-1">
-                                                                    <span class="text-gray-400">[<?= htmlspecialchars(date('H:i:s', strtotime($log['created_at'] ?? 'now'))) ?>]</span>
-                                                                    <span class="<?= $log['level'] === 'error' ? 'text-red-600 font-bold' : 'text-gray-700' ?>"><?= htmlspecialchars($log['message'] ?? '') ?></span>
-                                                                </div>
-                                                            <?php endforeach; ?>
-                                                        <?php endif; ?>
-                                                    </div>
                                                 </td>
                                                 <td class="px-6 py-4">
                                                     <div class="flex flex-col space-y-2">


### PR DESCRIPTION
I have removed the "Logs" column from the tasks table on the project details page (`src/frontend/project.php`). This was done by removing the relevant table header and data cells, and adjusting the `colspan` for the empty state row. I verified the changes by running the integration test suite and inspecting the generated screenshots, and also ran the full test suite with `composer test` to ensure no regressions.

Fixes #283

---
*PR created automatically by Jules for task [378886905848760655](https://jules.google.com/task/378886905848760655) started by @chatelao*