### PR TITLE
Filter issues to show open or last 3 completed

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -12,14 +12,26 @@ class Task
 
     public function findByProjectId(int $projectId, bool $showAll = true): array
     {
-        $sql = "SELECT * FROM tasks WHERE project_id = ?";
+        $sql = "SELECT t1.* FROM tasks t1 WHERE t1.project_id = ?";
+        $params = [$projectId];
+
         if (!$showAll) {
-            $sql .= " AND (github_state = 'open' OR status NOT IN ('completed', 'failed'))";
+            $sql .= " AND (t1.github_state = 'open' OR (
+                t1.github_state = 'closed' AND t1.status = 'completed'
+                AND (
+                    SELECT COUNT(*) FROM tasks t2
+                    WHERE t2.project_id = t1.project_id
+                    AND t2.github_state = 'closed'
+                    AND t2.status = 'completed'
+                    AND (t2.created_at > t1.created_at OR (t2.created_at = t1.created_at AND t2.task_id > t1.task_id))
+                ) < 3
+            ))";
         }
-        $sql .= " ORDER BY created_at DESC";
+
+        $sql .= " ORDER BY t1.created_at DESC";
 
         $stmt = $this->db->getConnection()->prepare($sql);
-        $stmt->execute([$projectId]);
+        $stmt->execute($params);
         return $stmt->fetchAll();
     }
 
@@ -36,7 +48,16 @@ class Task
              WHERE p.user_id = ?";
 
         if (!$showAll) {
-            $sql .= " AND (t.github_state = 'open' OR t.status NOT IN ('completed', 'failed'))";
+            $sql .= " AND (t.github_state = 'open' OR (
+                t.github_state = 'closed' AND t.status = 'completed'
+                AND (
+                    SELECT COUNT(*) FROM tasks t3
+                    WHERE t3.project_id = t.project_id
+                    AND t3.github_state = 'closed'
+                    AND t3.status = 'completed'
+                    AND (t3.created_at > t.created_at OR (t3.created_at = t.created_at AND t3.task_id > t.task_id))
+                ) < 3
+            ))";
         }
 
         $sql .= " ORDER BY t.created_at DESC";

--- a/test/Integration/TaskFilteringTest.php
+++ b/test/Integration/TaskFilteringTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\Task;
+use PDO;
+use Tests\TestDatabaseTrait;
+
+class TaskFilteringTest extends TestCase
+{
+    use TestDatabaseTrait;
+
+    private $db;
+    private $pdo;
+    private $taskModel;
+
+    protected function setUp(): void
+    {
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $this->pdo->exec("DROP TABLE IF EXISTS tasks");
+        $this->pdo->exec("DROP TABLE IF EXISTS projects");
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
+
+        $this->pdo->exec("CREATE TABLE projects (
+            project_id $pk,
+            user_id INT NOT NULL,
+            github_repo VARCHAR(255) NOT NULL
+        )");
+
+        $this->pdo->exec("CREATE TABLE tasks (
+            task_id $pk,
+            user_id INT NOT NULL,
+            project_id INT NOT NULL,
+            issue_number INT NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            status VARCHAR(50) DEFAULT 'pending',
+            github_state VARCHAR(20) DEFAULT 'open',
+            created_at $timestamp,
+            UNIQUE(project_id, issue_number)
+        )");
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        $this->taskModel = new Task($this->db);
+    }
+
+    private function createTask($projectId, $issueNumber, $state, $status, $createdAt)
+    {
+        $stmt = $this->pdo->prepare("INSERT INTO tasks (user_id, project_id, issue_number, title, github_state, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)");
+        $stmt->execute([1, $projectId, $issueNumber, "Issue $issueNumber", $state, $status, $createdAt]);
+    }
+
+    public function testFilteringLogic()
+    {
+        // Project 1
+        $this->createTask(1, 1, 'open', 'pending', '2023-01-01 10:00:00');
+        $this->createTask(1, 2, 'open', 'in_progress', '2023-01-01 11:00:00');
+        $this->createTask(1, 3, 'closed', 'completed', '2023-01-01 12:00:00'); // 4th completed
+        $this->createTask(1, 4, 'closed', 'completed', '2023-01-01 13:00:00'); // 3rd completed
+        $this->createTask(1, 5, 'closed', 'completed', '2023-01-01 14:00:00'); // 2nd completed
+        $this->createTask(1, 6, 'closed', 'completed', '2023-01-01 15:00:00'); // 1st completed
+        $this->createTask(1, 7, 'closed', 'failed', '2023-01-01 16:00:00');    // failed, should be hidden
+
+        // findByProjectId(1, false)
+        $tasks = $this->taskModel->findByProjectId(1, false);
+
+        // Expected issues: 1, 2 (open), 4, 5, 6 (last 3 completed)
+        $issueNumbers = array_column($tasks, 'issue_number');
+        sort($issueNumbers);
+
+        $this->assertEquals([1, 2, 4, 5, 6], $issueNumbers, "Should only show open issues and last 3 completed issues for Project 1");
+
+        // Project 2 (just to test findByUserProjects)
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'repo1'), (2, 1, 'repo2')");
+        $this->createTask(2, 10, 'open', 'pending', '2023-01-01 10:00:00');
+        $this->createTask(2, 11, 'closed', 'completed', '2023-01-01 11:00:00');
+
+        $activeTasks = $this->taskModel->findActiveByUserProjects(1);
+        $issueNumbers = array_column($activeTasks, 'issue_number');
+        sort($issueNumbers);
+
+        $this->assertEquals([1, 2, 4, 5, 6, 10, 11], $issueNumbers, "Should only show active issues for all user projects");
+    }
+}


### PR DESCRIPTION
Updated App\Task to filter task listings when showAll is false. Now only open issues and the 3 most recent completed issues per project are shown. This is implemented using a correlated subquery for better database compatibility. Added a new integration test TaskFilteringTest.php to verify the logic.

Fixes #303

---
*PR created automatically by Jules for task [7665959710317812679](https://jules.google.com/task/7665959710317812679) started by @chatelao*