### PR TITLE
Remove system-wide Telegram key and use per-user configuration

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,6 @@ To receive real-time updates for issue events, you must configure a webhook for 
 ### 5. Telegram Bot
 1.  Message [@BotFather](https://t.me/botfather) on Telegram.
 2.  Use the `/newbot` command and follow the instructions to get your **Bot Token**.
-3.  For `TELEGRAM_WEBHOOK_SECRET`, generate a random, secure string (e.g., using `openssl rand -hex 32`). This is used to verify that requests to your webhook are actually coming from Telegram.
 
 ---
 
@@ -183,8 +182,6 @@ Use this method if you want to deploy from your local machine via SSH.
    #
    # Telegram Bot: https://t.me/botfather
    #
-   SetEnv TELEGRAM_BOT_TOKEN      your_telegram_bot_token
-   SetEnv TELEGRAM_WEBHOOK_SECRET your_telegram_webhook_secret
 
    #
    # Administration
@@ -242,8 +239,6 @@ The application requires several environment variables to be set in your web ser
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth App Client Secret |
 | `GITHUB_REDIRECT_URI` | `https://your-domain.com/github-callback.php` |
 | `GOOGLE_JULES_API_KEY` | (Optional/Deprecated) Global fallback API Key for Google Jules/Gemini. Users should now set their own keys in the Dashboard. |
-| `TELEGRAM_BOT_TOKEN` | (Optional) Telegram Bot Token |
-| `TELEGRAM_WEBHOOK_SECRET` | (Optional) Secret token for Telegram webhooks |
 | `UPGRADE_ALLOWED_EMAIL` | (Required for upgrades) Email address of the admin user authorized to trigger database migrations on the Admin Dashboard. |
 | `ENABLE_UPGRADE_PAGE` | (Optional) Set to `true` to enable the interactive database upgrade page at `/upgrade.php`. Useful for initial setup or maintenance. **Disable after use for security.** |
 | `DB_UPGRADE_SECRET` | (Optional) A secret token that allows automated database upgrades via the "Apply DB Patch" workflow. Should be set in `.htaccess` or server configuration. |

--- a/src/backend/TelegramChannelHandler.php
+++ b/src/backend/TelegramChannelHandler.php
@@ -13,9 +13,15 @@ class TelegramChannelHandler implements NotificationChannelInterface
     public function send(array $notification): bool
     {
         $userId = $notification['user_id'];
-        $chatId = $this->userModel->getTelegramChatId($userId);
+        $user = $this->userModel->findById($userId);
+        if (!$user) {
+            return false;
+        }
 
-        if (!$chatId) {
+        $chatId = $this->userModel->getTelegramChatId($userId);
+        $botToken = $user['telegram_bot_token'] ?? '';
+
+        if (!$chatId || !$botToken) {
             return false;
         }
 
@@ -32,7 +38,7 @@ class TelegramChannelHandler implements NotificationChannelInterface
         }
 
         try {
-            return $this->telegramService->sendMessage($chatId, $text);
+            return $this->telegramService->withToken($botToken)->sendMessage($chatId, $text);
         } catch (\Exception $e) {
             // Silently fail for now, or log if needed
             return false;

--- a/src/backend/TelegramService.php
+++ b/src/backend/TelegramService.php
@@ -17,7 +17,14 @@ class TelegramService
             'base_uri' => 'https://api.telegram.org/',
             'timeout'  => 10.0,
         ]);
-        $this->botToken = $botToken ?? (getenv('TELEGRAM_BOT_TOKEN') ?: '');
+        $this->botToken = $botToken ?? '';
+    }
+
+    public function withToken(string $botToken): self
+    {
+        $new = clone $this;
+        $new->botToken = $botToken;
+        return $new;
     }
 
     /**

--- a/src/frontend/telegram-webhook.php
+++ b/src/frontend/telegram-webhook.php
@@ -16,18 +16,14 @@ $userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : null;
 $headers = getallheaders();
 $headersStr = json_encode($headers);
 $input = file_get_contents('php://input');
-$botToken = getenv('TELEGRAM_BOT_TOKEN') ?: '';
-$webhookSecret = getenv('TELEGRAM_WEBHOOK_SECRET') ?: '';
+$botToken = '';
+$webhookSecret = '';
 
 if ($userId) {
     $user = $userModel->findById($userId);
     if ($user) {
-        if (!empty($user['telegram_bot_token'])) {
-            $botToken = $user['telegram_bot_token'];
-        }
-        if (!empty($user['telegram_webhook_secret'])) {
-            $webhookSecret = $user['telegram_webhook_secret'];
-        }
+        $botToken = $user['telegram_bot_token'] ?? '';
+        $webhookSecret = $user['telegram_webhook_secret'] ?? '';
     }
 }
 

--- a/test/Unit/Services/TelegramChannelHandlerTest.php
+++ b/test/Unit/Services/TelegramChannelHandlerTest.php
@@ -32,11 +32,22 @@ class TelegramChannelHandlerTest extends TestCase
         ];
 
         $this->userModel->expects($this->once())
+            ->method('findById')
+            ->with(1)
+            ->willReturn(['user_id' => 1, 'telegram_bot_token' => 'fake-token']);
+
+        $this->userModel->expects($this->once())
             ->method('getTelegramChatId')
             ->with(1)
             ->willReturn(123456);
 
+        $mockService = $this->createMock(TelegramService::class);
         $this->telegramService->expects($this->once())
+            ->method('withToken')
+            ->with('fake-token')
+            ->willReturn($mockService);
+
+        $mockService->expects($this->once())
             ->method('sendMessage')
             ->with(123456, $this->stringContains('<b>Test Notification</b>'))
             ->willReturn(true);
@@ -54,12 +65,17 @@ class TelegramChannelHandlerTest extends TestCase
         ];
 
         $this->userModel->expects($this->once())
+            ->method('findById')
+            ->with(1)
+            ->willReturn(['user_id' => 1, 'telegram_bot_token' => 'fake-token']);
+
+        $this->userModel->expects($this->once())
             ->method('getTelegramChatId')
             ->with(1)
             ->willReturn(null);
 
         $this->telegramService->expects($this->never())
-            ->method('sendMessage');
+            ->method('withToken');
 
         $result = $this->handler->send($notification);
         $this->assertFalse($result);
@@ -74,11 +90,22 @@ class TelegramChannelHandlerTest extends TestCase
         ];
 
         $this->userModel->expects($this->once())
+            ->method('findById')
+            ->with(1)
+            ->willReturn(['user_id' => 1, 'telegram_bot_token' => 'fake-token']);
+
+        $this->userModel->expects($this->once())
             ->method('getTelegramChatId')
             ->with(1)
             ->willReturn(123456);
 
+        $mockService = $this->createMock(TelegramService::class);
         $this->telegramService->expects($this->once())
+            ->method('withToken')
+            ->with('fake-token')
+            ->willReturn($mockService);
+
+        $mockService->expects($this->once())
             ->method('sendMessage')
             ->willThrowException(new \Exception('API Error'));
 


### PR DESCRIPTION
Removed all system-wide Telegram bot configurations. The system now solely relies on per-user 'Custom Bot' settings stored in the database. This includes updates to the service layer, webhook handler, notification dispatcher, documentation, and relevant unit tests.

Fixes #385

---
*PR created automatically by Jules for task [9058968126097045299](https://jules.google.com/task/9058968126097045299) started by @chatelao*