### PR TITLE
Move project settings to an independent page

### DIFF
--- a/src/backend/Project.php
+++ b/src/backend/Project.php
@@ -74,6 +74,23 @@ class Project
         return $project ?: null;
     }
 
+    public function update(int $projectId, int $userId, int $githubAccountId, string $githubRepo): bool
+    {
+        // Verify that the github account belongs to the user
+        $stmt = $this->db->getConnection()->prepare(
+            "SELECT github_account_id FROM user_github_accounts WHERE github_account_id = ? AND user_id = ?"
+        );
+        $stmt->execute([$githubAccountId, $userId]);
+        if (!$stmt->fetch()) {
+            throw new Exception("Invalid GitHub account selected.");
+        }
+
+        $stmt = $this->db->getConnection()->prepare(
+            "UPDATE projects SET github_account_id = ?, github_repo = ? WHERE project_id = ? AND user_id = ?"
+        );
+        return $stmt->execute([$githubAccountId, $githubRepo, $projectId, $userId]);
+    }
+
     public function delete(int $id, int $userId): bool
     {
         $stmt = $this->db->getConnection()->prepare(

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -57,16 +57,6 @@ if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['github_repo'
     }
 }
 
-// Handle Project Deletion
-if ($user && isset($_GET['delete_project'])) {
-    if (!$auth->validateCsrfToken($_GET['csrf_token'] ?? null)) {
-        die("CSRF token validation failed.");
-    }
-    $projectModel->delete((int)$_GET['delete_project'], $user['user_id']);
-    header('Location: index.php?success=project_deleted');
-    exit;
-}
-
 $projects = $user ? $projectModel->findByUserId($user['user_id']) : [];
 $githubAccounts = $user ? $userModel->getGitHubAccounts($user['user_id']) : [];
 $taskModel = new Task($db);
@@ -212,8 +202,8 @@ $errorMessage = $errorMessage ?? null;
                                                             <?= htmlspecialchars($project['github_repo'] ?? '') ?>
                                                         </a>
                                                     </h5>
-                                                    <a href="?delete_project=<?= $project['project_id'] ?>&csrf_token=<?= $auth->getCsrfToken() ?>" class="text-red-600 hover:text-red-800" onclick="return confirm('Are you sure?')">
-                                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
+                                                    <a href="project-settings.php?id=<?= $project['project_id'] ?>" class="text-gray-400 hover:text-gray-600 focus:outline-none" title="Project Settings">
+                                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
                                                     </a>
                                                 </div>
                                                 <?php

--- a/src/frontend/project-settings.php
+++ b/src/frontend/project-settings.php
@@ -1,0 +1,280 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Database;
+use App\Auth;
+use App\User;
+use App\Project;
+use App\Task;
+use App\GitHubService;
+
+$auth = new Auth();
+$db = new Database();
+$userModel = new User($db);
+$projectModel = new Project($db);
+$taskModel = new Task($db);
+
+if (!$auth->isLoggedIn()) {
+    header('Location: login.php');
+    exit;
+}
+
+$user = $userModel->findById($auth->getUserId());
+$projectId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$project = $projectModel->findById($projectId);
+
+if (!$project || $project['user_id'] !== $user['user_id']) {
+    die("Project not found or access denied.");
+}
+
+$githubAccounts = $userModel->getGitHubAccounts($user['user_id']);
+$errorMessage = null;
+$successMessage = null;
+
+// Handle Project Update
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_project'])) {
+    if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
+        die("CSRF token validation failed.");
+    }
+
+    $repo = trim($_POST['github_repo']);
+    $accountId = (int)$_POST['github_account_id'];
+
+    if (!empty($repo) && $accountId > 0) {
+        try {
+            $projectModel->update($projectId, $user['user_id'], $accountId, $repo);
+            header("Location: project-settings.php?id=$projectId&success=project_updated");
+            exit;
+        } catch (Exception $e) {
+            $errorMessage = $e->getMessage();
+        }
+    } else {
+        $errorMessage = "Repository and GitHub Account are required.";
+    }
+}
+
+// Handle Setup Webhook (copied from project.php)
+$webhookUrl = ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/webhook.php?project_id=' . $projectId;
+$githubToken = $project['github_token'] ?? null;
+$webhookStatus = 'unknown';
+
+if ($githubToken) {
+    try {
+        $githubService = new GitHubService(null, $githubToken);
+        $webhooks = $githubService->listWebhooks($project['github_repo']);
+        $webhookStatus = 'missing';
+        foreach ($webhooks as $wh) {
+            if (isset($wh['config']['url']) && str_starts_with($wh['config']['url'], ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/webhook.php')) {
+                if ($wh['config']['url'] === $webhookUrl || $wh['config']['url'] === ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/webhook.php') {
+                    $webhookStatus = $wh['active'] ? 'active' : 'inactive';
+                    break;
+                }
+            }
+        }
+    } catch (Exception $e) {
+        $webhookStatus = 'error';
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['setup_webhook'])) {
+    if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
+        die("CSRF token validation failed.");
+    }
+
+    try {
+        if (!$githubToken) {
+            throw new Exception("GitHub token not found for this project.");
+        }
+
+        $githubService = new GitHubService(null, $githubToken);
+        $githubService->createWebhook($project['github_repo'], $webhookUrl, $project['webhook_secret']);
+
+        header("Location: project-settings.php?id=$projectId&success=webhook_setup");
+        exit;
+    } catch (Exception $e) {
+        $errorMessage = "Error setting up webhook: " . $e->getMessage();
+    }
+}
+
+// Handle Project Deletion
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_project'])) {
+    if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
+        die("CSRF token validation failed.");
+    }
+
+    if ($projectModel->delete($projectId, $user['user_id'])) {
+        header('Location: index.php?success=project_deleted');
+        exit;
+    } else {
+        $errorMessage = "Failed to delete project.";
+    }
+}
+
+if (isset($_GET['success'])) {
+    if ($_GET['success'] === 'project_updated') $successMessage = "Project settings updated successfully.";
+    if ($_GET['success'] === 'webhook_setup') $successMessage = "Webhook set up successfully.";
+}
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Settings - Agent Control</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body class="bg-gray-100 font-sans leading-normal tracking-normal">
+    <nav class="bg-white border-b border-gray-200 fixed w-full z-30 top-0">
+        <div class="px-3 py-3 lg:px-5 lg:pl-3">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center justify-start">
+                    <a href="index.php" class="text-xl font-bold flex items-center lg:ml-2.5">
+                        <span class="self-center whitespace-nowrap">Agent Control</span>
+                    </a>
+                </div>
+                <div class="flex items-center">
+                    <?php include 'navbar-icons.php'; ?>
+                    <div class="flex items-center ml-3">
+                        <img class="w-8 h-8 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="user photo">
+                        <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name'] ?? '') ?></div>
+                        <a href="templates.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Templates</a>
+                        <a href="settings.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Settings</a>
+                        <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <div class="flex pt-16 overflow-hidden bg-gray-50">
+        <div id="main-content" class="relative w-full h-full overflow-y-auto bg-gray-50">
+            <main>
+                <div class="px-4 pt-6">
+                    <nav class="flex mb-5" aria-label="Breadcrumb">
+                        <ol class="inline-flex items-center space-x-1 md:space-x-2">
+                            <li class="inline-flex items-center">
+                                <a href="index.php" class="text-gray-700 hover:text-gray-900 inline-flex items-center">
+                                    <svg class="w-5 h-5 mr-2.5" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path></svg>
+                                    Dashboard
+                                </a>
+                            </li>
+                            <li>
+                                <div class="flex items-center">
+                                    <svg class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
+                                    <a href="project.php?id=<?= $projectId ?>" class="text-gray-700 hover:text-gray-900 ml-1 md:ml-2 font-medium">
+                                        <?= htmlspecialchars($project['github_repo'] ?? '') ?>
+                                    </a>
+                                </div>
+                            </li>
+                            <li>
+                                <div class="flex items-center">
+                                    <svg class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
+                                    <span class="text-gray-400 ml-1 md:ml-2 font-medium">Settings</span>
+                                </div>
+                            </li>
+                        </ol>
+                    </nav>
+
+                    <div class="mb-4">
+                        <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">Project Settings</h1>
+                    </div>
+
+                    <?php if ($errorMessage): ?>
+                        <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+                            <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if ($successMessage): ?>
+                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+                            <span class="font-medium">Success!</span> <?= htmlspecialchars($successMessage) ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <div class="grid grid-cols-1 gap-4">
+                        <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+                            <h3 class="text-lg font-bold text-gray-900 mb-4">General Settings</h3>
+                            <form method="POST">
+                                <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <label class="block mb-2 text-sm font-medium text-gray-900">GitHub Account</label>
+                                        <select name="github_account_id" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                            <?php foreach ($githubAccounts as $account): ?>
+                                                <option value="<?= $account['github_account_id'] ?>" <?= $account['github_account_id'] == $project['github_account_id'] ? 'selected' : '' ?>><?= htmlspecialchars($account['github_username'] ?? '') ?></option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </div>
+                                    <div>
+                                        <label class="block mb-2 text-sm font-medium text-gray-900">Repository (owner/repo)</label>
+                                        <input type="text" name="github_repo" value="<?= htmlspecialchars($project['github_repo'] ?? '') ?>" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                    </div>
+                                </div>
+                                <button type="submit" name="update_project" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Save Changes</button>
+                            </form>
+                        </div>
+
+                        <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+                            <h3 class="text-lg font-bold text-gray-900 mb-4">Webhook Configuration</h3>
+                            <div class="space-y-4">
+                                <div class="flex items-center justify-between">
+                                    <span class="text-sm font-medium text-gray-700">Status</span>
+                                    <?php if ($webhookStatus === 'active'): ?>
+                                        <span class="px-2.5 py-0.5 text-xs font-bold rounded-full bg-green-100 text-green-800">Connected</span>
+                                    <?php elseif ($webhookStatus === 'inactive'): ?>
+                                        <span class="px-2.5 py-0.5 text-xs font-bold rounded-full bg-yellow-100 text-yellow-800">Inactive</span>
+                                    <?php elseif ($webhookStatus === 'missing'): ?>
+                                        <span class="px-2.5 py-0.5 text-xs font-bold rounded-full bg-red-100 text-red-800">Not Found</span>
+                                    <?php elseif ($webhookStatus === 'error'): ?>
+                                        <span class="px-2.5 py-0.5 text-xs font-bold rounded-full bg-red-100 text-red-800">API Error</span>
+                                    <?php else: ?>
+                                        <span class="px-2.5 py-0.5 text-xs font-bold rounded-full bg-gray-100 text-gray-800">Unknown</span>
+                                    <?php endif; ?>
+                                </div>
+
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700">Payload URL</label>
+                                    <div class="mt-1 flex rounded-md shadow-sm">
+                                        <input type="text" readonly value="<?= htmlspecialchars($webhookUrl) ?>" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg block w-full p-2.5">
+                                    </div>
+                                </div>
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700">Secret</label>
+                                    <div class="mt-1 flex rounded-md shadow-sm">
+                                        <input type="text" readonly value="<?= htmlspecialchars($project['webhook_secret'] ?? '') ?>" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg block w-full p-2.5">
+                                    </div>
+                                </div>
+
+                                <?php if ($webhookStatus === 'missing' || $webhookStatus === 'error'): ?>
+                                    <form method="POST">
+                                        <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                        <button type="submit" name="setup_webhook" class="text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Setup Webhook Automatically</button>
+                                    </form>
+                                <?php endif; ?>
+
+                                <p class="text-sm text-gray-500">
+                                    Configure this in your GitHub Repository <b>Settings > Webhooks</b>.<br>
+                                    Set Content type to <b>application/json</b> and select <b>Issues</b> events.
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="p-4 bg-white border border-red-200 rounded-lg shadow-sm">
+                            <h3 class="text-lg font-bold text-red-900 mb-4">Danger Zone</h3>
+                            <p class="text-sm text-gray-600 mb-4">Once you delete a project, there is no going back. Please be certain.</p>
+                            <form method="POST" onsubmit="return confirm('Are you sure you want to delete this project? This action cannot be undone.')">
+                                <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                <button type="submit" name="delete_project" class="text-white bg-red-600 hover:bg-red-700 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Delete Project</button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -118,52 +118,15 @@ $triggerAgent = function($taskId) use ($taskModel, $logger, $user, $project, $ju
 
 $githubToken = $project['github_token'] ?? null;
 $roadmapFiles = [];
-$webhookStatus = 'unknown';
-$webhookUrl = ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/webhook.php?project_id=' . $projectId;
-
 if ($githubToken) {
     try {
         $githubService = new GitHubService(null, $githubToken);
         $roadmapFiles = $githubService->getRoadmapFiles($project['github_repo']);
-
-        // Check Webhook Status
-        $webhooks = $githubService->listWebhooks($project['github_repo']);
-        $webhookStatus = 'missing';
-        foreach ($webhooks as $wh) {
-            if (isset($wh['config']['url']) && str_starts_with($wh['config']['url'], ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/webhook.php')) {
-                // Check if it's specifically for this project or generic
-                if ($wh['config']['url'] === $webhookUrl || $wh['config']['url'] === ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/webhook.php') {
-                    $webhookStatus = $wh['active'] ? 'active' : 'inactive';
-                    break;
-                }
-            }
-        }
     } catch (Exception $e) {
-        // Silently fail or log roadmap/webhook fetching
-        $webhookStatus = 'error';
+        // Silently fail or log roadmap fetching
     }
 }
 
-// Handle Setup Webhook
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['setup_webhook'])) {
-    if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
-        die("CSRF token validation failed.");
-    }
-
-    try {
-        if (!$githubToken) {
-            throw new Exception("GitHub token not found for this project.");
-        }
-
-        $githubService = new GitHubService(null, $githubToken);
-        $githubService->createWebhook($project['github_repo'], $webhookUrl, $project['webhook_secret']);
-
-        header("Location: project.php?id=$projectId&success=webhook_setup");
-        exit;
-    } catch (Exception $e) {
-        $errorMessage = "Error setting up webhook: " . $e->getMessage();
-    }
-}
 
 // Handle Agent Trigger
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['trigger_agent'])) {
@@ -351,12 +314,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                         </ol>
                     </nav>
 
-                    <div class="mb-4">
+                    <div class="mb-4 flex justify-between items-center">
                         <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">
                             <a href="https://github.com/<?= htmlspecialchars($project['github_repo'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
                                 <?= htmlspecialchars($project['github_repo'] ?? '') ?>
                             </a>
                         </h1>
+                        <a href="project-settings.php?id=<?= $projectId ?>" class="text-gray-500 hover:text-gray-900 focus:outline-none" title="Project Settings">
+                            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                        </a>
                     </div>
 
                     <div class="mb-6">
@@ -384,6 +350,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                             <span class="font-medium">Success!</span> Quick issue created. It may take a few seconds to appear in the list (synced via webhook).
                         </div>
                     <?php endif; ?>
+
 
 
                     <?php if ($lastAgentResponse): ?>
@@ -420,50 +387,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                 <?php endif; ?>
                             </div>
 
-                            <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
-                                <h3 class="text-lg font-bold text-gray-900 mb-4">Webhook Configuration</h3>
-                                <div class="space-y-3">
-                                    <div class="flex items-center justify-between">
-                                        <span class="text-xs font-medium text-gray-500 uppercase">Status</span>
-                                        <?php if ($webhookStatus === 'active'): ?>
-                                            <span class="px-2 py-0.5 text-[10px] font-bold rounded-full bg-green-100 text-green-800">Connected</span>
-                                        <?php elseif ($webhookStatus === 'inactive'): ?>
-                                            <span class="px-2 py-0.5 text-[10px] font-bold rounded-full bg-yellow-100 text-yellow-800">Inactive</span>
-                                        <?php elseif ($webhookStatus === 'missing'): ?>
-                                            <span class="px-2 py-0.5 text-[10px] font-bold rounded-full bg-red-100 text-red-800">Not Found</span>
-                                        <?php elseif ($webhookStatus === 'error'): ?>
-                                            <span class="px-2 py-0.5 text-[10px] font-bold rounded-full bg-red-100 text-red-800">API Error</span>
-                                        <?php else: ?>
-                                            <span class="px-2 py-0.5 text-[10px] font-bold rounded-full bg-gray-100 text-gray-800">Unknown</span>
-                                        <?php endif; ?>
-                                    </div>
-
-                                    <div>
-                                        <label class="block text-xs font-medium text-gray-500 uppercase">Payload URL</label>
-                                        <div class="mt-1 flex">
-                                            <input type="text" readonly value="<?= htmlspecialchars($webhookUrl) ?>" class="bg-gray-50 border border-gray-300 text-gray-900 text-xs rounded-lg block w-full p-2" id="webhook-url">
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <label class="block text-xs font-medium text-gray-500 uppercase">Secret</label>
-                                        <div class="mt-1 flex">
-                                            <input type="text" readonly value="<?= htmlspecialchars($project['webhook_secret'] ?? '') ?>" class="bg-gray-50 border border-gray-300 text-gray-900 text-xs rounded-lg block w-full p-2" id="webhook-secret">
-                                        </div>
-                                    </div>
-
-                                    <?php if ($webhookStatus === 'missing' || $webhookStatus === 'error'): ?>
-                                        <form method="POST">
-                                            <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
-                                            <button type="submit" name="setup_webhook" class="w-full text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none">Setup Webhook Automatically</button>
-                                        </form>
-                                    <?php endif; ?>
-
-                                    <p class="text-[10px] text-gray-500">
-                                        Configure this in your GitHub Repository <b>Settings > Webhooks</b>.
-                                        Set Content type to <b>application/json</b> and select <b>Issues</b> events.
-                                    </p>
-                                </div>
-                            </div>
 
                             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm" x-data="{
                                 templates: <?= htmlspecialchars(json_encode($templates)) ?>,

--- a/test/Integration/verify_project_settings_ui.php
+++ b/test/Integration/verify_project_settings_ui.php
@@ -1,0 +1,99 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Database;
+use App\Auth;
+use App\User;
+use App\Project;
+use App\Task;
+
+// Set environment for testing
+putenv('DB_NAME=:memory:');
+
+// Initialize session if not started
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$db = new Database();
+$pdo = $db->getConnection();
+
+// Create schema for SQLite in-memory
+$pdo->exec("CREATE TABLE IF NOT EXISTS users (
+    user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    google_id VARCHAR(255) UNIQUE NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    avatar VARCHAR(255),
+    role VARCHAR(20) DEFAULT 'user',
+    jules_api_key VARCHAR(255),
+    telegram_link_token VARCHAR(255),
+    telegram_bot_token VARCHAR(255),
+    telegram_webhook_secret VARCHAR(255),
+    jules_quota_usage INT DEFAULT 0,
+    jules_quota_limit INT DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_github_accounts (
+    github_account_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    github_username VARCHAR(255) NOT NULL,
+    github_token VARCHAR(255) NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+    UNIQUE(user_id, github_username)
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS projects (
+    project_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    github_account_id INT NOT NULL,
+    github_repo VARCHAR(255) NOT NULL,
+    webhook_secret VARCHAR(255),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+    FOREIGN KEY (github_account_id) REFERENCES user_github_accounts(github_account_id) ON DELETE CASCADE
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
+    task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    project_id INT NOT NULL,
+    issue_number INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    body TEXT,
+    status TEXT DEFAULT 'pending',
+    github_state VARCHAR(20) DEFAULT 'open',
+    github_data TEXT,
+    agent_response TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(project_id, issue_number)
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_telegram_accounts (
+    telegram_account_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    telegram_chat_id BIGINT UNIQUE NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+)");
+
+// Create a mock user
+$userModel = new User($db);
+$pdo->exec("INSERT OR IGNORE INTO users (user_id, google_id, name, email) VALUES (1, 'google-123', 'Test User', 'test@example.com')");
+$_SESSION['user_id'] = 1;
+
+// Add GitHub account
+$userModel->addGitHubAccount(1, 'mock-token', 'mock-user');
+$githubAccountId = $pdo->lastInsertId();
+
+// Create a mock project
+$projectModel = new Project($db);
+$result = $projectModel->create(1, $githubAccountId, 'owner/repo');
+$project = $projectModel->findByRepo('owner/repo')[0];
+
+// Include the actual file to test
+$_GET['id'] = $project['project_id'];
+include __DIR__ . '/../../src/frontend/project-settings.php';


### PR DESCRIPTION
Moved repository and project settings to an independent page as requested.

Key changes:
1. **New Dedicated Page**: Created `src/frontend/project-settings.php` which centralizes:
   - General settings (changing GitHub account or repository).
   - Webhook configuration (status, manual setup instructions, and automatic setup button).
   - Project deletion (now more secure using a POST request with CSRF protection).
2. **Model Enhancements**: Added an `update` method to the `App\Project` class to support the new functionality, including ownership verification for linked GitHub accounts.
3. **UI Improvements**:
   - Replaced the direct delete button on the dashboard project cards with a settings icon.
   - Removed the bulky "Webhook Configuration" tile from the project details page and replaced it with a settings link in the header.
4. **Security**: Ensured all destructive actions (update, webhook setup, deletion) are protected by CSRF tokens.

Verified with automated tests and visual inspection via Playwright.

Fixes #298

---
*PR created automatically by Jules for task [3681896905162518748](https://jules.google.com/task/3681896905162518748) started by @chatelao*