### PR TITLE
Add LTS target checkbox to manual deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: boolean
         default: true
+      lts_target:
+        description: 'LTS target'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   deploy:
@@ -35,7 +40,7 @@ jobs:
           server: ${{ secrets.SFTP_SERVER }}
           username: ${{ secrets.SFTP_USERNAME }}
           password: ${{ secrets.SFTP_PASSWORD }}
-          remote_path: ${{ secrets.SFTP_PATH }}
+          remote_path: ${{ inputs.lts_target && secrets.SFTP_PATH_LTS || secrets.SFTP_PATH }}
           port: 22
           local_path: './'
           sftp_only: false


### PR DESCRIPTION
This PR adds a new "LTS target" checkbox to the manual deployment workflow. When selected, the deployment will target the path specified by the `SFTP_PATH_LTS` secret instead of the default `SFTP_PATH`. The checkbox defaults to unchecked to maintain existing behavior.

Fixes #311

---
*PR created automatically by Jules for task [4785928855183671100](https://jules.google.com/task/4785928855183671100) started by @chatelao*