### PR TITLE
Improve PR Status Display and Refactor github_state Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .phpunit.cache/
 .env
 *.log
+*.sqlite
 /test/screenshots/
 /docs/_build/

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -251,8 +251,7 @@ class Task
 
     public function getStatusColor(array $task): string
     {
-        $githubData = json_decode($task['github_data'] ?? '{}', true);
-        $state = $githubData['state'] ?? 'open';
+        $state = $task['github_state'] ?? 'open';
 
         if ($state === 'closed') {
             return 'purple';

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -219,8 +219,7 @@ $errorMessage = $errorMessage ?? null;
                                                     foreach ($tasks as $task):
                                                         $color = $taskModel->getStatusColor($task);
                                                         $isAutorepeat = $taskModel->hasAutorepeatLabel($task);
-                                                        $githubData = json_decode($task['github_data'] ?? '{}', true);
-                                                        $state = $githubData['state'] ?? 'open';
+                                                        $state = $task['github_state'] ?? 'open';
 
                                                         $emoji = '⏳';
                                                         $statusLabel = $task['status'] ?? '';

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -483,8 +483,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                     ?>
                                                     <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
                                                         <?php
-                                                        $githubData = json_decode($task['github_data'] ?? '{}', true);
-                                                        if (($githubData['state'] ?? 'open') === 'closed') echo '✅ ';
+                                                        if (($task['github_state'] ?? 'open') === 'closed') echo '✅ ';
                                                         elseif ($task['status'] === 'completed') echo '✅ ';
                                                         elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') echo '❌ Jules ';
                                                         elseif ($task['status'] === 'failed_pr') echo '❌ PR ';
@@ -497,8 +496,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                 <td class="px-6 py-4">
                                                     <div class="flex flex-col space-y-2">
                                                         <?php
-                                                        $githubData = json_decode($task['github_data'] ?? '{}', true);
-                                                        $isClosed = ($githubData['state'] ?? 'open') === 'closed';
+                                                        $isClosed = ($task['github_state'] ?? 'open') === 'closed';
                                                         $isCompleted = ($task['status'] ?? '') === 'completed';
                                                         $isImplemented = ($task['status'] ?? '') === 'implemented';
                                                         ?>

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -55,9 +55,14 @@ if (in_array($julesStatus, ['coding', 'testing', 'researching', 'planning', 'in-
 
 $prStatus = !empty($task['pr_url']) ? 'Open' : 'None';
 $prColor = !empty($task['pr_url']) ? 'green' : 'gray';
-if ($task['status'] === 'failed_pr') {
+if ($task['github_state'] === 'closed' && !empty($task['pr_url'])) {
+    $prStatus = 'Closed';
+    $prColor = 'purple';
+} elseif ($task['status'] === 'failed_pr') {
     $prStatus = 'Failed';
     $prColor = 'red';
+} elseif ($task['status'] === 'completed' && !empty($task['pr_url'])) {
+    $prStatus = 'Passed';
 }
 
 ?>
@@ -215,7 +220,7 @@ if ($task['status'] === 'failed_pr') {
                                     </li>
                                     <?php if (!empty($task['pr_url'])): ?>
                                         <li>
-                                            <a href="<?= htmlspecialchars($task['pr_url'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="flex items-center text-green-600 hover:underline font-bold">
+                                            <a href="<?= htmlspecialchars($task['pr_url'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="flex items-center text-<?= $prColor ?>-600 hover:underline font-bold">
                                                 <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24"><path d="M11 19.25c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM11 14.5c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM11 9.75c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 19.25c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 14.5c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 9.75c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM20.5 2h-17C2.673 2 2 2.673 2 3.5v17c0 .827.673 1.5 1.5 1.5h17c.827 0 1.5-.673 1.5-1.5v-17C22 2.673 21.327 2 20.5 2zM20 18H4V4h16v14z"/></svg>
                                                 View Pull Request
                                             </a>


### PR DESCRIPTION
This change improves the visual feedback for Pull Requests in the Task Detail view. PRs associated with closed issues now correctly display as "Closed" in purple, following GitHub's color scheme. Additionally, the PR status label is more descriptive, showing "Passed" when the task is completed and "Failed" when PR checks fail.

To support this more efficiently, the codebase was refactored to use the existing `github_state` database column for issue state checks, reducing the need for expensive JSON decoding of the `github_data` field in the frontend and backend.

Finally, `.gitignore` was updated to exclude transient SQLite files to prevent them from being accidentally committed.

Fixes #321

---
*PR created automatically by Jules for task [7333568517619295655](https://jules.google.com/task/7333568517619295655) started by @chatelao*