### PR TITLE
Project-specific GitHub account handling and auto-selection

### DIFF
--- a/src/backend/Project.php
+++ b/src/backend/Project.php
@@ -51,7 +51,7 @@ class Project
     public function findByUserId(int $userId): array
     {
         $stmt = $this->db->getConnection()->prepare(
-            "SELECT p.*, a.github_username
+            "SELECT p.*, a.github_username, a.github_token
              FROM projects p
              JOIN user_github_accounts a ON p.github_account_id = a.github_account_id
              WHERE p.user_id = ?

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -312,18 +312,26 @@ class Task
         return $issueUrl;
     }
 
-    public function refreshJulesStatus(int $userId, GitHubService $githubService, JulesService $julesService, ?NotificationService $notificationService = null): void
+    public function refreshJulesStatus(int $userId, GitHubService $githubService, JulesService $julesService, ?NotificationService $notificationService = null, ?int $projectId = null): void
     {
-        $stmt = $this->db->getConnection()->prepare(
-            "SELECT t.*, p.github_repo
+        $sql = "SELECT t.*, p.github_repo
              FROM tasks t
              JOIN projects p ON t.project_id = p.project_id
              WHERE t.user_id = ?
              AND (t.last_synced_at IS NULL OR t.last_synced_at < ?)
-             AND (t.status NOT IN ('completed', 'failed') OR t.jules_status NOT IN ('completed', 'failed'))"
-        );
+             AND (t.status NOT IN ('completed', 'failed') OR t.jules_status NOT IN ('completed', 'failed'))";
+
+        if ($projectId !== null) {
+            $sql .= " AND t.project_id = ?";
+        }
+
+        $stmt = $this->db->getConnection()->prepare($sql);
         $fiveMinutesAgo = date('Y-m-d H:i:s', strtotime('-5 minutes'));
-        $stmt->execute([$userId, $fiveMinutesAgo]);
+        $params = [$userId, $fiveMinutesAgo];
+        if ($projectId !== null) {
+            $params[] = $projectId;
+        }
+        $stmt->execute($params);
         $tasks = $stmt->fetchAll();
 
         $userStmt = $this->db->getConnection()->prepare("SELECT jules_api_key, jules_quota_updated_at FROM users WHERE user_id = ?");

--- a/src/frontend/ajax-sync.php
+++ b/src/frontend/ajax-sync.php
@@ -44,13 +44,16 @@ try {
         }
     } else {
         // Global refresh for dashboard
-        $githubAccounts = $userModel->getGitHubAccounts($userId);
-        if (!empty($githubAccounts)) {
-            // Use the first account's token for refreshing Jules status
-            $githubService = new GitHubService(null, $githubAccounts[0]['github_token']);
-            $taskModel->refreshJulesStatus($userId, $githubService, $julesService, $notificationService);
+        $projects = $projectModel->findByUserId($userId);
+        if (!empty($projects)) {
+            foreach ($projects as $project) {
+                if (!empty($project['github_token'])) {
+                    $githubService = new GitHubService(null, $project['github_token']);
+                    $taskModel->refreshJulesStatus($userId, $githubService, $julesService, $notificationService, (int)$project['project_id']);
+                }
+            }
         } else {
-            // Fallback without token
+            // Fallback without token if no projects
             $githubService = new GitHubService();
             $taskModel->refreshJulesStatus($userId, $githubService, $julesService, $notificationService);
         }

--- a/src/frontend/cronjob.php
+++ b/src/frontend/cronjob.php
@@ -17,6 +17,7 @@ if ($cronSecret && ($_GET['key'] ?? '') !== $cronSecret) {
 
 $db = new Database();
 $userModel = new User($db);
+$projectModel = new Project($db);
 $taskModel = new Task($db);
 $githubService = new GitHubService();
 $julesService = new JulesService();
@@ -29,16 +30,16 @@ foreach ($users as $user) {
     $userId = (int)$user['user_id'];
     echo "Refreshing for user: " . $user['name'] . " (ID: $userId)...\n";
 
-    // We need a GitHub token to fetch comments.
-    // refreshJulesStatus currently takes one GitHubService.
-    // If a user has multiple GitHub accounts, we might need to iterate.
-    $githubAccounts = $userModel->getGitHubAccounts($userId);
+    // We need GitHub tokens to fetch comments.
+    // Each project might use a different GitHub account.
+    $projects = $projectModel->findByUserId($userId);
+    $scopedJulesService = new JulesService(null, $user['jules_api_key'] ?? null);
 
-    foreach ($githubAccounts as $account) {
-        $scopedGithubService = new GitHubService(null, $account['github_token']);
-        $scopedJulesService = new JulesService(null, $user['jules_api_key'] ?? null);
-
-        $taskModel->refreshJulesStatus($userId, $scopedGithubService, $scopedJulesService);
+    foreach ($projects as $project) {
+        if (!empty($project['github_token'])) {
+            $scopedGithubService = new GitHubService(null, $project['github_token']);
+            $taskModel->refreshJulesStatus($userId, $scopedGithubService, $scopedJulesService, null, (int)$project['project_id']);
+        }
     }
 }
 

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -250,19 +250,36 @@ $errorMessage = $errorMessage ?? null;
                                             <?php if (empty($githubAccounts)): ?>
                                                 <p class="text-sm text-gray-500 text-center">Please link a GitHub account first.</p>
                                             <?php else: ?>
-                                                <form method="POST" class="w-full">
+                                                <form method="POST" class="w-full" x-data="{
+                                                    repo: '',
+                                                    accounts: <?= htmlspecialchars(json_encode(array_map(fn($a) => ['id' => $a['github_account_id'], 'username' => $a['github_username']], $githubAccounts))) ?>,
+                                                    selectedAccountId: '<?= $githubAccounts[0]['github_account_id'] ?>',
+                                                    get repoOwner() {
+                                                        return this.repo.split('/')[0].trim().toLowerCase();
+                                                    },
+                                                    autoSelect() {
+                                                        const owner = this.repoOwner;
+                                                        if (!owner) return;
+                                                        const match = this.accounts.find(a => a.username.toLowerCase() === owner);
+                                                        if (match) {
+                                                            this.selectedAccountId = match.id;
+                                                        }
+                                                    }
+                                                }">
                                                     <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                                     <div class="mb-2">
                                                         <label class="block mb-1 text-xs font-medium text-gray-900">GitHub Account</label>
-                                                        <select name="github_account_id" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                                        <select name="github_account_id" x-model="selectedAccountId" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                                             <?php foreach ($githubAccounts as $account): ?>
-                                                                <option value="<?= $account['github_account_id'] ?>"><?= htmlspecialchars($account['github_username'] ?? '') ?></option>
+                                                                <option value="<?= $account['github_account_id'] ?>" x-text="'<?= htmlspecialchars($account['github_username'] ?? '') ?>' + (repoOwner === '<?= strtolower($account['github_username'] ?? '') ?>' ? ' (Recommended)' : '')">
+                                                                    <?= htmlspecialchars($account['github_username'] ?? '') ?>
+                                                                </option>
                                                             <?php endforeach; ?>
                                                         </select>
                                                     </div>
                                                     <div class="mb-2">
                                                         <label class="block mb-1 text-xs font-medium text-gray-900">Repository (owner/repo)</label>
-                                                        <input type="text" name="github_repo" placeholder="owner/repo" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                                        <input type="text" name="github_repo" x-model="repo" @input="autoSelect()" placeholder="owner/repo" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                                     </div>
                                                     <button type="submit" class="w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Link New Repository</button>
                                                 </form>

--- a/src/frontend/project-settings.php
+++ b/src/frontend/project-settings.php
@@ -198,20 +198,37 @@ if (isset($_GET['success'])) {
                     <div class="grid grid-cols-1 gap-4">
                         <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                             <h3 class="text-lg font-bold text-gray-900 mb-4">General Settings</h3>
-                            <form method="POST">
+                            <form method="POST" x-data="{
+                                repo: '<?= htmlspecialchars($project['github_repo'] ?? '') ?>',
+                                accounts: <?= htmlspecialchars(json_encode(array_map(fn($a) => ['id' => $a['github_account_id'], 'username' => $a['github_username']], $githubAccounts))) ?>,
+                                selectedAccountId: '<?= $project['github_account_id'] ?>',
+                                get repoOwner() {
+                                    return this.repo.split('/')[0].trim().toLowerCase();
+                                },
+                                autoSelect() {
+                                    const owner = this.repoOwner;
+                                    if (!owner) return;
+                                    const match = this.accounts.find(a => a.username.toLowerCase() === owner);
+                                    if (match) {
+                                        this.selectedAccountId = match.id;
+                                    }
+                                }
+                            }">
                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <label class="block mb-2 text-sm font-medium text-gray-900">GitHub Account</label>
-                                        <select name="github_account_id" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                        <select name="github_account_id" x-model="selectedAccountId" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                             <?php foreach ($githubAccounts as $account): ?>
-                                                <option value="<?= $account['github_account_id'] ?>" <?= $account['github_account_id'] == $project['github_account_id'] ? 'selected' : '' ?>><?= htmlspecialchars($account['github_username'] ?? '') ?></option>
+                                                <option value="<?= $account['github_account_id'] ?>" x-text="'<?= htmlspecialchars($account['github_username'] ?? '') ?>' + (repoOwner === '<?= strtolower($account['github_username'] ?? '') ?>' ? ' (Recommended)' : '')">
+                                                    <?= htmlspecialchars($account['github_username'] ?? '') ?>
+                                                </option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
                                     <div>
                                         <label class="block mb-2 text-sm font-medium text-gray-900">Repository (owner/repo)</label>
-                                        <input type="text" name="github_repo" value="<?= htmlspecialchars($project['github_repo'] ?? '') ?>" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                        <input type="text" name="github_repo" x-model="repo" @input="autoSelect()" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                     </div>
                                 </div>
                                 <button type="submit" name="update_project" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Save Changes</button>

--- a/test/Integration/verify_index_ui.php
+++ b/test/Integration/verify_index_ui.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+use App\Database;
+use App\Auth;
+use App\User;
+use App\Project;
+use App\Task;
+
+putenv('DB_NAME=:memory:');
+if (session_status() === PHP_SESSION_NONE) { session_start(); }
+$db = new Database();
+$pdo = $db->getConnection();
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY AUTOINCREMENT, google_id VARCHAR(255) UNIQUE NOT NULL, name VARCHAR(255) NOT NULL, email VARCHAR(255) UNIQUE NOT NULL, avatar VARCHAR(255), role VARCHAR(20) DEFAULT 'user', jules_api_key VARCHAR(255), telegram_link_token VARCHAR(255), created_at DATETIME DEFAULT CURRENT_TIMESTAMP)");
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_github_accounts (github_account_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INT NOT NULL, github_username VARCHAR(255) NOT NULL, github_token VARCHAR(255) NOT NULL, created_at DATETIME DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE, UNIQUE(user_id, github_username))");
+$pdo->exec("CREATE TABLE IF NOT EXISTS projects (project_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INT NOT NULL, github_account_id INT NOT NULL, github_repo VARCHAR(255) NOT NULL, webhook_secret VARCHAR(255), created_at DATETIME DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE, FOREIGN KEY (github_account_id) REFERENCES user_github_accounts(github_account_id) ON DELETE CASCADE)");
+$pdo->exec("CREATE TABLE IF NOT EXISTS tasks (task_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INT NOT NULL, project_id INT NOT NULL, issue_number INT NOT NULL, title VARCHAR(255) NOT NULL, body TEXT, status TEXT DEFAULT 'pending', github_state VARCHAR(20) DEFAULT 'open', github_data TEXT, agent_response TEXT, created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP, UNIQUE(project_id, issue_number))");
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_telegram_accounts (telegram_account_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INT NOT NULL, telegram_chat_id BIGINT UNIQUE NOT NULL, created_at DATETIME DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE)");
+$pdo->exec("CREATE TABLE IF NOT EXISTS notifications (notification_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INT NOT NULL, type VARCHAR(50) NOT NULL, title VARCHAR(255) NOT NULL, message TEXT NOT NULL, data JSON, is_read BOOLEAN DEFAULT FALSE, created_at DATETIME DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE)");
+
+
+$pdo->exec("INSERT OR IGNORE INTO users (user_id, google_id, name, email) VALUES (1, 'google-123', 'Test User', 'test@example.com')");
+$_SESSION['user_id'] = 1;
+$userModel = new User($db);
+$userModel->addGitHubAccount(1, 'token1', 'owner1');
+$userModel->addGitHubAccount(1, 'token2', 'otheruser');
+
+include __DIR__ . '/../../src/frontend/index.php';

--- a/test/Integration/verify_project_ui.php
+++ b/test/Integration/verify_project_ui.php
@@ -97,6 +97,40 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS issue_templates (
     FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 )");
 
+$pdo->exec("CREATE TABLE IF NOT EXISTS notifications (
+    notification_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    message TEXT NOT NULL,
+    data JSON,
+    is_read BOOLEAN DEFAULT FALSE,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_notification_settings (
+    user_id INT NOT NULL,
+    channel VARCHAR(20) NOT NULL,
+    is_enabled BOOLEAN DEFAULT TRUE,
+    PRIMARY KEY (user_id, channel),
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS project_notification_settings (
+    project_id INT NOT NULL,
+    notification_type VARCHAR(50) NOT NULL,
+    is_enabled BOOLEAN DEFAULT TRUE,
+    PRIMARY KEY (project_id, notification_type),
+    FOREIGN KEY (project_id) REFERENCES projects(project_id) ON DELETE CASCADE
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS task_notification_settings (
+    task_id INT NOT NULL PRIMARY KEY,
+    is_muted BOOLEAN DEFAULT FALSE,
+    FOREIGN KEY (task_id) REFERENCES tasks(task_id) ON DELETE CASCADE
+)");
+
 // Create a mock user
 $userModel = new User($db);
 $pdo->exec("INSERT OR IGNORE INTO users (user_id, google_id, name, email) VALUES (1, 'google-123', 'Test User', 'test@example.com')");


### PR DESCRIPTION
This change enhances the multi-account GitHub support by allowing users to easily select the correct GitHub account for each project based on the repository owner. It also ensures that the backend synchronization logic correctly uses the project-specific tokens instead of a global user token.

Key changes:
- UI enhancements in `index.php` and `project-settings.php` for smarter account selection.
- Backend logic updates in `Task.php`, `ajax-sync.php`, and `cronjob.php` to scope GitHub operations to the project-specific account.
- Verification through updated integration test mocks and manual Playwright screenshots.

Fixes #313

---
*PR created automatically by Jules for task [3219187226214717167](https://jules.google.com/task/3219187226214717167) started by @chatelao*