### PR TITLE
PR Mergeability Coloring

### DIFF
--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -109,6 +109,16 @@ if ($task['github_state'] === 'closed' && !empty($task['pr_url'])) {
     $prStatus = 'Passed';
 }
 
+$prBadgeClasses = "bg-{$prColor}-100 text-{$prColor}-800";
+if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
+    $mergeState = $prDetails['mergeable_state'] ?? '';
+    if ($mergeState === 'clean') {
+        $prBadgeClasses = "bg-green-200 text-green-900";
+    } elseif ($mergeState === 'behind') {
+        $prBadgeClasses = "bg-green-600 text-white";
+    }
+}
+
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -234,7 +244,7 @@ if ($task['github_state'] === 'closed' && !empty($task['pr_url'])) {
                                             <h4 class="text-lg font-bold text-gray-900 leading-tight">
                                                 <?= htmlspecialchars($prDetails['title'] ?? 'PR Details') ?>
                                             </h4>
-                                            <span class="px-2.5 py-0.5 rounded-full text-xs font-medium <?= $prDetails['state'] === 'open' ? 'bg-green-100 text-green-800' : 'bg-purple-100 text-purple-800' ?> border border-current shadow-sm">
+                                            <span class="px-2.5 py-0.5 rounded-full text-xs font-medium <?= $prBadgeClasses ?> border border-current shadow-sm">
                                                 <?= ucfirst($prDetails['state'] ?? 'unknown') ?>
                                             </span>
                                         </div>
@@ -328,7 +338,7 @@ if ($task['github_state'] === 'closed' && !empty($task['pr_url'])) {
                                     </div>
                                     <div class="flex items-center justify-between">
                                         <span class="text-sm font-medium text-gray-600">GH PR</span>
-                                        <span class="px-2.5 py-0.5 rounded-full text-xs font-medium bg-<?= $prColor ?>-100 text-<?= $prColor ?>-800">
+                                        <span class="px-2.5 py-0.5 rounded-full text-xs font-medium <?= $prBadgeClasses ?>">
                                             <?= htmlspecialchars($prStatus) ?>
                                         </span>
                                     </div>


### PR DESCRIPTION
I have updated the task detail page to reflect the mergeability status of associated Pull Requests. 

Specifically:
1. In `src/frontend/task.php`, I've added logic to check the `mergeable_state` property of the PR details returned by the GitHub API.
2. If the state is `clean` (indicating it is ready to be merged), the PR badge now uses a light green theme (`bg-green-200 text-green-900`).
3. If the state is `behind` (indicating it is mergeable but needs an update from the parent branch), the PR badge now uses a dark green theme (`bg-green-600 text-white`).
4. These changes are applied to both the sidebar status overview and the main PR information card.
5. I verified these visual changes by creating a temporary integration test script that mocked different GitHub API responses and confirmed the correct Tailwind classes were rendered in the HTML. I also captured screenshots of both states.
6. All existing unit and integration tests passed successfully.

Fixes #365

---
*PR created automatically by Jules for task [11323721655838360491](https://jules.google.com/task/11323721655838360491) started by @chatelao*