### PR TITLE
Granular Task Status Broadcast Control

### DIFF
--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -42,7 +42,17 @@ class NotificationService
             $notificationId = $this->persistNotification($userId, $type, $title, $message, $data);
         }
 
-        // 5. Dispatch to other enabled channels
+        // 5. Check if broadcast is enabled for this status (if it's a task_status event)
+        $shouldBroadcast = true;
+        if ($type === 'task_status' && isset($data['project_id']) && isset($data['status'])) {
+            $shouldBroadcast = $this->isStatusBroadcastEnabled((int)$data['project_id'], $data['status']);
+        }
+
+        if (!$shouldBroadcast) {
+            return true;
+        }
+
+        // 6. Dispatch to other enabled channels
         $notification = [
             'notification_id' => $notificationId,
             'user_id' => $userId,
@@ -164,6 +174,61 @@ class NotificationService
         }
     }
 
+    public function getStatusSettings(int $projectId): array
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "SELECT status, is_enabled FROM project_status_notification_settings WHERE project_id = ?"
+        );
+        $stmt->execute([$projectId]);
+        $rows = $stmt->fetchAll();
+
+        $settings = [];
+        foreach ($rows as $row) {
+            $settings[$row['status']] = (bool)$row['is_enabled'];
+        }
+
+        // Default settings if not present
+        $statuses = ['researching', 'planning', 'coding', 'testing', 'in_progress', 'implemented', 'completed', 'failed_jules', 'failed_pr'];
+        foreach ($statuses as $status) {
+            if (!isset($settings[$status])) {
+                $settings[$status] = true;
+            }
+        }
+
+        return $settings;
+    }
+
+    public function updateStatusSettings(int $projectId, array $settings): bool
+    {
+        $db = $this->db->getConnection();
+        $db->beginTransaction();
+
+        try {
+            foreach ($settings as $status => $enabled) {
+                $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+                if ($driver === 'sqlite') {
+                    $stmt = $db->prepare(
+                        "INSERT INTO project_status_notification_settings (project_id, status, is_enabled)
+                         VALUES (?, ?, ?)
+                         ON CONFLICT(project_id, status) DO UPDATE SET is_enabled = excluded.is_enabled"
+                    );
+                } else {
+                    $stmt = $db->prepare(
+                        "INSERT INTO project_status_notification_settings (project_id, status, is_enabled)
+                         VALUES (?, ?, ?)
+                         ON DUPLICATE KEY UPDATE is_enabled = VALUES(is_enabled)"
+                    );
+                }
+                $stmt->execute([$projectId, $status, (int)$enabled]);
+            }
+            $db->commit();
+            return true;
+        } catch (\Exception $e) {
+            $db->rollBack();
+            return false;
+        }
+    }
+
     private function isTaskMuted(int $taskId): bool
     {
         $settings = $this->getTaskSettings($taskId);
@@ -174,6 +239,12 @@ class NotificationService
     {
         $settings = $this->getProjectSettings($projectId);
         return $settings[$type] ?? true;
+    }
+
+    private function isStatusBroadcastEnabled(int $projectId, string $status): bool
+    {
+        $settings = $this->getStatusSettings($projectId);
+        return $settings[$status] ?? true;
     }
 
     private function persistNotification(int $userId, string $type, string $title, string $message, array $data): int

--- a/src/frontend/project-settings.php
+++ b/src/frontend/project-settings.php
@@ -66,7 +66,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_notifications'
         'task_status' => isset($_POST['notify_task_status']),
         'agent_event' => isset($_POST['notify_agent_event'])
     ];
-    if ($notificationService->updateProjectSettings($projectId, $settings)) {
+
+    $statusSettings = [
+        'researching' => isset($_POST['broadcast_researching']),
+        'planning' => isset($_POST['broadcast_planning']),
+        'coding' => isset($_POST['broadcast_coding']),
+        'testing' => isset($_POST['broadcast_testing']),
+        'in_progress' => isset($_POST['broadcast_in_progress']),
+        'implemented' => isset($_POST['broadcast_implemented']),
+        'completed' => isset($_POST['broadcast_completed']),
+        'failed_jules' => isset($_POST['broadcast_failed_jules']),
+        'failed_pr' => isset($_POST['broadcast_failed_pr'])
+    ];
+
+    if ($notificationService->updateProjectSettings($projectId, $settings) &&
+        $notificationService->updateStatusSettings($projectId, $statusSettings)) {
         $redirectUrl = basename($_SERVER['PHP_SELF']) . "?id=$projectId&success=notifications_updated";
         header("Location: $redirectUrl");
         exit;
@@ -264,8 +278,9 @@ if (isset($_GET['success'])) {
                             <h3 class="text-lg font-bold text-gray-900 mb-4">Notification Preferences</h3>
                             <?php
                             $projectNotifSettings = $notificationService->getProjectSettings($projectId);
+                            $statusNotifSettings = $notificationService->getStatusSettings($projectId);
                             ?>
-                            <form method="POST" class="space-y-4">
+                            <form method="POST" class="space-y-6">
                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                                     <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
@@ -290,6 +305,36 @@ if (isset($_GET['success'])) {
                                         </label>
                                     </div>
                                 </div>
+
+                                <div class="border-t border-gray-100 pt-4">
+                                    <h4 class="text-sm font-bold text-gray-900 mb-2 uppercase tracking-wider">Status Broadcast Preferences</h4>
+                                    <p class="text-xs text-gray-500 mb-4">Choose which status changes trigger a broadcast (Telegram/Browser). All events still appear in the inbox.</p>
+                                    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                                        <?php
+                                        $statuses = [
+                                            'researching' => 'Researching',
+                                            'planning' => 'Planning',
+                                            'coding' => 'Coding',
+                                            'testing' => 'Testing',
+                                            'in_progress' => 'In Progress',
+                                            'implemented' => 'Implemented',
+                                            'completed' => 'Completed',
+                                            'failed_jules' => 'Jules Failed',
+                                            'failed_pr' => 'PR Failed'
+                                        ];
+                                        foreach ($statuses as $id => $label):
+                                        ?>
+                                        <div class="flex items-center justify-between p-2 bg-gray-50 rounded-lg border border-gray-100 shadow-sm">
+                                            <span class="text-xs font-medium text-gray-600"><?= $label ?></span>
+                                            <label class="relative inline-flex items-center cursor-pointer scale-75">
+                                                <input type="checkbox" name="broadcast_<?= $id ?>" class="sr-only peer" <?= ($statusNotifSettings[$id] ?? true) ? 'checked' : '' ?>>
+                                                <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                                            </label>
+                                        </div>
+                                        <?php endforeach; ?>
+                                    </div>
+                                </div>
+
                                 <button type="submit" name="update_notifications" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Save Notification Settings</button>
                             </form>
                         </div>

--- a/src/sql/patches/011_add_status_broadcast_settings.sql
+++ b/src/sql/patches/011_add_status_broadcast_settings.sql
@@ -1,0 +1,11 @@
+-- SQL Patch: Add status broadcast settings
+-- This table stores which task statuses should trigger a broadcast (Telegram, Browser)
+-- while ensuring all events still appear in the in-app event list.
+
+CREATE TABLE IF NOT EXISTS project_status_notification_settings (
+    project_id INT NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    is_enabled BOOLEAN DEFAULT TRUE,
+    PRIMARY KEY (project_id, status),
+    FOREIGN KEY (project_id) REFERENCES projects(project_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/test/Integration/verify_project_settings_ui.php
+++ b/test/Integration/verify_project_settings_ui.php
@@ -52,6 +52,13 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS task_notification_settings (
     is_muted BOOLEAN DEFAULT 0
 )");
 
+$pdo->exec("CREATE TABLE IF NOT EXISTS project_status_notification_settings (
+    project_id INTEGER NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    is_enabled BOOLEAN DEFAULT 1,
+    PRIMARY KEY (project_id, status)
+)");
+
 $pdo->exec("CREATE TABLE IF NOT EXISTS user_telegram_accounts (
     telegram_account_id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INT NOT NULL,


### PR DESCRIPTION
I have updated the notification system to allow granular control over which task status changes should trigger a broadcast to external channels (like Telegram), while ensuring that all events still appear in the in-app event list (inbox).

Key changes:
1.  **Database Migration**: Created `src/sql/patches/011_add_status_broadcast_settings.sql` to store per-project status broadcast preferences.
2.  **Backend Logic**: Updated `App\NotificationService` to implement `getStatusSettings`, `updateStatusSettings`, and `isStatusBroadcastEnabled`. Modified the `notify()` method to ensure that `task_status` notifications are always persisted to the inbox (if enabled) but only broadcast to other channels if the specific status is enabled in the project settings.
3.  **Frontend UI**: Enhanced `src/frontend/project-settings.php` with a new "Status Broadcast Preferences" section, providing toggles for all major task statuses (researching, planning, coding, testing, in_progress, implemented, completed, failed_jules, failed_pr).
4.  **Verification**: Verified the changes with automated tests and visual inspection using Playwright scripts. Recorded screenshots and videos are available in the verification directory.

Fixes #371

---
*PR created automatically by Jules for task [4957704777690326968](https://jules.google.com/task/4957704777690326968) started by @chatelao*