### PR TITLE
Add non-breaking code style verification to CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
     - name: Build documentation
       run: sphinx-build -b html docs docs/_build/html
 
+    - name: Run code style check
+      run: composer lint -- --report=full --no-colors > CODE_QUALITY.md || true
+
     - name: Upload artifacts
       if: always()
       uses: actions/upload-artifact@v4
@@ -78,3 +81,4 @@ jobs:
         path: |
           test/screenshots/
           docs/_build/html/
+          CODE_QUALITY.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.sqlite
 /test/screenshots/
 /docs/_build/
+CODE_QUALITY.md

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,12 @@
         "erusev/parsedown": "^1.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.0"
+        "phpunit/phpunit": "^11.0",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "scripts": {
         "test": "vendor/bin/phpunit -c test/phpunit.xml",
+        "lint": "vendor/bin/phpcs",
         "post-install-cmd": [
             "Google\\Task\\Composer::cleanup"
         ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "805ef97bd684f9ebafca122e2a3a1c85",
+    "content-hash": "358d6f6088ef0178c89291bf0caddd9d",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -3756,6 +3756,85 @@
                 }
             ],
             "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-10T16:43:36+00:00"
         },
         {
             "name": "staabm/side-effects-detector",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ruleset name="Project Rules">
+    <description>Project coding standard.</description>
+    <arg name="colors"/>
+    <arg value="sp"/>
+    <rule ref="PSR12"/>
+
+    <file>src/backend</file>
+    <file>src/frontend</file>
+
+    <exclude-pattern>src/frontend/vendor/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
This PR integrates PHP_CodeSniffer into the project and CI/CD pipeline to ensure coding style consistency following the PSR-12 standard.

Key changes:
- Added `squizlabs/php_codesniffer` to `composer.json`.
- Introduced a `composer lint` script for local and CI use.
- Created `phpcs.xml` configuration file targeting `src/backend` and `src/frontend` (excluding vendors).
- Modified `.github/workflows/ci.yml` to execute the style check in a non-breaking manner (`|| true`), saving output to `CODE_QUALITY.md` and uploading it as an artifact.
- Added `CODE_QUALITY.md` to `.gitignore` to keep the repository clean of generated reports.

Fixes #355

---
*PR created automatically by Jules for task [10831592784600724660](https://jules.google.com/task/10831592784600724660) started by @chatelao*