### PR TITLE
Split 'failed' status into 'Jules' and 'PR' failure types

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -196,7 +196,7 @@ class GitHubService
                 'secret' => $secret,
                 'insecure_ssl' => '0'
             ],
-            'events' => ['issues'],
+            'events' => ['issues', 'check_suite'],
             'active' => true,
         ]);
     }

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -14,7 +14,7 @@ class Task
     {
         $sql = "SELECT * FROM tasks WHERE project_id = ?";
         if (!$showAll) {
-            $sql .= " AND (github_state = 'open' OR status NOT IN ('completed', 'failed'))";
+            $sql .= " AND (github_state = 'open' OR status NOT IN ('completed', 'failed', 'failed_jules', 'failed_pr'))";
         }
         $sql .= " ORDER BY created_at DESC";
 
@@ -36,7 +36,7 @@ class Task
              WHERE p.user_id = ?";
 
         if (!$showAll) {
-            $sql .= " AND (t.github_state = 'open' OR t.status NOT IN ('completed', 'failed'))";
+            $sql .= " AND (t.github_state = 'open' OR t.status NOT IN ('completed', 'failed', 'failed_jules', 'failed_pr'))";
         }
 
         $sql .= " ORDER BY t.created_at DESC";
@@ -107,6 +107,16 @@ class Task
             "SELECT * FROM tasks WHERE task_id = ?"
         );
         $stmt->execute([$id]);
+        $task = $stmt->fetch();
+        return $task ?: null;
+    }
+
+    public function findByPrUrl(string $prUrl): ?array
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "SELECT * FROM tasks WHERE pr_url = ?"
+        );
+        $stmt->execute([$prUrl]);
         $task = $stmt->fetch();
         return $task ?: null;
     }
@@ -229,7 +239,7 @@ class Task
 
         $status = $task['status'] ?? 'pending';
 
-        if ($status === 'failed') {
+        if ($status === 'failed' || str_starts_with($status, 'failed_')) {
             return 'red';
         }
 
@@ -294,11 +304,11 @@ class Task
         $issueUrl = "https://github.com/" . ($repo ?? $task['github_repo']) . "/issues/" . $task['issue_number'];
         $status = $task['status'] ?? 'pending';
 
-        if ($status === 'completed') {
+        if ($status === 'completed' || $status === 'failed_pr') {
             return $task['pr_url'] ?: $issueUrl;
         }
 
-        if ($status === 'in_progress') {
+        if ($status === 'in_progress' || $status === 'failed_jules') {
             return $task['jules_url'] ?: $issueUrl;
         }
 
@@ -320,7 +330,7 @@ class Task
              JOIN projects p ON t.project_id = p.project_id
              WHERE t.user_id = ?
              AND (t.last_synced_at IS NULL OR t.last_synced_at < ?)
-             AND (t.status NOT IN ('completed', 'failed') OR t.jules_status NOT IN ('completed', 'failed'))"
+             AND (t.status NOT IN ('completed', 'failed', 'failed_jules', 'failed_pr') OR t.jules_status NOT IN ('completed', 'failed'))"
         );
         $fiveMinutesAgo = date('Y-m-d H:i:s', strtotime('-5 minutes'));
         $stmt->execute([$userId, $fiveMinutesAgo]);
@@ -422,7 +432,7 @@ class Task
                     } elseif ($newStatus === 'completed' || $newStatus === 'finished') {
                         $mappedStatus = !empty($prUrl) ? 'completed' : 'implemented';
                     } elseif ($newStatus === 'failed' || $newStatus === 'error') {
-                        $mappedStatus = 'failed';
+                        $mappedStatus = 'failed_jules';
                     }
 
                     if ($mappedStatus !== $task['status'] || $newStatus !== $task['jules_status']) {
@@ -436,9 +446,12 @@ class Task
                             $message = "Task \"" . $task['title'] . "\" status changed to " . $mappedStatus . ".";
                             if ($mappedStatus === 'completed' || $mappedStatus === 'implemented') {
                                 $title = "✅ Task Completed: #" . $task['issue_number'];
-                            } elseif ($mappedStatus === 'failed') {
-                                $title = "❌ Task Failed: #" . $task['issue_number'];
-                                $message = "Task \"" . $task['title'] . "\" failed.";
+                            } elseif ($mappedStatus === 'failed_jules') {
+                                $title = "❌ Jules Failed: #" . $task['issue_number'];
+                                $message = "Jules session for \"" . $task['title'] . "\" failed.";
+                            } elseif ($mappedStatus === 'failed_pr') {
+                                $title = "❌ PR Failed: #" . $task['issue_number'];
+                                $message = "PR checks for \"" . $task['title'] . "\" failed.";
                             }
 
                             $notificationService->notify($userId, 'task_status', $title, $message, [

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -20,12 +20,17 @@ class WebhookHandler
     {
         $action = $event['action'] ?? '';
         $issue = $event['issue'] ?? null;
+        $checkSuite = $event['check_suite'] ?? null;
+
+        $taskModel = new Task($this->db);
+
+        if ($checkSuite) {
+            return $this->handleCheckSuite($project, $event, $taskModel, $notificationService);
+        }
 
         if (!$issue) {
             return true;
         }
-
-        $taskModel = new Task($this->db);
 
         if ($action === 'deleted') {
             return $taskModel->deleteByIssueNumber($project['project_id'], $issue['number']);
@@ -81,5 +86,56 @@ class WebhookHandler
         }
 
         return $result;
+    }
+
+    private function handleCheckSuite(array $project, array $event, Task $taskModel, ?NotificationService $notificationService): bool
+    {
+        $action = $event['action'] ?? '';
+        $checkSuite = $event['check_suite'] ?? null;
+
+        if ($action !== 'completed' || !$checkSuite) {
+            return true;
+        }
+
+        $conclusion = $checkSuite['conclusion'] ?? '';
+        $pullRequests = $checkSuite['pull_requests'] ?? [];
+
+        foreach ($pullRequests as $pr) {
+            $prUrl = $pr['url'] ?? '';
+            if (!$prUrl) continue;
+
+            // GitHub API PR URL is usually api.github.com/repos/.../pulls/...
+            // But we store html_url in tasks table. Let's try to convert or match.
+            // Example PR URL stored: https://github.com/owner/repo/pull/123
+            $htmlUrl = str_replace(['api.github.com/repos', '/pulls/'], ['github.com', '/pull/'], $prUrl);
+
+            $task = $taskModel->findByPrUrl($htmlUrl);
+            if (!$task) continue;
+
+            $newStatus = $task['status'];
+            if ($conclusion === 'failure' || $conclusion === 'timed_out' || $conclusion === 'cancelled') {
+                $newStatus = 'failed_pr';
+            } elseif ($conclusion === 'success' && $task['status'] === 'failed_pr') {
+                $newStatus = 'completed';
+            }
+
+            if ($newStatus !== $task['status']) {
+                $taskModel->updateStatus($task['task_id'], $newStatus);
+
+                if ($notificationService) {
+                    $title = $newStatus === 'failed_pr' ? "❌ PR Failed: #" . $task['issue_number'] : "✅ PR Fixed: #" . $task['issue_number'];
+                    $message = $newStatus === 'failed_pr' ? "PR checks for \"" . $task['title'] . "\" failed." : "PR checks for \"" . $task['title'] . "\" are now passing.";
+
+                    $notificationService->notify($project['user_id'], 'task_status', $title, $message, [
+                        'task_id' => $task['task_id'],
+                        'project_id' => $task['project_id'],
+                        'status' => $newStatus,
+                        'source_url' => $taskModel->getTargetUrl(array_merge($task, ['status' => $newStatus]))
+                    ]);
+                }
+            }
+        }
+
+        return true;
     }
 }

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -233,17 +233,28 @@ $errorMessage = $errorMessage ?? null;
                                                         $state = $githubData['state'] ?? 'open';
 
                                                         $emoji = '⏳';
-                                                        if ($state === 'closed') $emoji = '✅';
-                                                        elseif ($task['status'] === 'completed') $emoji = '✅';
-                                                        elseif ($task['status'] === 'failed') $emoji = '❌';
-                                                        elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) $emoji = '🚧';
+                                                        $statusLabel = $task['status'] ?? '';
+                                                        if ($state === 'closed') {
+                                                            $emoji = '✅';
+                                                            $statusLabel = 'closed';
+                                                        } elseif ($task['status'] === 'completed') {
+                                                            $emoji = '✅';
+                                                        } elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') {
+                                                            $emoji = '❌';
+                                                            $statusLabel = 'Jules';
+                                                        } elseif ($task['status'] === 'failed_pr') {
+                                                            $emoji = '❌';
+                                                            $statusLabel = 'PR';
+                                                        } elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) {
+                                                            $emoji = '🚧';
+                                                        }
                                                     ?>
                                                         <div class="relative group">
                                                             <a href="task.php?id=<?= $task['task_id'] ?>"
                                                                class="status-square <?= $color ?> <?= $isAutorepeat ? 'auto-repeat-tag' : '' ?>">
                                                             </a>
                                                             <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-[10px] rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
-                                                                #<?= htmlspecialchars($task['issue_number'] ?? '') ?>: <?= $emoji ?> <?= htmlspecialchars(mb_substr($task['title'] ?? '', 0, 30)) ?><?= mb_strlen($task['title'] ?? '') > 30 ? '...' : '' ?>
+                                                                #<?= htmlspecialchars($task['issue_number'] ?? '') ?>: <?= $emoji ?> <?= htmlspecialchars($statusLabel) ?> - <?= htmlspecialchars(mb_substr($task['title'] ?? '', 0, 30)) ?><?= mb_strlen($task['title'] ?? '') > 30 ? '...' : '' ?>
                                                             </div>
                                                         </div>
                                                     <?php endforeach; ?>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -97,7 +97,7 @@ $triggerAgent = function($taskId) use ($taskModel, $logger, $user, $project, $ju
         } catch (\Exception $e) {
             $errorMessage = "Error triggering agent: " . $e->getMessage();
             $logger->log($user['user_id'], $taskId, "Error: " . $e->getMessage(), "error");
-            $taskModel->updateStatus($taskId, 'failed');
+            $taskModel->updateStatus($taskId, 'failed_jules');
             if (isset($githubService) && $githubService) {
                 try {
                     $githubService->postComment($project['github_repo'], $task['issue_number'], "❌ Agent failed to process this issue: " . $e->getMessage());
@@ -564,11 +564,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                         $githubData = json_decode($task['github_data'] ?? '{}', true);
                                                         if (($githubData['state'] ?? 'open') === 'closed') echo '✅ ';
                                                         elseif ($task['status'] === 'completed') echo '✅ ';
-                                                        elseif ($task['status'] === 'failed') echo '❌ ';
+                                                        elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') echo '❌ Jules ';
+                                                        elseif ($task['status'] === 'failed_pr') echo '❌ PR ';
                                                         elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) echo '🚧 ';
                                                         else echo '⏳ ';
                                                         ?>
-                                                        <?= htmlspecialchars($task['status'] ?? '') ?>
+                                                        <?= htmlspecialchars(str_replace(['failed_jules', 'failed_pr'], 'failed', $task['status'] ?? '')) ?>
                                                     </span>
                                                 </td>
                                                 <td class="px-6 py-4">

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -49,12 +49,16 @@ if (in_array($julesStatus, ['coding', 'testing', 'researching', 'planning', 'in-
     $julesColor = 'yellow';
 } elseif (in_array($julesStatus, ['completed', 'finished'])) {
     $julesColor = 'green';
-} elseif (in_array($julesStatus, ['failed', 'error'])) {
+} elseif (in_array($julesStatus, ['failed', 'error']) || $task['status'] === 'failed_jules') {
     $julesColor = 'red';
 }
 
 $prStatus = !empty($task['pr_url']) ? 'Open' : 'None';
 $prColor = !empty($task['pr_url']) ? 'green' : 'gray';
+if ($task['status'] === 'failed_pr') {
+    $prStatus = 'Failed';
+    $prColor = 'red';
+}
 
 ?>
 <!DOCTYPE html>
@@ -127,11 +131,12 @@ $prColor = !empty($task['pr_url']) ? 'green' : 'gray';
                                         <?php
                                         if ($task['status'] === 'completed') echo '✅ ';
                                         elseif (in_array($task['status'], ['in_progress', 'coding', 'testing'])) echo '🚧 ';
-                                        elseif ($task['status'] === 'failed') echo '❌ ';
+                                        elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') echo '❌ Jules ';
+                                        elseif ($task['status'] === 'failed_pr') echo '❌ PR ';
                                         elseif (in_array($task['status'], ['researching', 'planning', 'awaiting-plan-approval', 'awaiting-user-feedback'])) echo '🔵 ';
                                         else echo '⏳ ';
                                         ?>
-                                        <?= htmlspecialchars($task['status'] ?? '') ?>
+                                        <?= htmlspecialchars(str_replace(['failed_jules', 'failed_pr'], 'failed', $task['status'] ?? '')) ?>
                                     </span>
                                 </div>
 

--- a/src/frontend/webhook.php
+++ b/src/frontend/webhook.php
@@ -30,7 +30,7 @@ $notificationService = new NotificationService($db);
 $signature = $_SERVER['HTTP_X_HUB_SIGNATURE_256'] ?? '';
 $event = $_SERVER['HTTP_X_GITHUB_EVENT'] ?? '';
 
-if (empty($payload) || empty($signature) || !in_array($event, ['issues', 'ping'])) {
+if (empty($payload) || empty($signature) || !in_array($event, ['issues', 'ping', 'check_suite'])) {
     http_response_code(400);
     exit('Invalid request');
 }

--- a/src/sql/patches/010_split_failed_status.sql
+++ b/src/sql/patches/010_split_failed_status.sql
@@ -1,0 +1,1 @@
+UPDATE tasks SET status = 'failed_jules' WHERE status = 'failed';


### PR DESCRIPTION
Distinguished between agent-side (Jules) failures and GitHub PR check failures by splitting the unified 'failed' status. Implemented automatic PR check failure detection via GitHub webhooks and updated the UI to provide more specific feedback to users.

Fixes #299

---
*PR created automatically by Jules for task [2604562208141062848](https://jules.google.com/task/2604562208141062848) started by @chatelao*