### PR TITLE
Fix CI failure and redeclared method in TelegramService

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -155,9 +155,11 @@ class Task
         $stmt->execute([$userId]);
         $tasks = $stmt->fetchAll();
 
-        return array_filter($tasks, function($task) {
+        return array_filter($tasks, function ($task) {
             $githubData = json_decode($task['github_data'], true);
-            if (!$githubData) return false;
+            if (!$githubData) {
+                return false;
+            }
 
             $isOpen = ($githubData['state'] ?? '') === 'open';
             $hasAutorepeat = false;
@@ -376,7 +378,7 @@ class Task
             'https://github-production-user-asset-6210df.s3.amazonaws.com/'
         ];
 
-        return preg_replace_callback('/<img\s+[^>]*src="([^"]+)"[^>]*>/i', function($matches) use ($trustedDomains) {
+        return preg_replace_callback('/<img\s+[^>]*src="([^"]+)"[^>]*>/i', function ($matches) use ($trustedDomains) {
             $src = $matches[1];
             $isTrusted = false;
             foreach ($trustedDomains as $domain) {
@@ -415,7 +417,7 @@ class Task
 
         // First, find all matches to preserve them
         $placeholders = [];
-        $text = preg_replace_callback('/<img\s+[^>]*src="([^"]+)"[^>]*>/i', function($matches) use ($trustedDomains, &$placeholders) {
+        $text = preg_replace_callback('/<img\s+[^>]*src="([^"]+)"[^>]*>/i', function ($matches) use ($trustedDomains, &$placeholders) {
             $src = $matches[1];
             $isTrusted = false;
             foreach ($trustedDomains as $domain) {
@@ -577,7 +579,7 @@ class Task
 
                     if (!$sessionId) {
                         // Reverse to find the latest "on it" comment
-                        $julesComments = array_reverse(array_filter($comments, function($c) {
+                        $julesComments = array_reverse(array_filter($comments, function ($c) {
                             $login = strtolower($c['user']['login'] ?? '');
                             return ($login === 'google-labs-jules[bot]' || $login === 'jules') &&
                                 stripos($c['body'] ?? '', 'on it') !== false;

--- a/src/backend/TelegramChannelHandler.php
+++ b/src/backend/TelegramChannelHandler.php
@@ -25,13 +25,6 @@ class TelegramChannelHandler implements NotificationChannelInterface
             return false;
         }
 
-        $user = $this->userModel->findById($userId);
-        $telegramService = $this->telegramService;
-
-        if ($user && !empty($user['telegram_bot_token'])) {
-            $telegramService = $this->telegramService->withToken($user['telegram_bot_token']);
-        }
-
         $title = $notification['title'];
         $message = $notification['message'];
         $sourceUrl = $notification['data']['source_url'] ?? null;

--- a/src/backend/TelegramService.php
+++ b/src/backend/TelegramService.php
@@ -22,13 +22,6 @@ class TelegramService
 
     public function withToken(string $botToken): self
     {
-        $new = clone $this;
-        $new->botToken = $botToken;
-        return $new;
-    }
-
-    public function withToken(string $botToken): self
-    {
         return new self($this->client, $botToken);
     }
 

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -117,7 +117,9 @@ class WebhookHandler
 
         foreach ($pullRequests as $pr) {
             $prUrl = $pr['url'] ?? '';
-            if (!$prUrl) continue;
+            if (!$prUrl) {
+                continue;
+            }
 
             // GitHub API PR URL is usually api.github.com/repos/.../pulls/...
             // But we store html_url in tasks table. Let's try to convert or match.
@@ -125,7 +127,9 @@ class WebhookHandler
             $htmlUrl = str_replace(['api.github.com/repos', '/pulls/'], ['github.com', '/pull/'], $prUrl);
 
             $task = $taskModel->findByPrUrl($htmlUrl);
-            if (!$task) continue;
+            if (!$task) {
+                continue;
+            }
 
             $newStatus = $task['status'];
             if ($conclusion === 'failure' || $conclusion === 'timed_out' || $conclusion === 'cancelled') {

--- a/src/frontend/admin/index.php
+++ b/src/frontend/admin/index.php
@@ -86,7 +86,7 @@ $allUsers = $userModel->getAllUsersWithProjectCount();
                                             </tr>
                                         </thead>
                                         <tbody class="bg-white divide-y divide-gray-200">
-                                            <?php foreach ($allUsers as $user): ?>
+                                            <?php foreach ($allUsers as $user) : ?>
                                                 <tr class="hover:bg-gray-50">
                                                     <td class="p-4 flex items-center whitespace-nowrap">
                                                         <img class="w-10 h-10 rounded-full" src="<?= htmlspecialchars($user['avatar'] ?? 'https://www.gravatar.com/avatar/?d=mp') ?>" alt="<?= htmlspecialchars($user['name']) ?> avatar">

--- a/src/frontend/admin/upgrade.php
+++ b/src/frontend/admin/upgrade.php
@@ -132,7 +132,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['trigger_upgrade']) |
                                         <label for="patch" class="block text-sm font-medium text-gray-700">Select Patch</label>
                                         <select id="patch" name="patch" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md border">
                                             <option value="all">Apply All Pending Patches</option>
-                                            <?php foreach ($pendingPatches as $patch): ?>
+                                            <?php foreach ($pendingPatches as $patch) : ?>
                                                 <option value="<?= htmlspecialchars($patch) ?>"><?= htmlspecialchars($patch) ?></option>
                                             <?php endforeach; ?>
                                         </select>
@@ -146,13 +146,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['trigger_upgrade']) |
                         </div>
                     </div>
 
-                    <?php if (!empty($logs)): ?>
+                    <?php if (!empty($logs)) : ?>
                         <div class="p-4 mb-4 bg-gray-900 border border-gray-700 rounded-lg shadow-sm overflow-hidden">
                             <h3 class="text-base font-semibold text-gray-100 mb-2">Migration Logs:</h3>
                             <pre class="text-xs text-green-400 font-mono whitespace-pre-wrap"><?php
-                                foreach ($logs as $log) {
-                                    echo htmlspecialchars($log) . "\n";
-                                }
+                            foreach ($logs as $log) {
+                                echo htmlspecialchars($log) . "\n";
+                            }
                             ?></pre>
                         </div>
                     <?php endif; ?>

--- a/src/frontend/callback.php
+++ b/src/frontend/callback.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once __DIR__ . '/../../vendor/autoload.php';
 use App\Auth;
 use App\Database;

--- a/src/frontend/debug_jules.php
+++ b/src/frontend/debug_jules.php
@@ -52,7 +52,6 @@ try {
         'headers' => $response->getHeaders(),
         'body' => json_decode($response->getBody()->getContents(), true)
     ], JSON_PRETTY_PRINT);
-
 } catch (\Exception $e) {
     header('Content-Type: text/plain');
     echo "Error: " . $e->getMessage() . "\n";

--- a/src/frontend/github-callback.php
+++ b/src/frontend/github-callback.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once __DIR__ . '/../../vendor/autoload.php';
 use App\Auth;
 use App\GitHubAuth;

--- a/src/frontend/github-login.php
+++ b/src/frontend/github-login.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once __DIR__ . '/../../vendor/autoload.php';
 use App\Auth;
 use App\GitHubAuth;

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -128,7 +128,7 @@ $errorMessage = $errorMessage ?? null;
                     <span class="self-center text-xl font-semibold sm:text-2xl whitespace-nowrap">Agent Control</span>
                 </div>
                 <div class="flex items-center">
-                    <?php if ($user): ?>
+                    <?php if ($user) : ?>
                         <?php include 'navbar-icons.php'; ?>
                         <div class="flex items-center ml-3">
                             <div>
@@ -141,7 +141,7 @@ $errorMessage = $errorMessage ?? null;
                             <a href="settings.php" class="ml-4 text-sm font-medium text-blue-600 hover:underline">Settings</a>
                             <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
                         </div>
-                    <?php else: ?>
+                    <?php else : ?>
                         <a href="login.php" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 focus:outline-none">Login with Google</a>
                     <?php endif; ?>
                 </div>
@@ -153,13 +153,13 @@ $errorMessage = $errorMessage ?? null;
         <div id="main-content" class="relative w-full h-full overflow-y-auto bg-gray-50">
             <main>
                 <div class="px-4 pt-6">
-                    <?php if ($errorMessage): ?>
+                    <?php if ($errorMessage) : ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
                             <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage ?? '') ?>
                         </div>
                     <?php endif; ?>
 
-                    <?php if ($user && !empty($autorepeatTasks)): ?>
+                    <?php if ($user && !empty($autorepeatTasks)) : ?>
                         <div class="mb-4 p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                             <h3 class="text-lg font-bold text-gray-900 mb-4">Running Autorepeat Tasks</h3>
                             <div class="overflow-x-auto">
@@ -172,7 +172,7 @@ $errorMessage = $errorMessage ?? null;
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        <?php foreach ($autorepeatTasks as $task): ?>
+                                        <?php foreach ($autorepeatTasks as $task) : ?>
                                             <tr class="bg-white border-b">
                                                 <td class="px-6 py-4 font-medium text-gray-900">
                                                     <a href="https://github.com/<?= htmlspecialchars($task['github_repo'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
@@ -200,10 +200,10 @@ $errorMessage = $errorMessage ?? null;
 
                     <div class="grid w-full grid-cols-1 gap-4 mt-4">
                         <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm sm:p-6">
-                            <?php if ($user): ?>
+                            <?php if ($user) : ?>
                                 <div class="mt-4">
                                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                                        <?php foreach ($projects as $project): ?>
+                                        <?php foreach ($projects as $project) : ?>
                                             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                                                 <div class="flex justify-between items-start">
                                                     <h5 class="text-lg font-bold text-gray-900 truncate">
@@ -218,14 +218,14 @@ $errorMessage = $errorMessage ?? null;
                                                 <?php
                                                 $repoParts = explode('/', $project['github_repo']);
                                                 $repoOwner = $repoParts[0] ?? '';
-                                                if (strcasecmp($repoOwner, $project['github_username']) !== 0): ?>
+                                                if (strcasecmp($repoOwner, $project['github_username']) !== 0) : ?>
                                                     <p class="text-sm text-gray-500 mt-1">Linked as&nbsp;<?= htmlspecialchars($project['github_username'] ?? '') ?></p>
                                                 <?php endif; ?>
 
                                                 <div class="flex flex-wrap gap-2 mt-3">
                                                     <?php
                                                     $tasks = $projectTasks[$project['project_id']] ?? [];
-                                                    foreach ($tasks as $task):
+                                                    foreach ($tasks as $task) :
                                                         $color = $taskModel->getStatusColor($task);
                                                         $isAutorepeat = $taskModel->hasAutorepeatLabel($task);
                                                         $state = $task['github_state'] ?? 'open';
@@ -246,7 +246,7 @@ $errorMessage = $errorMessage ?? null;
                                                         } elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) {
                                                             $emoji = '🚧';
                                                         }
-                                                    ?>
+                                                        ?>
                                                         <div class="relative group">
                                                             <a href="task.php?id=<?= $task['task_id'] ?>"
                                                                class="status-square <?= $color ?> <?= $isAutorepeat ? 'auto-repeat-tag' : '' ?>">
@@ -266,9 +266,9 @@ $errorMessage = $errorMessage ?? null;
 
                                         <!-- Add Project Card -->
                                         <div class="p-4 bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg flex flex-col items-center justify-center">
-                                            <?php if (empty($githubAccounts)): ?>
+                                            <?php if (empty($githubAccounts)) : ?>
                                                 <p class="text-sm text-gray-500 text-center">Please link a GitHub account first.</p>
-                                            <?php else: ?>
+                                            <?php else : ?>
                                                 <form method="POST" class="w-full" x-data="{
                                                     repo: '',
                                                     selectedAccountId: '<?= $githubAccounts[0]['github_account_id'] ?>',
@@ -292,7 +292,7 @@ $errorMessage = $errorMessage ?? null;
                                                     <div class="mb-2">
                                                         <label class="block mb-1 text-xs font-medium text-gray-900">GitHub Account</label>
                                                         <select name="github_account_id" x-model="selectedAccountId" class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
-                                                            <?php foreach ($githubAccounts as $account): ?>
+                                                            <?php foreach ($githubAccounts as $account) : ?>
                                                                 <option value="<?= $account['github_account_id'] ?>" x-text="'<?= htmlspecialchars($account['github_username'] ?? '') ?>' + (recommendedId == <?= $account['github_account_id'] ?> ? ' (Recommended)' : '')">
                                                                     <?= htmlspecialchars($account['github_username'] ?? '') ?>
                                                                 </option>
@@ -309,7 +309,7 @@ $errorMessage = $errorMessage ?? null;
                                         </div>
                                     </div>
                                 </div>
-                            <?php else: ?>
+                            <?php else : ?>
                                 <h3 class="text-base font-normal text-gray-500">Welcome to Agent Control</h3>
                                 <p class="text-2xl font-bold leading-none text-gray-900 sm:text-3xl">Please Login</p>
                                 <div class="mt-4">

--- a/src/frontend/login.php
+++ b/src/frontend/login.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once __DIR__ . '/../../vendor/autoload.php';
 use App\Auth;
 use App\Database;

--- a/src/frontend/logout.php
+++ b/src/frontend/logout.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once __DIR__ . '/../../vendor/autoload.php';
 use App\Auth;
 $auth = new Auth();

--- a/src/frontend/mock_header.php
+++ b/src/frontend/mock_header.php
@@ -42,7 +42,7 @@ $telegramConnected = true;
                     $syncMessage = 'Issues synced from GitHub';
                     ?>
                     <div class="flex items-center space-x-4 mr-4">
-                        <?php if ($syncStatus): ?>
+                        <?php if ($syncStatus) : ?>
                             <div class="flex items-center">
                                 <div class="w-3 h-3 rounded-full <?= $syncStatus === 'success' ? 'bg-green-500' : 'bg-red-500' ?>" title="<?= htmlspecialchars($syncMessage) ?>"></div>
                             </div>
@@ -60,7 +60,7 @@ $telegramConnected = true;
                             <svg class="w-5 h-5 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .52 5.586 3.004 3.004 0 0 0 5.193 2.019A4 4 0 0 1 12 18c.35 0 .692.045 1.02.13a3.004 3.004 0 0 0 5.193-2.019 4 4 0 0 0 .52-5.586 4 4 0 0 0-2.526-5.77A3 3 0 1 0 12 5M9 14.5a2.5 2.5 0 0 0 2.46-2.019M15 14.5a2.5 2.5 0 0 1-2.46-2.019"/></svg>
                             <span class="text-xs font-bold">
                                 <?= $completedTasks ?>/<?= $totalTasks ?>
-                                <?php if (isset($user['jules_quota_limit']) && $user['jules_quota_limit'] > 0): ?>
+                                <?php if (isset($user['jules_quota_limit']) && $user['jules_quota_limit'] > 0) : ?>
                                     <span class="ml-1 text-gray-500 font-normal">(<?= htmlspecialchars($user['jules_quota_usage']) ?>/<?= htmlspecialchars($user['jules_quota_limit']) ?>)</span>
                                 <?php endif; ?>
                             </span>

--- a/src/frontend/notifications.php
+++ b/src/frontend/notifications.php
@@ -69,7 +69,7 @@ $totalPages = ceil($totalNotifications / $limit);
                     </a>
                 </div>
                 <div class="flex items-center">
-                    <?php if ($user): ?>
+                    <?php if ($user) : ?>
                         <?php include 'navbar-icons.php'; ?>
                     <?php endif; ?>
                     <div class="flex items-center ml-3">
@@ -107,7 +107,7 @@ $totalPages = ceil($totalNotifications / $limit);
 
                     <div class="mb-4 flex justify-between items-center">
                         <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">All Notifications</h1>
-                        <?php if ($totalNotifications > 0): ?>
+                        <?php if ($totalNotifications > 0) : ?>
                         <form method="POST">
                             <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                             <button type="submit" name="mark_all_read" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Mark all as read</button>
@@ -115,18 +115,18 @@ $totalPages = ceil($totalNotifications / $limit);
                         <?php endif; ?>
                     </div>
 
-                    <?php if (isset($_GET['success']) && $_GET['success'] === 'all_read'): ?>
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'all_read') : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> All notifications marked as read.
                         </div>
                     <?php endif; ?>
 
                     <div class="bg-white border border-gray-200 rounded-lg shadow-sm overflow-hidden">
-                        <?php if (empty($notifications)): ?>
+                        <?php if (empty($notifications)) : ?>
                             <div class="p-8 text-center text-gray-500 italic">No notifications found.</div>
-                        <?php else: ?>
+                        <?php else : ?>
                             <ul class="divide-y divide-gray-200">
-                                <?php foreach ($notifications as $n): ?>
+                                <?php foreach ($notifications as $n) : ?>
                                     <?php $data = json_decode($n['data'] ?? '{}', true); ?>
                                     <li class="p-4 hover:bg-gray-50 transition-colors <?= !$n['is_read'] ? 'bg-blue-50/50' : '' ?>">
                                         <div class="flex justify-between items-start">
@@ -135,7 +135,7 @@ $totalPages = ceil($totalNotifications / $limit);
                                                     <h4 class="text-sm font-bold text-gray-900 markdown-body">
                                                         <?= $parsedown->text($taskModel->processGitHubImages($n['title'])) ?>
                                                     </h4>
-                                                    <?php if (!$n['is_read']): ?>
+                                                    <?php if (!$n['is_read']) : ?>
                                                         <span class="ml-2 w-2 h-2 bg-blue-600 rounded-full"></span>
                                                     <?php endif; ?>
                                                 </div>
@@ -144,7 +144,7 @@ $totalPages = ceil($totalNotifications / $limit);
                                                 </div>
                                                 <div class="mt-2 flex items-center space-x-4">
                                                     <span class="text-xs text-gray-400 font-mono"><?= htmlspecialchars($n['created_at']) ?></span>
-                                                    <?php if (!empty($data['source_url'])): ?>
+                                                    <?php if (!empty($data['source_url'])) : ?>
                                                         <a href="<?= htmlspecialchars($data['source_url']) ?>" target="_blank" class="text-xs text-blue-600 hover:underline flex items-center">
                                                             View Source
                                                             <svg class="w-3 h-3 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
@@ -157,16 +157,16 @@ $totalPages = ceil($totalNotifications / $limit);
                                 <?php endforeach; ?>
                             </ul>
 
-                            <?php if ($totalPages > 1): ?>
+                            <?php if ($totalPages > 1) : ?>
                                 <div class="p-4 border-t border-gray-200 flex items-center justify-between bg-gray-50">
                                     <div class="text-sm text-gray-700">
                                         Showing <span class="font-medium"><?= $offset + 1 ?></span> to <span class="font-medium"><?= min($offset + $limit, $totalNotifications) ?></span> of <span class="font-medium"><?= $totalNotifications ?></span> notifications
                                     </div>
                                     <div class="flex-1 flex justify-end space-x-2">
-                                        <?php if ($page > 1): ?>
+                                        <?php if ($page > 1) : ?>
                                             <a href="?page=<?= $page - 1 ?>" class="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-100">Previous</a>
                                         <?php endif; ?>
-                                        <?php if ($page < $totalPages): ?>
+                                        <?php if ($page < $totalPages) : ?>
                                             <a href="?page=<?= $page + 1 ?>" class="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-100">Next</a>
                                         <?php endif; ?>
                                     </div>

--- a/src/frontend/project-settings.php
+++ b/src/frontend/project-settings.php
@@ -79,8 +79,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_notifications'
         'failed_pr' => isset($_POST['broadcast_failed_pr'])
     ];
 
-    if ($notificationService->updateProjectSettings($projectId, $settings) &&
-        $notificationService->updateStatusSettings($projectId, $statusSettings)) {
+    if (
+        $notificationService->updateProjectSettings($projectId, $settings) &&
+        $notificationService->updateStatusSettings($projectId, $statusSettings)
+    ) {
         $redirectUrl = basename($_SERVER['PHP_SELF']) . "?id=$projectId&success=notifications_updated";
         header("Location: $redirectUrl");
         exit;
@@ -147,9 +149,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_project'])) {
 }
 
 if (isset($_GET['success'])) {
-    if ($_GET['success'] === 'project_updated') $successMessage = "Project settings updated successfully.";
-    if ($_GET['success'] === 'webhook_setup') $successMessage = "Webhook set up successfully.";
-    if ($_GET['success'] === 'notifications_updated') $successMessage = "Notification settings updated successfully.";
+    if ($_GET['success'] === 'project_updated') {
+        $successMessage = "Project settings updated successfully.";
+    }
+    if ($_GET['success'] === 'webhook_setup') {
+        $successMessage = "Webhook set up successfully.";
+    }
+    if ($_GET['success'] === 'notifications_updated') {
+        $successMessage = "Notification settings updated successfully.";
+    }
 }
 
 ?>
@@ -219,13 +227,13 @@ if (isset($_GET['success'])) {
                         <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">Project Settings</h1>
                     </div>
 
-                    <?php if ($errorMessage): ?>
+                    <?php if ($errorMessage) : ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
                             <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
                         </div>
                     <?php endif; ?>
 
-                    <?php if ($successMessage): ?>
+                    <?php if ($successMessage) : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> <?= htmlspecialchars($successMessage) ?>
                         </div>
@@ -258,7 +266,7 @@ if (isset($_GET['success'])) {
                                     <div>
                                         <label class="block mb-2 text-sm font-medium text-gray-900">GitHub Account</label>
                                         <select name="github_account_id" x-model="selectedAccountId" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
-                                            <?php foreach ($githubAccounts as $account): ?>
+                                            <?php foreach ($githubAccounts as $account) : ?>
                                                 <option value="<?= $account['github_account_id'] ?>" x-text="'<?= htmlspecialchars($account['github_username'] ?? '') ?>' + (recommendedId == <?= $account['github_account_id'] ?> ? ' (Recommended)' : '')">
                                                     <?= htmlspecialchars($account['github_username'] ?? '') ?>
                                                 </option>
@@ -322,8 +330,8 @@ if (isset($_GET['success'])) {
                                             'failed_jules' => 'Jules Failed',
                                             'failed_pr' => 'PR Failed'
                                         ];
-                                        foreach ($statuses as $id => $label):
-                                        ?>
+                                        foreach ($statuses as $id => $label) :
+                                            ?>
                                         <div class="flex items-center justify-between p-2 bg-gray-50 rounded-lg border border-gray-100 shadow-sm">
                                             <span class="text-xs font-medium text-gray-600"><?= $label ?></span>
                                             <label class="relative inline-flex items-center cursor-pointer scale-75">
@@ -344,15 +352,15 @@ if (isset($_GET['success'])) {
                             <div class="space-y-4">
                                 <div class="flex items-center justify-between">
                                     <span class="text-sm font-medium text-gray-700">Status</span>
-                                    <?php if ($webhookStatus === 'active'): ?>
+                                    <?php if ($webhookStatus === 'active') : ?>
                                         <span class="px-2.5 py-0.5 text-xs font-bold rounded-full bg-green-100 text-green-800">Connected</span>
-                                    <?php elseif ($webhookStatus === 'inactive'): ?>
+                                    <?php elseif ($webhookStatus === 'inactive') : ?>
                                         <span class="px-2.5 py-0.5 text-xs font-bold rounded-full bg-yellow-100 text-yellow-800">Inactive</span>
-                                    <?php elseif ($webhookStatus === 'missing'): ?>
+                                    <?php elseif ($webhookStatus === 'missing') : ?>
                                         <span class="px-2.5 py-0.5 text-xs font-bold rounded-full bg-red-100 text-red-800">Not Found</span>
-                                    <?php elseif ($webhookStatus === 'error'): ?>
+                                    <?php elseif ($webhookStatus === 'error') : ?>
                                         <span class="px-2.5 py-0.5 text-xs font-bold rounded-full bg-red-100 text-red-800">API Error</span>
-                                    <?php else: ?>
+                                    <?php else : ?>
                                         <span class="px-2.5 py-0.5 text-xs font-bold rounded-full bg-gray-100 text-gray-800">Unknown</span>
                                     <?php endif; ?>
                                 </div>
@@ -370,7 +378,7 @@ if (isset($_GET['success'])) {
                                     </div>
                                 </div>
 
-                                <?php if ($webhookStatus === 'missing' || $webhookStatus === 'error'): ?>
+                                <?php if ($webhookStatus === 'missing' || $webhookStatus === 'error') : ?>
                                     <form method="POST">
                                         <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                         <button type="submit" name="setup_webhook" class="text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Setup Webhook Automatically</button>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -56,7 +56,7 @@ $tasks = $taskModel->findByProjectId($projectId, $showAll);
 $lastAgentResponse = null;
 $errorMessage = null;
 
-$triggerAgent = function($taskId) use ($taskModel, $logger, $user, $project, $julesService, $notificationService, &$lastAgentResponse, &$errorMessage, &$tasks, $projectId, $showAll) {
+$triggerAgent = function ($taskId) use ($taskModel, $logger, $user, $project, $julesService, $notificationService, &$lastAgentResponse, &$errorMessage, &$tasks, $projectId, $showAll) {
     $task = $taskModel->findById($taskId);
     if ($task && $task['project_id'] === $project['project_id']) {
         try {
@@ -314,13 +314,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                         </div>
                     </div>
 
-                    <?php if ($errorMessage): ?>
+                    <?php if ($errorMessage) : ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
                             <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage ?? '') ?>
                         </div>
                     <?php endif; ?>
 
-                    <?php if (isset($_GET['success']) && $_GET['success'] === 'issue_created'): ?>
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'issue_created') : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Issue created from template. It may take a few seconds to appear in the list (synced via webhook).
                         </div>
@@ -329,7 +329,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
 
 
 
-                    <?php if ($lastAgentResponse): ?>
+                    <?php if ($lastAgentResponse) : ?>
                         <div class="p-4 mb-4 text-sm text-blue-800 rounded-lg bg-blue-50" role="alert">
                             <span class="font-medium">Agent Response:</span>
                             <div class="mt-2 p-2 bg-white rounded border border-blue-200 whitespace-pre-wrap font-mono text-xs">
@@ -342,17 +342,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                         <div class="lg:col-span-1 order-1 lg:order-2 space-y-4">
                             <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                                 <h3 class="text-lg font-bold text-gray-900 mb-4">Project Overview</h3>
-                                <?php if (empty($roadmapFiles)): ?>
+                                <?php if (empty($roadmapFiles)) : ?>
                                     <p class="text-sm text-gray-500 italic">No roadmap files found in the repository.</p>
-                                <?php else: ?>
+                                <?php else : ?>
                                     <ul class="space-y-2">
-                                        <?php foreach ($roadmapFiles as $file): ?>
+                                        <?php foreach ($roadmapFiles as $file) : ?>
                                             <li class="flex flex-col">
                                                 <a href="<?= htmlspecialchars($file['html_url'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-600 hover:underline flex items-center">
                                                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
                                                     <?= htmlspecialchars($file['name'] ?? '') ?>
                                                 </a>
-                                                <?php if (!empty($file['next_task'])): ?>
+                                                <?php if (!empty($file['next_task'])) : ?>
                                                     <span class="text-[10px] text-gray-500 ml-6 italic whitespace-nowrap">
                                                         🚧 <?= htmlspecialchars($file['next_task'] ?? '') ?>
                                                     </span>
@@ -378,15 +378,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                 }
                             }">
                                 <h3 class="text-lg font-bold text-gray-900 mb-4">Create Issue from Template</h3>
-                                <?php if (empty($templates)): ?>
+                                <?php if (empty($templates)) : ?>
                                     <p class="text-sm text-gray-500 italic">No templates available. <a href="templates.php" class="text-blue-600 hover:underline">Create one first.</a></p>
-                                <?php else: ?>
+                                <?php else : ?>
                                     <form method="POST">
                                         <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                         <div class="mb-4">
                                             <label class="block mb-2 text-sm font-medium text-gray-900">Select Template</label>
                                             <select name="template_id" x-model="selectedTemplateId" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5" required>
-                                                <?php foreach ($templates as $tmpl): ?>
+                                                <?php foreach ($templates as $tmpl) : ?>
                                                     <option value="<?= $tmpl['issue_template_id'] ?>"><?= htmlspecialchars($tmpl['name'] ?? '') ?></option>
                                                 <?php endforeach; ?>
                                             </select>
@@ -420,12 +420,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        <?php if (empty($tasks)): ?>
+                                        <?php if (empty($tasks)) : ?>
                                             <tr class="bg-white border-b">
                                                 <td colspan="3" class="px-6 py-4 text-center">No tasks found. Open an issue on GitHub to see it here.</td>
                                             </tr>
                                         <?php endif; ?>
-                                        <?php foreach ($tasks as $task): ?>
+                                        <?php foreach ($tasks as $task) : ?>
                                             <tr class="bg-white border-b">
                                                 <td class="px-6 py-4">
                                                     <div class="text-base text-gray-900 font-normal markdown-body">
@@ -442,20 +442,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                     <?php
                                                     $statusColor = $taskModel->getStatusColor($task);
                                                     $bgClass = 'bg-gray-100 text-gray-800';
-                                                    if ($statusColor === 'green') $bgClass = 'bg-green-100 text-green-800';
-                                                    elseif ($statusColor === 'yellow') $bgClass = 'bg-yellow-100 text-yellow-800';
-                                                    elseif ($statusColor === 'blue') $bgClass = 'bg-blue-100 text-blue-800';
-                                                    elseif ($statusColor === 'red') $bgClass = 'bg-red-100 text-red-800';
-                                                    elseif ($statusColor === 'purple') $bgClass = 'bg-purple-100 text-purple-800';
+                                                    if ($statusColor === 'green') {
+                                                        $bgClass = 'bg-green-100 text-green-800';
+                                                    } elseif ($statusColor === 'yellow') {
+                                                        $bgClass = 'bg-yellow-100 text-yellow-800';
+                                                    } elseif ($statusColor === 'blue') {
+                                                        $bgClass = 'bg-blue-100 text-blue-800';
+                                                    } elseif ($statusColor === 'red') {
+                                                        $bgClass = 'bg-red-100 text-red-800';
+                                                    } elseif ($statusColor === 'purple') {
+                                                        $bgClass = 'bg-purple-100 text-purple-800';
+                                                    }
                                                     ?>
                                                     <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
                                                         <?php
-                                                        if (($task['github_state'] ?? 'open') === 'closed') echo '✅ ';
-                                                        elseif ($task['status'] === 'completed') echo '✅ ';
-                                                        elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') echo '❌ Jules ';
-                                                        elseif ($task['status'] === 'failed_pr') echo '❌ PR ';
-                                                        elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) echo '🚧 ';
-                                                        else echo '⏳ ';
+                                                        if (($task['github_state'] ?? 'open') === 'closed') {
+                                                            echo '✅ ';
+                                                        } elseif ($task['status'] === 'completed') {
+                                                            echo '✅ ';
+                                                        } elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') {
+                                                            echo '❌ Jules ';
+                                                        } elseif ($task['status'] === 'failed_pr') {
+                                                            echo '❌ PR ';
+                                                        } elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) {
+                                                            echo '🚧 ';
+                                                        } else {
+                                                            echo '⏳ ';
+                                                        }
                                                         ?>
                                                         <?= htmlspecialchars(str_replace(['failed_jules', 'failed_pr'], 'failed', $task['status'] ?? '')) ?>
                                                     </span>
@@ -467,14 +480,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                         $isCompleted = ($task['status'] ?? '') === 'completed';
                                                         $isImplemented = ($task['status'] ?? '') === 'implemented';
                                                         ?>
-                                                        <?php if (!$isClosed && !$isCompleted && !$isImplemented): ?>
+                                                        <?php if (!$isClosed && !$isCompleted && !$isImplemented) : ?>
                                                             <form method="POST" class="inline">
                                                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                                                 <input type="hidden" name="task_id" value="<?= $task['task_id'] ?>">
                                                                 <button type="submit" name="trigger_agent" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none w-full">Run Agent</button>
                                                             </form>
                                                         <?php endif; ?>
-                                                        <?php if ($isCompleted || $isImplemented): ?>
+                                                        <?php if ($isCompleted || $isImplemented) : ?>
                                                             <form method="POST" class="inline">
                                                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                                                 <input type="hidden" name="task_id" value="<?= $task['task_id'] ?>">

--- a/src/frontend/settings.php
+++ b/src/frontend/settings.php
@@ -130,7 +130,7 @@ $errorMessage = $errorMessage ?? null;
                     </a>
                 </div>
                 <div class="flex items-center">
-                    <?php if ($user): ?>
+                    <?php if ($user) : ?>
                         <?php include 'navbar-icons.php'; ?>
                     <?php endif; ?>
                     <div class="flex items-center ml-3">
@@ -184,15 +184,15 @@ $errorMessage = $errorMessage ?? null;
                         </ul>
 
                         <div x-show="activeTab === 'general'" class="pt-4">
-                    <?php if (isset($_GET['success']) && $_GET['success'] === 'key_updated'): ?>
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'key_updated') : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Jules API Key updated successfully.
                         </div>
                     <?php endif; ?>
-                    <?php if (isset($_GET['success']) && $_GET['success'] === 'telegram_updated'): ?>
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'telegram_updated') : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Telegram configuration updated successfully.
-                            <?php if (isset($_GET['warning']) && $_GET['warning'] === 'webhook_failed'): ?>
+                            <?php if (isset($_GET['warning']) && $_GET['warning'] === 'webhook_failed') : ?>
                                 <div class="mt-2 text-yellow-800 font-normal">
                                     <strong>Warning:</strong> Automated webhook registration failed: <?= htmlspecialchars($_GET['error'] ?? 'Unknown error') ?>.
                                     You may need to register it manually.
@@ -201,7 +201,7 @@ $errorMessage = $errorMessage ?? null;
                         </div>
                     <?php endif; ?>
 
-                    <?php if ($errorMessage): ?>
+                    <?php if ($errorMessage) : ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
                             <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage ?? '') ?>
                         </div>
@@ -239,10 +239,10 @@ $errorMessage = $errorMessage ?? null;
                             <div class="mt-6">
                                 <h4 class="text-lg font-semibold text-gray-900">Linked GitHub Accounts</h4>
                                 <div class="mt-2 space-y-2">
-                                    <?php if (empty($githubAccounts)): ?>
+                                    <?php if (empty($githubAccounts)) : ?>
                                         <p class="text-sm text-gray-500 italic">No GitHub accounts linked yet.</p>
-                                    <?php else: ?>
-                                        <?php foreach ($githubAccounts as $account): ?>
+                                    <?php else : ?>
+                                        <?php foreach ($githubAccounts as $account) : ?>
                                             <div class="flex items-center text-green-600">
                                                 <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
                                                 Linked as&nbsp;<strong><?= htmlspecialchars($account['github_username'] ?? '') ?></strong>
@@ -311,7 +311,7 @@ $errorMessage = $errorMessage ?? null;
                         <?php
                         $notifSettings = $notificationService->getUserSettings($user['user_id']);
                         ?>
-                        <?php if (isset($_GET['success']) && $_GET['success'] === 'notifications_updated'): ?>
+                        <?php if (isset($_GET['success']) && $_GET['success'] === 'notifications_updated') : ?>
                             <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                                 <span class="font-medium">Success!</span> Notification preferences updated.
                             </div>
@@ -378,9 +378,9 @@ $errorMessage = $errorMessage ?? null;
                     <div x-show="activeTab === 'logging'" class="pt-4" x-cloak>
                         <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm sm:p-6">
                             <h3 class="text-lg font-semibold text-gray-900 mb-4">Webhook Call Logs (Last 5 per endpoint)</h3>
-                            <?php if (empty($webhookLogs)): ?>
+                            <?php if (empty($webhookLogs)) : ?>
                                 <p class="text-sm text-gray-500 italic">No webhook calls logged yet.</p>
-                            <?php else: ?>
+                            <?php else : ?>
                                 <div class="relative overflow-x-auto">
                                     <table class="w-full text-sm text-left text-gray-500">
                                         <thead class="text-xs text-gray-700 uppercase bg-gray-50">
@@ -392,7 +392,7 @@ $errorMessage = $errorMessage ?? null;
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            <?php foreach ($webhookLogs as $log): ?>
+                                            <?php foreach ($webhookLogs as $log) : ?>
                                                 <tr class="bg-white border-b hover:bg-gray-50" x-data="{ open: false }">
                                                     <td class="px-6 py-4 whitespace-nowrap"><?= htmlspecialchars($log['created_at'] ?? '') ?></td>
                                                     <td class="px-6 py-4 uppercase font-mono text-xs"><?= htmlspecialchars($log['endpoint'] ?? '') ?></td>
@@ -400,7 +400,7 @@ $errorMessage = $errorMessage ?? null;
                                                         <span class="px-2.5 py-0.5 rounded-full text-xs font-medium <?= ($log['status_code'] ?? 0) >= 200 && ($log['status_code'] ?? 0) < 300 ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' ?>">
                                                             <?= (int)($log['status_code'] ?? 0) ?>
                                                         </span>
-                                                        <?php if ($log['error_message']): ?>
+                                                        <?php if ($log['error_message']) : ?>
                                                             <div class="text-xs text-red-600 mt-1"><?= htmlspecialchars($log['error_message'] ?? '') ?></div>
                                                         <?php endif; ?>
                                                     </td>

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -88,7 +88,7 @@ if ($githubToken) {
     try {
         $comments = $githubService->getIssueComments($project['github_repo'], $task['issue_number']);
         // Filter for Jules comments
-        $julesMessages = array_filter($comments, function($comment) {
+        $julesMessages = array_filter($comments, function ($comment) {
             $login = strtolower($comment['user']['login'] ?? '');
             return $login === 'jules' || $login === 'google-labs-jules[bot]';
         });
@@ -199,7 +199,7 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                         </ol>
                     </nav>
 
-                    <?php if (isset($_GET['success']) && $_GET['success'] === 'notifications_updated'): ?>
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'notifications_updated') : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Notification settings updated.
                         </div>
@@ -214,12 +214,19 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                             <div class="flex items-center space-x-2">
                                 <span class="px-4 py-1.5 text-sm font-semibold rounded-full bg-<?= $statusColor ?>-100 text-<?= $statusColor ?>-800 flex items-center shadow-sm">
                                     <?php
-                                    if ($task['status'] === 'completed') echo '✅ ';
-                                    elseif (in_array($task['status'], ['in_progress', 'coding', 'testing'])) echo '🚧 ';
-                                    elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') echo '❌ Jules ';
-                                    elseif ($task['status'] === 'failed_pr') echo '❌ PR ';
-                                    elseif (in_array($task['status'], ['researching', 'planning', 'awaiting-plan-approval', 'awaiting-user-feedback'])) echo '🔵 ';
-                                    else echo '⏳ ';
+                                    if ($task['status'] === 'completed') {
+                                        echo '✅ ';
+                                    } elseif (in_array($task['status'], ['in_progress', 'coding', 'testing'])) {
+                                        echo '🚧 ';
+                                    } elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') {
+                                        echo '❌ Jules ';
+                                    } elseif ($task['status'] === 'failed_pr') {
+                                        echo '❌ PR ';
+                                    } elseif (in_array($task['status'], ['researching', 'planning', 'awaiting-plan-approval', 'awaiting-user-feedback'])) {
+                                        echo '🔵 ';
+                                    } else {
+                                        echo '⏳ ';
+                                    }
                                     ?>
                                     <?= htmlspecialchars(str_replace(['failed_jules', 'failed_pr'], 'failed', $task['status'] ?? '')) ?>
                                 </span>
@@ -227,7 +234,7 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                         </div>
 
                         <div class="flex flex-wrap gap-2 mb-6 border-b border-gray-200 pb-6">
-                            <?php foreach ($labels as $label): ?>
+                            <?php foreach ($labels as $label) : ?>
                                 <span class="px-2.5 py-1 text-xs font-semibold rounded-full border shadow-sm" style="background-color: #<?= $label['color'] ?>20; border-color: #<?= $label['color'] ?>; color: #<?= $label['color'] ?>; filter: brightness(0.8);">
                                     <?= htmlspecialchars($label['name'] ?? '') ?>
                                 </span>
@@ -253,7 +260,7 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                                 </div>
                             </div>
 
-                            <?php if ($prDetails): ?>
+                            <?php if ($prDetails) : ?>
                                 <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
                                     <div class="bg-green-50 px-4 py-3 border-b border-gray-200 flex items-center justify-between">
                                         <div class="flex items-center space-x-2">
@@ -276,7 +283,7 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                                             <span>Base: <code class="bg-gray-100 px-1 rounded"><?= htmlspecialchars($prDetails['base']['ref'] ?? 'main') ?></code></span>
                                             <span>Head: <code class="bg-gray-100 px-1 rounded"><?= htmlspecialchars($prDetails['head']['ref'] ?? 'feature') ?></code></span>
                                         </div>
-                                        <?php if (!empty($prDetails['body'])): ?>
+                                        <?php if (!empty($prDetails['body'])) : ?>
                                             <div class="prose prose-sm max-w-none text-gray-600 bg-gray-50 p-4 rounded-lg border border-gray-100">
                                                 <?= $parsedown->text($taskModel->processGitHubImages(mb_substr($prDetails['body'], 0, 300) . (mb_strlen($prDetails['body']) > 300 ? '...' : ''))) ?>
                                             </div>
@@ -285,13 +292,13 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                                 </div>
                             <?php endif; ?>
 
-                            <?php if (!empty($julesMessages)): ?>
+                            <?php if (!empty($julesMessages)) : ?>
                                 <div class="space-y-4">
                                     <h3 class="text-lg font-bold text-gray-900 px-1 flex items-center">
                                         <svg class="w-5 h-5 mr-2 text-blue-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/></svg>
                                         Last Jules Messages
                                     </h3>
-                                    <?php foreach ($julesMessages as $msg): ?>
+                                    <?php foreach ($julesMessages as $msg) : ?>
                                         <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
                                             <div class="bg-blue-50 px-4 py-2 border-b border-gray-200 flex items-center justify-between">
                                                 <div class="flex items-center space-x-2">
@@ -316,10 +323,10 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                                     <h3 class="text-sm font-bold text-gray-700">Task Logs</h3>
                                 </div>
                                 <div class="p-4 space-y-1 bg-gray-900 min-h-[100px] max-h-[400px] overflow-y-auto">
-                                    <?php if (empty($logs)): ?>
+                                    <?php if (empty($logs)) : ?>
                                         <p class="text-sm text-gray-400 italic">No logs available for this task.</p>
-                                    <?php else: ?>
-                                        <?php foreach ($logs as $log): ?>
+                                    <?php else : ?>
+                                        <?php foreach ($logs as $log) : ?>
                                             <div class="flex items-start text-xs font-mono p-1 rounded <?= $log['level'] === 'error' ? 'bg-red-900/30 text-red-300' : 'text-gray-300 hover:bg-gray-800' ?>">
                                                 <span class="text-gray-500 mr-3 shrink-0">[<?= htmlspecialchars(date('H:i:s', strtotime($log['created_at']))) ?>]</span>
                                                 <span class="flex-1"><?= htmlspecialchars($log['message'] ?? '') ?></span>
@@ -329,7 +336,7 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                                 </div>
                             </div>
 
-                            <?php if (!empty($task['agent_response'])): ?>
+                            <?php if (!empty($task['agent_response'])) : ?>
                                 <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
                                     <div class="bg-blue-50 px-4 py-3 border-b border-gray-200">
                                         <h3 class="text-sm font-bold text-blue-700">Last Agent Analysis</h3>
@@ -360,12 +367,12 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
 
                                     <!-- Jules Session -->
                                     <div class="flex items-center justify-between">
-                                        <?php if (!empty($task['jules_url'])): ?>
+                                        <?php if (!empty($task['jules_url'])) : ?>
                                             <a href="<?= htmlspecialchars($task['jules_url'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="flex items-center text-sm text-purple-600 hover:underline">
                                                 <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .52 5.586 3.004 3.004 0 0 0 5.193 2.019A4 4 0 0 1 12 18c.35 0 .692.045 1.02.13a3.004 3.004 0 0 0 5.193-2.019 4 4 0 0 0 .52-5.586 4 4 0 0 0-2.526-5.77A3 3 0 1 0 12 5M9 14.5a2.5 2.5 0 0 0 2.46-2.019M15 14.5a2.5 2.5 0 0 1-2.46-2.019"/></svg>
                                                 Jules Session
                                             </a>
-                                        <?php else: ?>
+                                        <?php else : ?>
                                             <div class="flex items-center text-sm text-gray-500">
                                                 <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .52 5.586 3.004 3.004 0 0 0 5.193 2.019A4 4 0 0 1 12 18c.35 0 .692.045 1.02.13a3.004 3.004 0 0 0 5.193-2.019 4 4 0 0 0 .52-5.586 4 4 0 0 0-2.526-5.77A3 3 0 1 0 12 5M9 14.5a2.5 2.5 0 0 0 2.46-2.019M15 14.5a2.5 2.5 0 0 1-2.46-2.019"/></svg>
                                                 Jules Session
@@ -378,12 +385,12 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
 
                                     <!-- Pull Request -->
                                     <div class="flex items-center justify-between">
-                                        <?php if (!empty($task['pr_url'])): ?>
+                                        <?php if (!empty($task['pr_url'])) : ?>
                                             <a href="<?= htmlspecialchars($task['pr_url'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="flex items-center text-sm text-<?= $prColor ?>-600 hover:underline">
                                                 <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24"><path d="M11 19.25c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM11 14.5c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM11 9.75c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 19.25c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 14.5c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 9.75c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM20.5 2h-17C2.673 2 2 2.673 2 3.5v17c0 .827.673 1.5 1.5 1.5h17c.827 0 1.5-.673 1.5-1.5v-17C22 2.673 21.327 2 20.5 2zM20 18H4V4h16v14z"/></svg>
                                                 Pull Request
                                             </a>
-                                        <?php else: ?>
+                                        <?php else : ?>
                                             <div class="flex items-center text-sm text-gray-500">
                                                 <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24"><path d="M11 19.25c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM11 14.5c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM11 9.75c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 19.25c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 14.5c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 9.75c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM20.5 2h-17C2.673 2 2 2.673 2 3.5v17c0 .827.673 1.5 1.5 1.5h17c.827 0 1.5-.673 1.5-1.5v-17C22 2.673 21.327 2 20.5 2zM20 18H4V4h16v14z"/></svg>
                                                 Pull Request
@@ -399,7 +406,7 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                                     <div class="text-xs text-gray-500 space-y-1">
                                         <p>Created: <?= htmlspecialchars($task['created_at'] ?? '') ?></p>
                                         <p>Last Synced: <?= htmlspecialchars($task['last_synced_at'] ?? 'Never') ?></p>
-                                        <?php if (!empty($task['jules_session_id'])): ?>
+                                        <?php if (!empty($task['jules_session_id'])) : ?>
                                             <p>Jules Session ID: <span class="font-mono"><?= htmlspecialchars($task['jules_session_id'] ?? '') ?></span></p>
                                         <?php endif; ?>
                                     </div>

--- a/src/frontend/tasks.php
+++ b/src/frontend/tasks.php
@@ -104,12 +104,12 @@ $title = $filterLabels[$filter] ?? 'Tasks';
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <?php if (empty($tasks)): ?>
+                                    <?php if (empty($tasks)) : ?>
                                         <tr class="bg-white border-b">
                                             <td colspan="3" class="px-6 py-4 text-center">No tasks matching this filter.</td>
                                         </tr>
                                     <?php endif; ?>
-                                    <?php foreach ($tasks as $task): ?>
+                                    <?php foreach ($tasks as $task) : ?>
                                         <tr class="bg-white border-b hover:bg-gray-50 transition-colors">
                                             <td class="px-6 py-4 font-medium text-gray-900">
                                                 <a href="project.php?id=<?= $task['project_id'] ?>" class="text-blue-600 hover:underline">
@@ -128,20 +128,33 @@ $title = $filterLabels[$filter] ?? 'Tasks';
                                                 <?php
                                                 $statusColor = $taskModel->getStatusColor($task);
                                                 $bgClass = 'bg-gray-100 text-gray-800';
-                                                if ($statusColor === 'green') $bgClass = 'bg-green-100 text-green-800';
-                                                elseif ($statusColor === 'yellow') $bgClass = 'bg-yellow-100 text-yellow-800';
-                                                elseif ($statusColor === 'blue') $bgClass = 'bg-blue-100 text-blue-800';
-                                                elseif ($statusColor === 'red') $bgClass = 'bg-red-100 text-red-800';
-                                                elseif ($statusColor === 'purple') $bgClass = 'bg-purple-100 text-purple-800';
+                                                if ($statusColor === 'green') {
+                                                    $bgClass = 'bg-green-100 text-green-800';
+                                                } elseif ($statusColor === 'yellow') {
+                                                    $bgClass = 'bg-yellow-100 text-yellow-800';
+                                                } elseif ($statusColor === 'blue') {
+                                                    $bgClass = 'bg-blue-100 text-blue-800';
+                                                } elseif ($statusColor === 'red') {
+                                                    $bgClass = 'bg-red-100 text-red-800';
+                                                } elseif ($statusColor === 'purple') {
+                                                    $bgClass = 'bg-purple-100 text-purple-800';
+                                                }
                                                 ?>
                                                 <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
                                                     <?php
-                                                    if (($task['github_state'] ?? 'open') === 'closed') echo '✅ ';
-                                                    elseif ($task['status'] === 'completed') echo '✅ ';
-                                                    elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') echo '❌ Jules ';
-                                                    elseif ($task['status'] === 'failed_pr') echo '❌ PR ';
-                                                    elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) echo '🚧 ';
-                                                    else echo '⏳ ';
+                                                    if (($task['github_state'] ?? 'open') === 'closed') {
+                                                        echo '✅ ';
+                                                    } elseif ($task['status'] === 'completed') {
+                                                        echo '✅ ';
+                                                    } elseif ($task['status'] === 'failed' || $task['status'] === 'failed_jules') {
+                                                        echo '❌ Jules ';
+                                                    } elseif ($task['status'] === 'failed_pr') {
+                                                        echo '❌ PR ';
+                                                    } elseif (in_array($task['status'], ['pending', 'analyzed', 'researching', 'planning', 'in_progress', 'coding', 'testing', 'implemented'])) {
+                                                        echo '🚧 ';
+                                                    } else {
+                                                        echo '⏳ ';
+                                                    }
                                                     ?>
                                                     <?= htmlspecialchars(str_replace(['failed_jules', 'failed_pr'], 'failed', $task['status'] ?? '')) ?>
                                                 </span>

--- a/src/frontend/templates.php
+++ b/src/frontend/templates.php
@@ -183,13 +183,13 @@ $templates = $templateModel->findByUserId($user['user_id']);
                         </div>
                     </div>
 
-                    <?php if ($errorMessage): ?>
+                    <?php if ($errorMessage) : ?>
                         <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
                             <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
                         </div>
                     <?php endif; ?>
 
-                    <?php if ($successMessage): ?>
+                    <?php if ($successMessage) : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> <?= htmlspecialchars($successMessage) ?>
                         </div>
@@ -208,12 +208,12 @@ $templates = $templateModel->findByUserId($user['user_id']);
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        <?php if (empty($templates)): ?>
+                                        <?php if (empty($templates)) : ?>
                                             <tr class="bg-white border-b">
                                                 <td colspan="3" class="px-6 py-4 text-center">No templates found. Create one using the form.</td>
                                             </tr>
                                         <?php endif; ?>
-                                        <?php foreach ($templates as $template): ?>
+                                        <?php foreach ($templates as $template) : ?>
                                             <tr class="bg-white border-b">
                                                 <td class="px-6 py-4 font-medium text-gray-900">
                                                     <?= htmlspecialchars($template['name']) ?>

--- a/src/frontend/upgrade.php
+++ b/src/frontend/upgrade.php
@@ -75,13 +75,13 @@ $appliedPatches = $status['applied'];
                 <p class="text-sm text-gray-600">Apply pending SQL patches to your database.</p>
             </div>
 
-            <?php if ($successMessage): ?>
+            <?php if ($successMessage) : ?>
                 <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50 border border-green-200" role="alert">
                     <span class="font-medium">Success!</span> <?= htmlspecialchars($successMessage) ?>
                 </div>
             <?php endif; ?>
 
-            <?php if ($errorMessage): ?>
+            <?php if ($errorMessage) : ?>
                 <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 border border-red-200" role="alert">
                     <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
                 </div>
@@ -94,18 +94,18 @@ $appliedPatches = $status['applied'];
                         Pending Patches (<?= count($pendingPatches) ?>)
                     </h2>
                     <div class="bg-gray-50 rounded-lg p-4 max-h-64 overflow-y-auto border border-gray-200">
-                        <?php if (empty($pendingPatches)): ?>
+                        <?php if (empty($pendingPatches)) : ?>
                             <p class="text-sm text-gray-500 italic">No pending patches. Your database is up to date.</p>
-                        <?php else: ?>
+                        <?php else : ?>
                             <ul class="space-y-2">
-                                <?php foreach ($pendingPatches as $patch): ?>
+                                <?php foreach ($pendingPatches as $patch) : ?>
                                     <li class="text-sm font-mono text-gray-700 bg-white p-2 rounded shadow-sm border border-gray-100"><?= htmlspecialchars($patch) ?></li>
                                 <?php endforeach; ?>
                             </ul>
                         <?php endif; ?>
                     </div>
 
-                    <?php if (!empty($pendingPatches)): ?>
+                    <?php if (!empty($pendingPatches)) : ?>
                         <form method="POST" class="mt-6 space-y-4">
                             <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
 
@@ -113,7 +113,7 @@ $appliedPatches = $status['applied'];
                                 <label for="patch" class="block text-sm font-medium text-gray-700">Select Patch</label>
                                 <select id="patch" name="patch" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md border">
                                     <option value="all">Apply All Pending Patches</option>
-                                    <?php foreach ($pendingPatches as $patch): ?>
+                                    <?php foreach ($pendingPatches as $patch) : ?>
                                         <option value="<?= htmlspecialchars($patch) ?>"><?= htmlspecialchars($patch) ?></option>
                                     <?php endforeach; ?>
                                 </select>
@@ -132,11 +132,11 @@ $appliedPatches = $status['applied'];
                         Applied Patches (<?= count($appliedPatches) ?>)
                     </h2>
                     <div class="bg-gray-50 rounded-lg p-4 max-h-64 overflow-y-auto border border-gray-200">
-                        <?php if (empty($appliedPatches)): ?>
+                        <?php if (empty($appliedPatches)) : ?>
                             <p class="text-sm text-gray-500 italic">No patches applied yet.</p>
-                        <?php else: ?>
+                        <?php else : ?>
                             <ul class="space-y-2">
-                                <?php foreach (array_reverse($appliedPatches) as $patch): ?>
+                                <?php foreach (array_reverse($appliedPatches) as $patch) : ?>
                                     <li class="text-sm font-mono text-gray-400 bg-white p-2 rounded shadow-sm border border-gray-100"><?= htmlspecialchars($patch) ?></li>
                                 <?php endforeach; ?>
                             </ul>
@@ -145,14 +145,14 @@ $appliedPatches = $status['applied'];
                 </div>
             </div>
 
-            <?php if (!empty($logs)): ?>
+            <?php if (!empty($logs)) : ?>
                 <div class="mt-8">
                     <h3 class="text-sm font-bold text-gray-700 mb-2 uppercase tracking-wider">Migration Logs</h3>
                     <div class="bg-gray-900 rounded-lg p-4 border border-gray-700">
                         <pre class="text-xs text-green-400 font-mono whitespace-pre-wrap"><?php
-                            foreach ($logs as $log) {
-                                echo htmlspecialchars($log) . "\n";
-                            }
+                        foreach ($logs as $log) {
+                            echo htmlspecialchars($log) . "\n";
+                        }
                         ?></pre>
                     </div>
                 </div>


### PR DESCRIPTION
This PR fixes the CI/CD failure caused by a fatal PHP error (`Cannot redeclare App\TelegramService::withToken()`). It also resolves a secondary issue in `TelegramChannelHandler.php` where `findById` was called twice, leading to unit test failures when mocks were used. Additionally, it applies standard code style fixes across the codebase to ensure consistency.

Fixes #392

---
*PR created automatically by Jules for task [17726950162723074306](https://jules.google.com/task/17726950162723074306) started by @chatelao*