### PR TITLE
Automate Telegram Bot webhook registration

### DIFF
--- a/src/backend/TelegramService.php
+++ b/src/backend/TelegramService.php
@@ -26,26 +26,72 @@ class TelegramService
      */
     public function sendMessage(int $chatId, string $text, array $extraParams = []): bool
     {
-        if (empty($this->botToken)) {
-            throw new Exception("Telegram Bot Token not configured.");
-        }
-
         $params = array_merge([
             'chat_id' => $chatId,
             'text'    => $text,
             'parse_mode' => 'HTML'
         ], $extraParams);
 
-        $response = $this->client->post("bot" . $this->botToken . "/sendMessage", [
-            'json' => $params
-        ]);
-
-        $data = json_decode($response->getBody()->getContents(), true);
-
-        if (!isset($data['ok']) || $data['ok'] !== true) {
-            throw new Exception("Telegram API Error: " . ($data['description'] ?? 'Unknown error'));
-        }
+        $this->apiRequest('sendMessage', $params);
 
         return true;
+    }
+
+    /**
+     * @throws GuzzleException
+     * @throws Exception
+     */
+    public function setWebhook(string $url, ?string $secretToken = null): bool
+    {
+        $params = ['url' => $url];
+        if ($secretToken) {
+            $params['secret_token'] = $secretToken;
+        }
+
+        $this->apiRequest('setWebhook', $params);
+
+        return true;
+    }
+
+    /**
+     * @throws GuzzleException
+     * @throws Exception
+     */
+    public function deleteWebhook(): bool
+    {
+        $this->apiRequest('deleteWebhook');
+
+        return true;
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function apiRequest(string $method, array $params = []): array
+    {
+        if (empty($this->botToken)) {
+            throw new Exception("Telegram Bot Token not configured.");
+        }
+
+        $options = [];
+        if (!empty($params)) {
+            $options['json'] = $params;
+        }
+
+        try {
+            $response = $this->client->post("bot" . $this->botToken . "/" . $method, $options);
+            $data = json_decode($response->getBody()->getContents(), true);
+
+            if (!isset($data['ok']) || $data['ok'] !== true) {
+                throw new Exception("Telegram API Error: " . ($data['description'] ?? 'Unknown error'));
+            }
+
+            return $data;
+        } catch (GuzzleException $e) {
+            $message = $e->getMessage();
+            // Sanitize potential token leaks in Guzzle error messages (which often include the URL)
+            $message = preg_replace('/bot\d+:[a-zA-Z0-9_-]+/', 'bot[REDACTED]', $message);
+            throw new Exception("Telegram Connection Error: " . $message);
+        }
     }
 }

--- a/src/frontend/settings.php
+++ b/src/frontend/settings.php
@@ -8,6 +8,7 @@ use App\User;
 use App\Task;
 use App\WebhookLogger;
 use App\NotificationService;
+use App\TelegramService;
 
 $auth = new Auth();
 $db = new Database();
@@ -42,9 +43,43 @@ if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_teleg
     if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
         die("CSRF token validation failed.");
     }
-    $botToken = trim($_POST['telegram_bot_token']);
-    $webhookSecret = trim($_POST['telegram_webhook_secret']);
-    if ($userModel->updateTelegramConfig($user['user_id'], $botToken, $webhookSecret)) {
+    $newBotToken = trim($_POST['telegram_bot_token']);
+    $newWebhookSecret = trim($_POST['telegram_webhook_secret']);
+
+    $oldBotToken = $user['telegram_bot_token'] ?? '';
+
+    // Unregister old webhook if token changed and wasn't empty
+    if (!empty($oldBotToken) && $oldBotToken !== $newBotToken) {
+        try {
+            $oldTelegramService = new TelegramService(null, $oldBotToken);
+            $oldTelegramService->deleteWebhook();
+        } catch (\Exception $e) {
+            // Silently fail if old token was already invalid or other API issues
+        }
+    }
+
+    if ($userModel->updateTelegramConfig($user['user_id'], $newBotToken, $newWebhookSecret)) {
+        // Register new webhook if token is provided
+        if (!empty($newBotToken)) {
+            try {
+                $telegramService = new TelegramService(null, $newBotToken);
+
+                $protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https://" : "http://";
+                if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+                    $protocol = "https://";
+                }
+
+                $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+                $webhookUrl = $protocol . $host . "/telegram-webhook.php?user_id=" . $user['user_id'];
+
+                $telegramService->setWebhook($webhookUrl, $newWebhookSecret);
+            } catch (\Exception $e) {
+                // If webhook registration fails, we still updated the config, but warn the user
+                header('Location: settings.php?success=telegram_updated&warning=webhook_failed&error=' . urlencode($e->getMessage()));
+                exit;
+            }
+        }
+
         header('Location: settings.php?success=telegram_updated');
         exit;
     } else {
@@ -157,6 +192,12 @@ $errorMessage = $errorMessage ?? null;
                     <?php if (isset($_GET['success']) && $_GET['success'] === 'telegram_updated'): ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Telegram configuration updated successfully.
+                            <?php if (isset($_GET['warning']) && $_GET['warning'] === 'webhook_failed'): ?>
+                                <div class="mt-2 text-yellow-800 font-normal">
+                                    <strong>Warning:</strong> Automated webhook registration failed: <?= htmlspecialchars($_GET['error'] ?? 'Unknown error') ?>.
+                                    You may need to register it manually.
+                                </div>
+                            <?php endif; ?>
                         </div>
                     <?php endif; ?>
 

--- a/test/Unit/Services/TelegramServiceTest.php
+++ b/test/Unit/Services/TelegramServiceTest.php
@@ -76,4 +76,34 @@ class TelegramServiceTest extends TestCase
 
         $this->assertTrue($result);
     }
+
+    public function testSetWebhookSuccess()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode(['ok' => true])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $service = new TelegramService($client, 'fake-token');
+        $result = $service->setWebhook('https://example.com/webhook', 'secret123');
+
+        $this->assertTrue($result);
+    }
+
+    public function testDeleteWebhookSuccess()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode(['ok' => true])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $service = new TelegramService($client, 'fake-token');
+        $result = $service->deleteWebhook();
+
+        $this->assertTrue($result);
+    }
 }


### PR DESCRIPTION
This change automates the registration of the Telegram Bot webhook when users save their custom bot token in the settings page. It also handles the cleanup of previous registrations if the token is changed. Additionally, it improves security by ensuring that the sensitive bot token is redacted from any error messages thrown by the TelegramService, preventing it from leaking into the UI or logs.

Fixes #337

---
*PR created automatically by Jules for task [11935665135809259805](https://jules.google.com/task/11935665135809259805) started by @chatelao*