### PR TITLE
Cleanup Deleted GitHub Issues in Cronjob

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -4,6 +4,7 @@ namespace App;
 
 use Github\Client;
 use Github\AuthMethod;
+use Github\ResultPager;
 use Exception;
 
 class GitHubService
@@ -141,9 +142,10 @@ class GitHubService
 
         [$username, $repository] = $parts;
 
-        return $this->client->api('issue')->all($username, $repository, [
+        $pager = new ResultPager($this->client);
+        return $pager->fetchAll($this->client->api('issue'), 'all', [$username, $repository, [
             'state' => $state
-        ]);
+        ]]);
     }
 
     /**

--- a/src/backend/Project.php
+++ b/src/backend/Project.php
@@ -51,7 +51,7 @@ class Project
     public function findByUserId(int $userId): array
     {
         $stmt = $this->db->getConnection()->prepare(
-            "SELECT p.*, a.github_username
+            "SELECT p.*, a.github_username, a.github_token
              FROM projects p
              JOIN user_github_accounts a ON p.github_account_id = a.github_account_id
              WHERE p.user_id = ?

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -211,6 +211,22 @@ class Task
         return $stmt->execute([$projectId, $issueNumber]);
     }
 
+    public function deleteByIssueNumbersNotIn(int $projectId, array $issueNumbers): bool
+    {
+        if (empty($issueNumbers)) {
+            $stmt = $this->db->getConnection()->prepare(
+                "DELETE FROM tasks WHERE project_id = ?"
+            );
+            return $stmt->execute([$projectId]);
+        }
+
+        $placeholders = implode(',', array_fill(0, count($issueNumbers), '?'));
+        $stmt = $this->db->getConnection()->prepare(
+            "DELETE FROM tasks WHERE project_id = ? AND issue_number NOT IN ($placeholders)"
+        );
+        return $stmt->execute(array_merge([$projectId], $issueNumbers));
+    }
+
     public function updateStatus(int $id, string $status): bool
     {
         $stmt = $this->db->getConnection()->prepare(
@@ -247,6 +263,7 @@ class Task
     public function syncIssues(int $userId, int $projectId, string $repo, GitHubService $githubService): void
     {
         $issues = $githubService->listIssues($repo, 'all');
+        $issueNumbers = [];
 
         foreach ($issues as $issue) {
             // Check if it's really an issue (not a PR)
@@ -254,7 +271,10 @@ class Task
                 continue;
             }
             $this->upsert($userId, $projectId, $issue);
+            $issueNumbers[] = $issue['number'];
         }
+
+        $this->deleteByIssueNumbersNotIn($projectId, $issueNumbers);
     }
 
     public function upsert(int $userId, int $projectId, array $issue): bool
@@ -480,7 +500,7 @@ class Task
         return $issueUrl;
     }
 
-    public function refreshJulesStatus(int $userId, GitHubService $githubService, JulesService $julesService, ?NotificationService $notificationService = null, ?int $taskId = null): void
+    public function refreshJulesStatus(int $userId, GitHubService $githubService, JulesService $julesService, ?NotificationService $notificationService = null, ?int $taskId = null, ?int $projectId = null): void
     {
         $sql = "SELECT t.*, p.github_repo
              FROM tasks t
@@ -492,6 +512,13 @@ class Task
         if ($taskId) {
             $sql .= " AND t.task_id = ?";
             $params[] = $taskId;
+        } elseif ($projectId) {
+            $sql .= " AND t.project_id = ?";
+            $params[] = $projectId;
+            $fiveMinutesAgo = date('Y-m-d H:i:s', strtotime('-5 minutes'));
+            $sql .= " AND (t.last_synced_at IS NULL OR t.last_synced_at < ?)
+                      AND (t.status NOT IN ('completed', 'failed', 'failed_jules', 'failed_pr') OR t.jules_status NOT IN ('completed', 'failed'))";
+            $params[] = $fiveMinutesAgo;
         } else {
             $fiveMinutesAgo = date('Y-m-d H:i:s', strtotime('-5 minutes'));
             $sql .= " AND (t.last_synced_at IS NULL OR t.last_synced_at < ?)

--- a/src/frontend/cronjob.php
+++ b/src/frontend/cronjob.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 use App\Database;
 use App\User;
+use App\Project;
 use App\Task;
 use App\GitHubService;
 use App\JulesService;
@@ -17,29 +18,29 @@ if ($cronSecret && ($_GET['key'] ?? '') !== $cronSecret) {
 
 $db = new Database();
 $userModel = new User($db);
+$projectModel = new Project($db);
 $taskModel = new Task($db);
-$githubService = new GitHubService();
 $julesService = new JulesService();
 
 $users = $userModel->getAllUsersWithProjectCount();
 
-echo "Starting Jules session state refresh...\n";
+echo "Starting synchronization and refresh...\n";
 
 foreach ($users as $user) {
     $userId = (int)$user['user_id'];
-    echo "Refreshing for user: " . $user['name'] . " (ID: $userId)...\n";
+    echo "Processing user: " . $user['name'] . " (ID: $userId)...\n";
 
-    // We need a GitHub token to fetch comments.
-    // refreshJulesStatus currently takes one GitHubService.
-    // If a user has multiple GitHub accounts, we might need to iterate.
-    $githubAccounts = $userModel->getGitHubAccounts($userId);
+    $projects = $projectModel->findByUserId($userId);
+    foreach ($projects as $project) {
+        if (!empty($project['github_token'])) {
+            echo "  Syncing project: " . $project['github_repo'] . "...\n";
+            $scopedGithubService = new GitHubService(null, $project['github_token']);
+            $taskModel->syncIssues($userId, $project['project_id'], $project['github_repo'], $scopedGithubService);
 
-    foreach ($githubAccounts as $account) {
-        $scopedGithubService = new GitHubService(null, $account['github_token']);
-        $scopedJulesService = new JulesService(null, $user['jules_api_key'] ?? null);
-
-        $taskModel->refreshJulesStatus($userId, $scopedGithubService, $scopedJulesService);
+            $scopedJulesService = new JulesService(null, $user['jules_api_key'] ?? null);
+            $taskModel->refreshJulesStatus($userId, $scopedGithubService, $scopedJulesService, null, null, $project['project_id']);
+        }
     }
 }
 
-echo "Finished Jules session state refresh.\n";
+echo "Finished synchronization and refresh.\n";


### PR DESCRIPTION
This PR implements a cleanup mechanism to ensure that issues deleted on GitHub are also removed from the local database during the periodic cronjob. 

Key changes:
1.  **GitHubService:** Updated `listIssues` to use `Github\ResultPager`, ensuring all pages of issues are fetched.
2.  **Task Model:**
    *   Added `deleteByIssueNumbersNotIn(int $projectId, array $issueNumbers)` to remove local tasks not found on GitHub.
    *   Updated `syncIssues` to call this cleanup method after processing current issues.
    *   Enhanced `refreshJulesStatus` with an optional `projectId` parameter to allow targeted status updates.
3.  **Cronjob:** Restructured `cronjob.php` to iterate through users and their projects, performing a full `syncIssues` followed by a targeted `refreshJulesStatus`.
4.  **Project Model:** Updated `findByUserId` to include `github_token`, enabling authenticated synchronization in the cronjob.

These changes ensure the local system remains in sync with GitHub even if webhook events are missed.

Fixes #381

---
*PR created automatically by Jules for task [1560578977088117821](https://jules.google.com/task/1560578977088117821) started by @chatelao*