### PR TITLE
Remove system-wide Jules API key fallback

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,13 +34,7 @@ This guide explains how to install the AI Brain application on a web server.
 5.  Click **Register application**.
 6.  Copy the **Client ID** and click **Generate a new client secret** to get your secret.
 
-### 3. Google Gemini (AI Agent)
-1.  Visit [Google AI Studio](https://aistudio.google.com/).
-2.  Click on **Get API key** in the sidebar.
-3.  Click **Create API key** (either in a new or existing Google Cloud project).
-4.  Copy the generated key for `GOOGLE_JULES_API_KEY`. (Note: Users can also provide their own keys in the application dashboard).
-
-### 4. GitHub Webhook Configuration
+### 3. GitHub Webhook Configuration
 To receive real-time updates for issue events, you must configure a webhook for each repository you link.
 1.  In the application, go to the **Project Details** page for your linked repository.
 2.  Copy the **Payload URL** and **Secret** from the "Webhook Configuration" section.
@@ -176,11 +170,6 @@ Use this method if you want to deploy from your local machine via SSH.
    SetEnv GITHUB_REDIRECT_URI     https://your-domain.com/github-callback.php
 
    #
-   # Google Jules (Optional Global Fallback): https://aistudio.google.com/
-   #
-   # SetEnv GOOGLE_JULES_API_KEY    your_google_jules_api_key
-
-   #
    # Telegram Bot: https://t.me/botfather
    #
    SetEnv TELEGRAM_BOT_TOKEN      your_telegram_bot_token
@@ -241,7 +230,6 @@ The application requires several environment variables to be set in your web ser
 | `GITHUB_CLIENT_ID` | GitHub OAuth App Client ID |
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth App Client Secret |
 | `GITHUB_REDIRECT_URI` | `https://your-domain.com/github-callback.php` |
-| `GOOGLE_JULES_API_KEY` | (Optional/Deprecated) Global fallback API Key for Google Jules/Gemini. Users should now set their own keys in the Dashboard. |
 | `TELEGRAM_BOT_TOKEN` | (Optional) Telegram Bot Token |
 | `TELEGRAM_WEBHOOK_SECRET` | (Optional) Secret token for Telegram webhooks |
 | `UPGRADE_ALLOWED_EMAIL` | (Required for upgrades) Email address of the admin user authorized to trigger database migrations on the Admin Dashboard. |

--- a/discover_quota.php
+++ b/discover_quota.php
@@ -4,17 +4,13 @@ require 'vendor/autoload.php';
 
 use GuzzleHttp\Client;
 
-$apiKey = getenv('GOOGLE_JULES_API_KEY');
-if (!$apiKey) {
-    echo "GOOGLE_JULES_API_KEY not set\n";
+if ($argc < 3) {
+    echo "Usage: php discover_quota.php <API_KEY> <SESSION_ID>\n";
     exit(1);
 }
 
-$sessionId = getenv('JULES_SESSION_ID');
-if (!$sessionId) {
-    echo "JULES_SESSION_ID not set\n";
-    exit(1);
-}
+$apiKey = $argv[1];
+$sessionId = $argv[2];
 
 $client = new Client();
 $url = "https://jules.googleapis.com/v1alpha/sessions/{$sessionId}?key={$apiKey}";
@@ -36,7 +32,6 @@ try {
     }
     echo "\nBody:\n";
     echo $response->getBody()->getContents() . "\n";
-
 } catch (\Exception $e) {
     echo "Error: " . $e->getMessage() . "\n";
     if (method_exists($e, 'getResponse') && $e->getResponse()) {

--- a/src/backend/JulesService.php
+++ b/src/backend/JulesService.php
@@ -17,7 +17,7 @@ class JulesService
             'base_uri' => 'https://generativelanguage.googleapis.com/',
             'timeout'  => 30.0,
         ]);
-        $this->apiKey = (!empty($apiKey)) ? $apiKey : (getenv('GOOGLE_JULES_API_KEY') ?: '');
+        $this->apiKey = $apiKey ?? '';
     }
 
     /**

--- a/src/frontend/cronjob.php
+++ b/src/frontend/cronjob.php
@@ -19,7 +19,6 @@ $db = new Database();
 $userModel = new User($db);
 $taskModel = new Task($db);
 $githubService = new GitHubService();
-$julesService = new JulesService();
 
 $users = $userModel->getAllUsersWithProjectCount();
 

--- a/src/frontend/webhook.php
+++ b/src/frontend/webhook.php
@@ -92,7 +92,9 @@ if (!empty($matchingProject['github_token'])) {
     $githubService = new GitHubService(null, $matchingProject['github_token']);
 }
 
-$julesService = new JulesService();
+$userModel = new User($db);
+$user = $userModel->findById($matchingProject['user_id']);
+$julesService = new JulesService(null, $user['jules_api_key'] ?? null);
 
 if ($handler->handle($matchingProject, $data, $githubService, $notificationService, $julesService)) {
     $logger->log($matchingProject['user_id'], 'github', $payload, $headersStr, 200);


### PR DESCRIPTION
This change removes the global fallback API key for the Jules service, ensuring that the application exclusively uses per-user API keys stored in the database. 

Key changes:
- `App\JulesService`: Constructor no longer checks for `GOOGLE_JULES_API_KEY` env var.
- `src/frontend/cronjob.php`: Removed global `$julesService` and ensured `$scopedJulesService` is used within the user loop with the user's specific key.
- `src/frontend/webhook.php`: Updated to fetch the user and instantiate `JulesService` with their specific API key.
- `INSTALL.md`: Removed all references and setup instructions for the global `GOOGLE_JULES_API_KEY`.
- `discover_quota.php`: Changed from environment variables to command-line arguments for better flexibility and alignment with the removal of the global key.

Fixes #386

---
*PR created automatically by Jules for task [7133284336126462380](https://jules.google.com/task/7133284336126462380) started by @chatelao*