### PR TITLE
Fix Telegram configuration "cURL error 3"

### DIFF
--- a/src/backend/TelegramService.php
+++ b/src/backend/TelegramService.php
@@ -79,7 +79,7 @@ class TelegramService
         }
 
         try {
-            $response = $this->client->post("bot" . $this->botToken . "/" . $method, $options);
+            $response = $this->client->post("/bot" . $this->botToken . "/" . $method, $options);
             $data = json_decode($response->getBody()->getContents(), true);
 
             if (!isset($data['ok']) || $data['ok'] !== true) {


### PR DESCRIPTION
This PR fixes an issue where saving Telegram configuration settings would fail with a "cURL error 3". The root cause was that the Telegram bot token (which contains a colon) was being passed to Guzzle without a leading slash, causing the URI parser to misinterpret the token as a scheme or port.

Changes:
- Added a leading slash to the request path in `App\TelegramService::apiRequest`.
- Verified the fix with a reproduction script using a real-world format token.
- Ensured all existing tests pass.

Fixes #344

---
*PR created automatically by Jules for task [2706790474877833095](https://jules.google.com/task/2706790474877833095) started by @chatelao*