### PR TITLE
Make navigation status counts clickable

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -102,6 +102,42 @@ class Task
         ];
     }
 
+    public function findByFilter(int $userId, string $filter): array
+    {
+        $sql = "SELECT t.*, p.github_repo
+                FROM tasks t
+                JOIN projects p ON t.project_id = p.project_id
+                WHERE t.user_id = ?";
+        $params = [$userId];
+
+        switch ($filter) {
+            case 'github_running':
+                $sql .= " AND t.github_state = 'open' AND t.status = 'implemented'";
+                break;
+            case 'github_passed':
+                $sql .= " AND t.github_state = 'open' AND t.status = 'completed'";
+                break;
+            case 'github_failed':
+                $sql .= " AND t.github_state = 'open' AND t.status = 'failed_pr'";
+                break;
+            case 'jules_running':
+                $sql .= " AND t.github_state = 'open' AND t.status IN ('researching', 'planning', 'in_progress', 'coding', 'testing')";
+                break;
+            case 'jules_failed':
+                $sql .= " AND t.github_state = 'open' AND t.status IN ('failed', 'failed_jules')";
+                break;
+            case 'open_issues':
+                $sql .= " AND t.github_state = 'open'";
+                break;
+        }
+
+        $sql .= " ORDER BY t.created_at DESC";
+
+        $stmt = $this->db->getConnection()->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchAll();
+    }
+
     public function getRunningAutorepeatTasks(int $userId): array
     {
         $stmt = $this->db->getConnection()->prepare(

--- a/src/frontend/navbar-icons.php
+++ b/src/frontend/navbar-icons.php
@@ -66,8 +66,9 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
     showNotifications: false,
     loadingNotifications: false,
     csrfToken: '<?= $auth->getCsrfToken() ?>',
+    basePath: window.location.pathname.includes('/admin/') ? '../' : '',
     init() {
-        const basePath = window.location.pathname.includes('/admin/') ? '../' : '';
+        const basePath = this.basePath;
 
         // Fetch Sync Status
         if (!this.syncStatus) {
@@ -164,9 +165,9 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
     <div class="flex items-center <?= $totalTasks > 0 ? 'text-black' : 'text-gray-300' ?>" title="GitHub PR Status: Running (Yellow), Passed (Green), Failed (Red)">
         <svg class="w-5 h-5 mr-1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
         <span class="text-xs font-bold space-x-1">
-            <span class="text-yellow-600" x-text="githubRunning"><?= $githubRunning ?></span>
-            <span class="text-green-600" x-text="githubPassed"><?= $githubPassed ?></span>
-            <span class="text-red-600" x-text="githubFailed"><?= $githubFailed ?></span>
+            <a :href="basePath + 'tasks.php?filter=github_running'" class="text-yellow-600 hover:underline" x-text="githubRunning"><?= $githubRunning ?></a>
+            <a :href="basePath + 'tasks.php?filter=github_passed'" class="text-green-600 hover:underline" x-text="githubPassed"><?= $githubPassed ?></a>
+            <a :href="basePath + 'tasks.php?filter=github_failed'" class="text-red-600 hover:underline" x-text="githubFailed"><?= $githubFailed ?></a>
         </span>
     </div>
 
@@ -175,9 +176,9 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
          title="Jules Sessions: Remaining (Green), Running (Yellow), Failed (Red)">
         <svg class="w-5 h-5 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .52 5.586 3.004 3.004 0 0 0 5.193 2.019A4 4 0 0 1 12 18c.35 0 .692.045 1.02.13a3.004 3.004 0 0 0 5.193-2.019 4 4 0 0 0 .52-5.586 4 4 0 0 0-2.526-5.77A3 3 0 1 0 12 5M9 14.5a2.5 2.5 0 0 0 2.46-2.019M15 14.5a2.5 2.5 0 0 1-2.46-2.019"/></svg>
         <span class="text-xs font-bold space-x-1">
-            <span class="text-green-600" x-text="quotaLimit > 0 ? (quotaLimit - quotaUsage) : 0"><?= max(0, $quotaLimit - $quotaUsage) ?></span>
-            <span class="text-yellow-600" x-text="julesRunning"><?= $julesRunning ?></span>
-            <span class="text-red-600" x-text="julesFailed"><?= $julesFailed ?></span>
+            <a :href="basePath + 'tasks.php?filter=open_issues'" class="text-green-600 hover:underline" x-text="quotaLimit > 0 ? (quotaLimit - quotaUsage) : 0"><?= max(0, $quotaLimit - $quotaUsage) ?></a>
+            <a :href="basePath + 'tasks.php?filter=jules_running'" class="text-yellow-600 hover:underline" x-text="julesRunning"><?= $julesRunning ?></a>
+            <a :href="basePath + 'tasks.php?filter=jules_failed'" class="text-red-600 hover:underline" x-text="julesFailed"><?= $julesFailed ?></a>
         </span>
     </div>
 

--- a/src/frontend/tasks.php
+++ b/src/frontend/tasks.php
@@ -1,0 +1,160 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Database;
+use App\Auth;
+use App\User;
+use App\Project;
+use App\Task;
+
+$auth = new Auth();
+$db = new Database();
+$userModel = new User($db);
+$taskModel = new Task($db);
+
+if (!$auth->isLoggedIn()) {
+    header('Location: login.php');
+    exit;
+}
+
+$user = $userModel->findById($auth->getUserId());
+$filter = $_GET['filter'] ?? 'all_open';
+
+$tasks = $taskModel->findByFilter($user['user_id'], $filter);
+
+$filterLabels = [
+    'github_running' => 'GitHub: Running Checks',
+    'github_passed' => 'GitHub: Checks Passed',
+    'github_failed' => 'GitHub: Checks Failed',
+    'jules_running' => 'Jules: Sessions Running',
+    'jules_failed' => 'Jules: Sessions Failed',
+    'open_issues' => 'All Open Issues'
+];
+
+$title = $filterLabels[$filter] ?? 'Tasks';
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($title) ?> - Agent Control</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body class="bg-gray-100 font-sans leading-normal tracking-normal">
+    <nav class="bg-white border-b border-gray-200 fixed w-full z-30 top-0">
+        <div class="px-3 py-3 lg:px-5 lg:pl-3">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center justify-start">
+                    <a href="index.php" class="text-xl font-bold flex items-center lg:ml-2.5">
+                        <span class="self-center whitespace-nowrap">Agent Control</span>
+                    </a>
+                </div>
+                <div class="flex items-center">
+                    <?php include 'navbar-icons.php'; ?>
+                    <div class="flex items-center ml-3">
+                        <img class="w-8 h-8 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="user photo">
+                        <div class="ml-3 text-sm font-medium text-gray-900"><?= htmlspecialchars($user['name'] ?? '') ?></div>
+                        <a href="templates.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Templates</a>
+                        <a href="settings.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Settings</a>
+                        <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <div class="flex pt-16 overflow-hidden bg-gray-50">
+        <div id="main-content" class="relative w-full h-full overflow-y-auto bg-gray-50">
+            <main>
+                <div class="px-4 pt-6">
+                    <nav class="flex mb-5" aria-label="Breadcrumb">
+                        <ol class="inline-flex items-center space-x-1 md:space-x-2">
+                            <li class="inline-flex items-center">
+                                <a href="index.php" class="text-gray-700 hover:text-gray-900 inline-flex items-center">
+                                    <svg class="w-5 h-5 mr-2.5" fill="currentColor" viewBox="0 0 20 20"><path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path></svg>
+                                    Dashboard
+                                </a>
+                            </li>
+                            <li>
+                                <div class="flex items-center">
+                                    <svg class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
+                                    <span class="text-gray-400 ml-1 md:ml-2 font-medium"><?= htmlspecialchars($title) ?></span>
+                                </div>
+                            </li>
+                        </ol>
+                    </nav>
+
+                    <div class="mb-6">
+                        <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl"><?= htmlspecialchars($title) ?></h1>
+                    </div>
+
+                    <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+                        <div class="overflow-x-auto">
+                            <table class="w-full text-sm text-left text-gray-500">
+                                <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+                                    <tr>
+                                        <th scope="col" class="px-6 py-3">Project</th>
+                                        <th scope="col" class="px-6 py-3">Issue</th>
+                                        <th scope="col" class="px-6 py-3">Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php if (empty($tasks)): ?>
+                                        <tr class="bg-white border-b">
+                                            <td colspan="3" class="px-6 py-4 text-center">No tasks matching this filter.</td>
+                                        </tr>
+                                    <?php endif; ?>
+                                    <?php foreach ($tasks as $task): ?>
+                                        <tr class="bg-white border-b hover:bg-gray-50 transition-colors">
+                                            <td class="px-6 py-4 font-medium text-gray-900">
+                                                <a href="project.php?id=<?= $task['project_id'] ?>" class="text-blue-600 hover:underline">
+                                                    <?= htmlspecialchars($task['github_repo'] ?? '') ?>
+                                                </a>
+                                            </td>
+                                            <td class="px-6 py-4">
+                                                <div class="text-base text-gray-900 font-normal">
+                                                    <a href="task.php?id=<?= $task['task_id'] ?>" class="hover:underline">#<?= htmlspecialchars($task['issue_number'] ?? '') ?></a>
+                                                    <a href="<?= htmlspecialchars($taskModel->getTargetUrl($task)) ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
+                                                        <?= htmlspecialchars($task['title'] ?? '') ?>
+                                                    </a>
+                                                </div>
+                                            </td>
+                                            <td class="px-6 py-4">
+                                                <?php
+                                                $statusColor = $taskModel->getStatusColor($task);
+                                                $bgClass = 'bg-gray-100 text-gray-800';
+                                                if ($statusColor === 'green') $bgClass = 'bg-green-100 text-green-800';
+                                                elseif ($statusColor === 'yellow') $bgClass = 'bg-yellow-100 text-yellow-800';
+                                                elseif ($statusColor === 'blue') $bgClass = 'bg-blue-100 text-blue-800';
+                                                elseif ($statusColor === 'red') $bgClass = 'bg-red-100 text-red-800';
+                                                elseif ($statusColor === 'purple') $bgClass = 'bg-purple-100 text-purple-800';
+                                                ?>
+                                                <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
+                                                    <?php
+                                                    if (($task['github_state'] ?? 'open') === 'closed') echo '✅ ';
+                                                    elseif ($task['status'] === 'completed') echo '✅ ';
+                                                    elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') echo '❌ Jules ';
+                                                    elseif ($task['status'] === 'failed_pr') echo '❌ PR ';
+                                                    elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) echo '🚧 ';
+                                                    else echo '⏳ ';
+                                                    ?>
+                                                    <?= htmlspecialchars(str_replace(['failed_jules', 'failed_pr'], 'failed', $task['status'] ?? '')) ?>
+                                                </span>
+                                            </td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </div>
+</body>
+</html>

--- a/test/Integration/verify_tasks_list_ui.php
+++ b/test/Integration/verify_tasks_list_ui.php
@@ -1,0 +1,101 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Database;
+use App\Auth;
+use App\User;
+use App\Project;
+use App\Task;
+
+// Set environment for testing
+putenv('DB_NAME=:memory:');
+
+// Initialize session if not started
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$db = new Database();
+$pdo = $db->getConnection();
+
+// Create schema
+$pdo->exec("CREATE TABLE IF NOT EXISTS users (
+    user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    google_id VARCHAR(255) UNIQUE NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    avatar VARCHAR(255),
+    role VARCHAR(20) DEFAULT 'user',
+    jules_api_key VARCHAR(255),
+    jules_quota_usage INT DEFAULT 0,
+    jules_quota_limit INT DEFAULT 100,
+    telegram_bot_token VARCHAR(255),
+    telegram_webhook_secret VARCHAR(255),
+    telegram_link_token VARCHAR(255),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS projects (
+    project_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    github_account_id INT NOT NULL,
+    github_repo VARCHAR(255) NOT NULL,
+    github_username VARCHAR(255),
+    webhook_secret VARCHAR(255),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
+    task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    project_id INT NOT NULL,
+    issue_number INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    body TEXT,
+    status TEXT DEFAULT 'pending',
+    jules_status VARCHAR(50) DEFAULT 'pending',
+    github_state VARCHAR(20) DEFAULT 'open',
+    github_data TEXT,
+    agent_response TEXT,
+    pr_url VARCHAR(255),
+    jules_url VARCHAR(255),
+    jules_session_id VARCHAR(255),
+    last_synced_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS notifications (
+    notification_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    message TEXT NOT NULL,
+    data TEXT,
+    is_read BOOLEAN DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_telegram_accounts (
+    telegram_account_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    telegram_chat_id BIGINT UNIQUE NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+// Create a mock user
+$pdo->exec("INSERT OR IGNORE INTO users (user_id, google_id, name, email, jules_quota_usage, jules_quota_limit) VALUES (1, 'google-123', 'Test User', 'test@example.com', 10, 100)");
+$_SESSION['user_id'] = 1;
+
+// Create mock project
+$pdo->exec("INSERT INTO projects (project_id, user_id, github_account_id, github_repo, github_username) VALUES (1, 1, 1, 'owner/repo', 'owner')");
+
+// Create mock tasks for different filters
+$pdo->exec("INSERT INTO tasks (user_id, project_id, issue_number, title, status, github_state) VALUES (1, 1, 1, 'GitHub Running Task', 'implemented', 'open')");
+$pdo->exec("INSERT INTO tasks (user_id, project_id, issue_number, title, status, github_state) VALUES (1, 1, 2, 'GitHub Passed Task', 'completed', 'open')");
+$pdo->exec("INSERT INTO tasks (user_id, project_id, issue_number, title, status, github_state) VALUES (1, 1, 3, 'GitHub Failed Task', 'failed_pr', 'open')");
+$pdo->exec("INSERT INTO tasks (user_id, project_id, issue_number, title, status, github_state) VALUES (1, 1, 4, 'Jules Running Task', 'coding', 'open')");
+$pdo->exec("INSERT INTO tasks (user_id, project_id, issue_number, title, status, github_state) VALUES (1, 1, 5, 'Jules Failed Task', 'failed_jules', 'open')");
+
+// Include tasks.php
+include __DIR__ . '/../../src/frontend/tasks.php';


### PR DESCRIPTION
This PR enables users to click on the six status count numbers in the top navigation bar to jump directly to a filtered list of the affected tasks.

Key changes:
- **Backend**: Implemented `App\Task::findByFilter` which supports filtering by `github_running`, `github_passed`, `github_failed`, `jules_running`, `jules_failed`, and `open_issues`.
- **Frontend**: Created a new `tasks.php` view that renders the filtered task list in a table format consistent with the project's UI.
- **Navigation**: Updated `navbar-icons.php` to make the count indicators clickable. It uses Alpine.js to dynamically determine the correct base path, ensuring the links remain functional even when browsing from within the `/admin/` directory.
- **Verification**: Included a new integration test script `test/Integration/verify_tasks_list_ui.php` and verified the UI via Playwright screenshots.

Fixes #367

---
*PR created automatically by Jules for task [9859278392922373195](https://jules.google.com/task/9859278392922373195) started by @chatelao*