### PR TITLE
Adjust Task Title Font Size

### DIFF
--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -104,7 +104,7 @@ $logs = $taskModel->getLogs($taskId);
                         <div class="lg:col-span-2 space-y-4">
                             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                                 <div class="flex justify-between items-start mb-4">
-                                    <h1 class="text-2xl font-bold text-gray-900"><?= htmlspecialchars($task['title'] ?? '') ?></h1>
+                                    <h1 class="text-lg font-bold text-gray-900"><?= htmlspecialchars($task['title'] ?? '') ?></h1>
                                     <span class="px-3 py-1 text-sm font-medium rounded-full bg-<?= $statusColor ?>-100 text-<?= $statusColor ?>-800 flex items-center">
                                         <?php
                                         if ($task['status'] === 'completed') echo '✅ ';


### PR DESCRIPTION
The task title on the task detail page was disproportionately large compared to other section headings. This change updates the title's Tailwind class to `text-lg`, matching the "Links & Status" heading in the sidebar, as requested. Accidental modifications to integration test files were reverted before submission.

Fixes #288

---
*PR created automatically by Jules for task [17447317875323926107](https://jules.google.com/task/17447317875323926107) started by @chatelao*