### PR TITLE
Prevent status icon and text from wrapping

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -187,7 +187,7 @@ $errorMessage = $errorMessage ?? null;
                                                     </a>
                                                 </td>
                                                 <td class="px-6 py-4">
-                                                    <span class="px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800">
+                                                    <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap bg-green-100 text-green-800">
                                                         🚧 Active
                                                     </span>
                                                 </td>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -410,7 +410,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                     <?= htmlspecialchars($file['name'] ?? '') ?>
                                                 </a>
                                                 <?php if (!empty($file['next_task'])): ?>
-                                                    <span class="text-[10px] text-gray-500 ml-6 italic">
+                                                    <span class="text-[10px] text-gray-500 ml-6 italic whitespace-nowrap">
                                                         🚧 <?= htmlspecialchars($file['next_task'] ?? '') ?>
                                                     </span>
                                                 <?php endif; ?>
@@ -559,7 +559,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                     elseif ($statusColor === 'red') $bgClass = 'bg-red-100 text-red-800';
                                                     elseif ($statusColor === 'purple') $bgClass = 'bg-purple-100 text-purple-800';
                                                     ?>
-                                                    <span class="px-2 py-1 text-xs font-medium rounded-full <?= $bgClass ?>">
+                                                    <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
                                                         <?php
                                                         $githubData = json_decode($task['github_data'] ?? '{}', true);
                                                         if (($githubData['state'] ?? 'open') === 'closed') echo '✅ ';

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -105,7 +105,7 @@ $logs = $taskModel->getLogs($taskId);
                             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                                 <div class="flex justify-between items-start mb-4">
                                     <h1 class="text-2xl font-bold text-gray-900"><?= htmlspecialchars($task['title'] ?? '') ?></h1>
-                                    <span class="px-3 py-1 text-sm font-medium rounded-full bg-<?= $statusColor ?>-100 text-<?= $statusColor ?>-800 flex items-center">
+                                    <span class="px-3 py-1 text-sm font-medium rounded-full whitespace-nowrap bg-<?= $statusColor ?>-100 text-<?= $statusColor ?>-800 flex items-center">
                                         <?php
                                         if ($task['status'] === 'completed') echo '✅ ';
                                         elseif (in_array($task['status'], ['in_progress', 'coding', 'testing'])) echo '🚧 ';


### PR DESCRIPTION
Added `whitespace-nowrap` to status badges in `src/frontend/index.php`, `src/frontend/project.php`, and `src/frontend/task.php` to ensure icons and status text remain on the same line. Verified the changes using Playwright and ran existing tests to ensure no regressions.

Fixes #287

---
*PR created automatically by Jules for task [2127522754305719149](https://jules.google.com/task/2127522754305719149) started by @chatelao*