### PR TITLE
Fix: Add notification for GitHub issue deletion

### DIFF
--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -33,7 +33,15 @@ class WebhookHandler
         }
 
         if ($action === 'deleted') {
-            return $taskModel->deleteByIssueNumber($project['project_id'], $issue['number']);
+            $result = $taskModel->deleteByIssueNumber($project['project_id'], $issue['number']);
+            if ($result && $notificationService) {
+                $notificationService->notify($project['user_id'], 'github_issue', "🗑️ Issue Deleted: #" . $issue['number'], "Issue \"" . ($issue['title'] ?? 'Unknown') . "\" was deleted in " . $project['github_repo'], [
+                    'project_id' => $project['project_id'],
+                    'issue_number' => $issue['number'],
+                    'source_url' => $issue['html_url'] ?? ''
+                ]);
+            }
+            return $result;
         }
 
         if (!in_array($action, ['opened', 'reopened', 'edited', 'closed', 'labeled', 'unlabeled'])) {

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -119,10 +119,17 @@ class WebhookHandlerTest extends TestCase
 
     public function testHandleDeletedIssue()
     {
-        $project = ['user_id' => 1, 'project_id' => 1];
+        $project = [
+            'user_id' => 1,
+            'project_id' => 1,
+            'github_repo' => 'owner/repo'
+        ];
         $event = [
             'action' => 'deleted',
-            'issue' => ['number' => 123]
+            'issue' => [
+                'number' => 123,
+                'title' => 'Deleted Issue'
+            ]
         ];
 
         $stmt = $this->createMock(PDOStatement::class);
@@ -130,7 +137,20 @@ class WebhookHandlerTest extends TestCase
 
         $this->pdo->method('prepare')->with($this->stringContains('DELETE FROM tasks'))->willReturn($stmt);
 
-        $this->assertTrue($this->handler->handle($project, $event));
+        $notificationService = $this->createMock(\App\NotificationService::class);
+        $notificationService->expects($this->once())
+            ->method('notify')
+            ->with(
+                1,
+                'github_issue',
+                $this->stringContains('Issue Deleted: #123'),
+                $this->stringContains('Issue "Deleted Issue" was deleted'),
+                $this->callback(function($data) {
+                    return $data['issue_number'] === 123 && $data['project_id'] === 1;
+                })
+            );
+
+        $this->assertTrue($this->handler->handle($project, $event, null, $notificationService));
     }
 
     public function testHandleUnsupportedAction()


### PR DESCRIPTION
This PR updates the `WebhookHandler` to trigger a notification via `NotificationService` when a GitHub issue is deleted. This ensures users are notified of deletions, consistent with other issue lifecycle events like opening, closing, and reopening. Unit tests have been updated to verify the new behavior.

Fixes #333

---
*PR created automatically by Jules for task [8282988662695415428](https://jules.google.com/task/8282988662695415428) started by @chatelao*