### PR TITLE
Fix Parsedown not found fatal error in task.php

### DIFF
--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -14,8 +14,6 @@ $db = new Database();
 $userModel = new User($db);
 $projectModel = new Project($db);
 $taskModel = new Task($db);
-$parsedown = new \Parsedown();
-$parsedown->setSafeMode(true);
 
 if (!$auth->isLoggedIn()) {
     header('Location: login.php');
@@ -23,6 +21,14 @@ if (!$auth->isLoggedIn()) {
 }
 
 $user = $userModel->findById($auth->getUserId());
+
+// Initialize Markdown parser
+if (!class_exists('\Parsedown')) {
+    die("Error: Class 'Parsedown' not found. Please run 'composer install' to install dependencies.");
+}
+$parsedown = new \Parsedown();
+$parsedown->setSafeMode(true);
+
 $taskId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $task = $taskModel->findById($taskId);
 


### PR DESCRIPTION
The issue was caused by the 'erusev/parsedown' dependency not being available in the environment, leading to a fatal error in 'src/frontend/task.php'. 

I have:
1. Installed the necessary dependencies using 'composer install'.
2. Updated 'src/frontend/task.php' to include a check for the 'Parsedown' class, providing a more descriptive error message if it's missing (e.g., advising to run 'composer install') instead of a fatal error.
3. Verified the fix by running the application with a mock server and confirming that the task page renders correctly with Markdown support.
4. Confirmed that the full test suite passes.

Fixes #332

---
*PR created automatically by Jules for task [4067478703413181905](https://jules.google.com/task/4067478703413181905) started by @chatelao*