### PR TITLE
GitHub Account Auto-selection based on Repo Owner

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -261,19 +261,39 @@ $errorMessage = $errorMessage ?? null;
                                             <?php if (empty($githubAccounts)): ?>
                                                 <p class="text-sm text-gray-500 text-center">Please link a GitHub account first.</p>
                                             <?php else: ?>
-                                                <form method="POST" class="w-full">
+                                                <form method="POST" class="w-full" x-data="{
+                                                    repo: '',
+                                                    selectedAccountId: '<?= $githubAccounts[0]['github_account_id'] ?>',
+                                                    accounts: <?= htmlspecialchars(json_encode($githubAccounts)) ?>,
+                                                    get recommendedId() {
+                                                        const owner = this.repo.split('/')[0]?.trim();
+                                                        if (!owner) return null;
+                                                        const match = this.accounts.find(a => a.github_username.toLowerCase() === owner.toLowerCase());
+                                                        return match ? match.github_account_id : null;
+                                                    },
+                                                    init() {
+                                                        this.$watch('repo', (value) => {
+                                                            const recId = this.recommendedId;
+                                                            if (recId) {
+                                                                this.selectedAccountId = recId;
+                                                            }
+                                                        });
+                                                    }
+                                                }">
                                                     <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                                     <div class="mb-2">
                                                         <label class="block mb-1 text-xs font-medium text-gray-900">GitHub Account</label>
-                                                        <select name="github_account_id" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                                        <select name="github_account_id" x-model="selectedAccountId" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                                             <?php foreach ($githubAccounts as $account): ?>
-                                                                <option value="<?= $account['github_account_id'] ?>"><?= htmlspecialchars($account['github_username'] ?? '') ?></option>
+                                                                <option value="<?= $account['github_account_id'] ?>" x-text="'<?= htmlspecialchars($account['github_username'] ?? '') ?>' + (recommendedId == <?= $account['github_account_id'] ?> ? ' (Recommended)' : '')">
+                                                                    <?= htmlspecialchars($account['github_username'] ?? '') ?>
+                                                                </option>
                                                             <?php endforeach; ?>
                                                         </select>
                                                     </div>
                                                     <div class="mb-2">
                                                         <label class="block mb-1 text-xs font-medium text-gray-900">Repository (owner/repo)</label>
-                                                        <input type="text" name="github_repo" placeholder="owner/repo" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                                        <input type="text" name="github_repo" x-model="repo" placeholder="owner/repo" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                                     </div>
                                                     <button type="submit" class="w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Link New Repository</button>
                                                 </form>

--- a/src/frontend/project-settings.php
+++ b/src/frontend/project-settings.php
@@ -198,20 +198,40 @@ if (isset($_GET['success'])) {
                     <div class="grid grid-cols-1 gap-4">
                         <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                             <h3 class="text-lg font-bold text-gray-900 mb-4">General Settings</h3>
-                            <form method="POST">
+                            <form method="POST" x-data="{
+                                repo: '<?= htmlspecialchars($project['github_repo'] ?? '') ?>',
+                                selectedAccountId: '<?= $project['github_account_id'] ?>',
+                                accounts: <?= htmlspecialchars(json_encode($githubAccounts)) ?>,
+                                get recommendedId() {
+                                    const owner = this.repo.split('/')[0]?.trim();
+                                    if (!owner) return null;
+                                    const match = this.accounts.find(a => a.github_username.toLowerCase() === owner.toLowerCase());
+                                    return match ? match.github_account_id : null;
+                                },
+                                init() {
+                                    this.$watch('repo', (value) => {
+                                        const recId = this.recommendedId;
+                                        if (recId) {
+                                            this.selectedAccountId = recId;
+                                        }
+                                    });
+                                }
+                            }">
                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <label class="block mb-2 text-sm font-medium text-gray-900">GitHub Account</label>
-                                        <select name="github_account_id" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                        <select name="github_account_id" x-model="selectedAccountId" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                             <?php foreach ($githubAccounts as $account): ?>
-                                                <option value="<?= $account['github_account_id'] ?>" <?= $account['github_account_id'] == $project['github_account_id'] ? 'selected' : '' ?>><?= htmlspecialchars($account['github_username'] ?? '') ?></option>
+                                                <option value="<?= $account['github_account_id'] ?>" x-text="'<?= htmlspecialchars($account['github_username'] ?? '') ?>' + (recommendedId == <?= $account['github_account_id'] ?> ? ' (Recommended)' : '')">
+                                                    <?= htmlspecialchars($account['github_username'] ?? '') ?>
+                                                </option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
                                     <div>
                                         <label class="block mb-2 text-sm font-medium text-gray-900">Repository (owner/repo)</label>
-                                        <input type="text" name="github_repo" value="<?= htmlspecialchars($project['github_repo'] ?? '') ?>" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
+                                        <input type="text" name="github_repo" x-model="repo" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
                                     </div>
                                 </div>
                                 <button type="submit" name="update_project" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Save Changes</button>


### PR DESCRIPTION
Implemented Alpine.js-based auto-selection and recommendation for GitHub accounts in both the project creation (index.php) and project settings (project-settings.php) forms. The system now extracts the owner from the 'owner/repo' input and highlights the matching linked GitHub account as '(Recommended)' and automatically selects it. Verified with Playwright screenshots and existing test suites.

Fixes #325

---
*PR created automatically by Jules for task [17634662607340750446](https://jules.google.com/task/17634662607340750446) started by @chatelao*