### PR TITLE
Set "Include vendor directory" default to disabled

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
         description: 'Include vendor directory'
         required: true
         type: boolean
-        default: true
+        default: false
 
 jobs:
   deploy:


### PR DESCRIPTION
Changed the default value for the `include_vendor` input in the `Manual SSH Deploy` workflow from `true` to `false`. This addresses the requirement to have "Include vendor directory" disabled by default.

Fixes #310

---
*PR created automatically by Jules for task [8327617331352856416](https://jules.google.com/task/8327617331352856416) started by @chatelao*