### PR TITLE
Optimize Google API library size

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,18 @@
         "phpunit/phpunit": "^11.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit -c test/phpunit.xml"
+        "test": "vendor/bin/phpunit -c test/phpunit.xml",
+        "post-install-cmd": [
+            "Google\\Task\\Composer::cleanup"
+        ],
+        "post-update-cmd": [
+            "Google\\Task\\Composer::cleanup"
+        ]
+    },
+    "extra": {
+        "google/apiclient-services": [
+            "Oauth2"
+        ]
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This change significantly reduces the disk space and deployment time for the application by removing over 300 unused Google API services from the `google/apiclient-services` package. Only the `Oauth2` service, which is required for Google Login, is retained. This is achieved using the official cleanup utility provided by the Google API PHP Client library.

Fixes #341

---
*PR created automatically by Jules for task [16534662838442691649](https://jules.google.com/task/16534662838442691649) started by @chatelao*