### PR TITLE
Fix undefined array key warnings for task counts

### DIFF
--- a/src/frontend/ajax-sync.php
+++ b/src/frontend/ajax-sync.php
@@ -66,14 +66,14 @@ try {
         'status' => 'success',
         'quota_usage' => $updatedUser['jules_quota_usage'] ?? 0,
         'quota_limit' => $updatedUser['jules_quota_limit'] ?? 0,
-        'total_tasks' => $counts['total'],
-        'open_issues' => $counts['open_issues'],
-        'completed_tasks' => $counts['completed_tasks'],
-        'jules_running' => $counts['jules_running'],
-        'jules_failed' => $counts['jules_failed'],
-        'github_running' => $counts['github_running'],
-        'github_passed' => $counts['github_passed'],
-        'github_failed' => $counts['github_failed']
+        'total_tasks' => $counts['total'] ?? 0,
+        'open_issues' => $counts['open_issues'] ?? 0,
+        'completed_tasks' => $counts['completed_tasks'] ?? 0,
+        'jules_running' => $counts['jules_running'] ?? 0,
+        'jules_failed' => $counts['jules_failed'] ?? 0,
+        'github_running' => $counts['github_running'] ?? 0,
+        'github_passed' => $counts['github_passed'] ?? 0,
+        'github_failed' => $counts['github_failed'] ?? 0
     ]);
 } catch (Exception $e) {
     http_response_code(500);

--- a/src/frontend/navbar-icons.php
+++ b/src/frontend/navbar-icons.php
@@ -1,18 +1,19 @@
 <?php
+
 /** @var array $user */
 /** @var App\User $userModel */
 /** @var App\Task $taskModel */
 
 if ($user) {
     $counts = $taskModel->getTaskCounts($user['user_id']);
-    $totalTasks = $counts['total'];
-    $openIssues = $counts['open_issues'];
-    $completedTasks = $counts['completed_tasks'];
-    $julesRunning = $counts['jules_running'];
-    $julesFailed = $counts['jules_failed'];
-    $githubRunning = $counts['github_running'];
-    $githubPassed = $counts['github_passed'];
-    $githubFailed = $counts['github_failed'];
+    $totalTasks = $counts['total'] ?? 0;
+    $openIssues = $counts['open_issues'] ?? 0;
+    $completedTasks = $counts['completed_tasks'] ?? 0;
+    $julesRunning = $counts['jules_running'] ?? 0;
+    $julesFailed = $counts['jules_failed'] ?? 0;
+    $githubRunning = $counts['github_running'] ?? 0;
+    $githubPassed = $counts['github_passed'] ?? 0;
+    $githubFailed = $counts['github_failed'] ?? 0;
 
     $quotaUsage = (int)($user['jules_quota_usage'] ?? 0);
     $quotaLimit = (int)($user['jules_quota_limit'] ?? 0);
@@ -51,8 +52,8 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
     syncing: <?= $syncStatus ? 'false' : 'true' ?>,
     syncStatus: <?= htmlspecialchars(json_encode($syncStatus)) ?>,
     syncMessage: <?= htmlspecialchars(json_encode($syncMessage)) ?>,
-    quotaUsage: <?= (int)($user['jules_quota_usage'] ?? 0) ?>,
-    quotaLimit: <?= (int)($user['jules_quota_limit'] ?? 0) ?>,
+    quotaUsage: <?= (int)$quotaUsage ?>,
+    quotaLimit: <?= (int)$quotaLimit ?>,
     openIssues: <?= (int)$openIssues ?>,
     totalTasks: <?= (int)$totalTasks ?>,
     completedTasks: <?= (int)$completedTasks ?>,


### PR DESCRIPTION
This change resolves the "Undefined array key" warnings and potential fatal errors shown in the reported error screenshot. By using the null coalescing operator (`?? 0`), we ensure that the application gracefully handles cases where certain task status counts might be missing from the background sync or initial load.

Key changes:
- Updated `src/frontend/navbar-icons.php` to safely handle all task count keys.
- Updated `src/frontend/ajax-sync.php` to provide safe defaults in its JSON response.
- Improved consistency in `navbar-icons.php` by using pre-calculated local variables for quota values in the Alpine.js state.
- Fixed a minor PSR-12 formatting issue (missing blank line after opening tag).

Fixes #366

---
*PR created automatically by Jules for task [16840566936437075784](https://jules.google.com/task/16840566936437075784) started by @chatelao*