### PR TITLE
Performance: Optimize page load and API interactions

### DIFF
--- a/src/backend/Project.php
+++ b/src/backend/Project.php
@@ -98,4 +98,16 @@ class Project
         );
         return $stmt->execute([$id, $userId]);
     }
+
+    public function updateRoadmapCache(int $projectId, array $roadmapData): bool
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "UPDATE projects SET roadmap_data = ?, roadmap_updated_at = ? WHERE project_id = ?"
+        );
+        return $stmt->execute([
+            json_encode($roadmapData),
+            date('Y-m-d H:i:s'),
+            $projectId
+        ]);
+    }
 }

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -243,6 +243,35 @@ class Task
         return $stmt->execute([$response, $status, $id]);
     }
 
+    public function updateGitHubCache(int $taskId, ?array $prData = null, ?array $commentsData = null): bool
+    {
+        $updates = [];
+        $params = [];
+
+        if ($prData !== null) {
+            $updates[] = "github_pr_data = ?";
+            $params[] = json_encode($prData);
+        }
+
+        if ($commentsData !== null) {
+            $updates[] = "github_comments_data = ?";
+            $params[] = json_encode($commentsData);
+        }
+
+        if (empty($updates)) {
+            return true;
+        }
+
+        $updates[] = "github_data_updated_at = ?";
+        $params[] = date('Y-m-d H:i:s');
+
+        $params[] = $taskId;
+
+        $sql = "UPDATE tasks SET " . implode(', ', $updates) . " WHERE task_id = ?";
+        $stmt = $this->db->getConnection()->prepare($sql);
+        return $stmt->execute($params);
+    }
+
     public function create(array $data): bool
     {
         $stmt = $this->db->getConnection()->prepare(

--- a/src/frontend/ajax-notifications.php
+++ b/src/frontend/ajax-notifications.php
@@ -15,6 +15,9 @@ if (!$auth->isLoggedIn()) {
     exit;
 }
 
+// Release session lock to prevent blocking other requests
+session_write_close();
+
 $db = new Database();
 $notificationService = new NotificationService($db);
 $taskModel = new \App\Task($db);

--- a/src/frontend/ajax-sync.php
+++ b/src/frontend/ajax-sync.php
@@ -20,6 +20,9 @@ if (!$auth->isLoggedIn()) {
     exit;
 }
 
+// Release session lock to prevent blocking other requests
+session_write_close();
+
 $db = new Database();
 $userModel = new User($db);
 $projectModel = new Project($db);
@@ -38,8 +41,7 @@ try {
             $githubToken = $project['github_token'] ?? null;
             if ($githubToken) {
                 $githubService = new GitHubService(null, $githubToken);
-                $taskModel->syncIssues($userId, $projectId, $project['github_repo'], $githubService);
-                $taskModel->refreshJulesStatus($userId, $githubService, $julesService, $notificationService);
+                $taskModel->refreshJulesStatus($userId, $githubService, $julesService, $notificationService, null, $projectId);
             }
         }
     } else {

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -126,10 +126,18 @@ $triggerAgent = function($taskId) use ($taskModel, $logger, $user, $project, $ju
 
 $githubToken = $project['github_token'] ?? null;
 $roadmapFiles = [];
-if ($githubToken) {
+
+$roadmapCacheTimeout = 3600; // 1 hour
+$roadmapUpdatedAt = strtotime($project['roadmap_updated_at'] ?? '2000-01-01');
+$isRoadmapCacheValid = (time() - $roadmapUpdatedAt) < $roadmapCacheTimeout;
+
+if ($isRoadmapCacheValid && !empty($project['roadmap_data'])) {
+    $roadmapFiles = json_decode($project['roadmap_data'], true);
+} elseif ($githubToken) {
     try {
         $githubService = new GitHubService(null, $githubToken);
         $roadmapFiles = $githubService->getRoadmapFiles($project['github_repo']);
+        $projectModel->updateRoadmapCache($projectId, $roadmapFiles);
     } catch (Exception $e) {
         // Silently fail or log roadmap fetching
     }

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -69,34 +69,47 @@ $julesMessages = [];
 
 $taskNotifSettings = $notificationService->getTaskSettings($taskId);
 
+$cacheTimeout = 15 * 60; // 15 minutes
+$cacheUpdatedAt = strtotime($task['github_data_updated_at'] ?? '2000-01-01');
+$isCacheValid = (time() - $cacheUpdatedAt) < $cacheTimeout;
+
 if ($githubToken) {
     $githubService = new GitHubService(null, $githubToken);
 
-    // Fetch PR details if available
-    if (!empty($task['pr_url'])) {
+    if ($isCacheValid && !empty($task['github_pr_data'])) {
+        $prDetails = json_decode($task['github_pr_data'], true);
+    } elseif (!empty($task['pr_url'])) {
+        // Fetch PR details if available
         $prNumber = $githubService->extractPrNumber($task['pr_url']);
         if ($prNumber) {
             try {
                 $prDetails = $githubService->getPullRequest($project['github_repo'], $prNumber);
+                $taskModel->updateGitHubCache($taskId, $prDetails, null);
             } catch (Exception $e) {
                 // Ignore PR fetch errors
             }
         }
     }
 
-    // Fetch last comments to find Jules messages
-    try {
-        $comments = $githubService->getIssueComments($project['github_repo'], $task['issue_number']);
-        // Filter for Jules comments
-        $julesMessages = array_filter($comments, function($comment) {
-            $login = strtolower($comment['user']['login'] ?? '');
-            return $login === 'jules' || $login === 'google-labs-jules[bot]';
-        });
-        // Take the last few
-        $julesMessages = array_slice(array_reverse($julesMessages), 0, 3);
-    } catch (Exception $e) {
-        // Ignore comment fetch errors
+    if ($isCacheValid && !empty($task['github_comments_data'])) {
+        $comments = json_decode($task['github_comments_data'], true);
+    } else {
+        // Fetch last comments to find Jules messages
+        try {
+            $comments = $githubService->getIssueComments($project['github_repo'], $task['issue_number']);
+            $taskModel->updateGitHubCache($taskId, null, $comments);
+        } catch (Exception $e) {
+            $comments = [];
+        }
     }
+
+    // Filter for Jules comments
+    $julesMessages = array_filter($comments, function($comment) {
+        $login = strtolower($comment['user']['login'] ?? '');
+        return $login === 'jules' || $login === 'google-labs-jules[bot]';
+    });
+    // Take the last few
+    $julesMessages = array_slice(array_reverse($julesMessages), 0, 3);
 }
 
 // Status logic for the right sidebar overview

--- a/src/sql/patches/012_add_caching_columns.sql
+++ b/src/sql/patches/012_add_caching_columns.sql
@@ -1,0 +1,6 @@
+ALTER TABLE tasks ADD COLUMN github_pr_data TEXT;
+ALTER TABLE tasks ADD COLUMN github_comments_data TEXT;
+ALTER TABLE tasks ADD COLUMN github_data_updated_at TIMESTAMP;
+
+ALTER TABLE projects ADD COLUMN roadmap_data TEXT;
+ALTER TABLE projects ADD COLUMN roadmap_updated_at TIMESTAMP;

--- a/test/Integration/verify_task_ui_fixed.php
+++ b/test/Integration/verify_task_ui_fixed.php
@@ -1,0 +1,144 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Database;
+use App\Auth;
+use App\User;
+use App\Project;
+use App\Task;
+
+// Set environment for testing
+putenv('DB_NAME=:memory:');
+
+// Initialize session if not started
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$db = new Database();
+$pdo = $db->getConnection();
+
+// Create schema
+$pdo->exec("CREATE TABLE IF NOT EXISTS users (
+    user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    google_id VARCHAR(255) UNIQUE NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    avatar VARCHAR(255),
+    role VARCHAR(20) DEFAULT 'user',
+    jules_api_key VARCHAR(255),
+    jules_quota_usage INT DEFAULT 0,
+    jules_quota_limit INT DEFAULT 0,
+    telegram_bot_token VARCHAR(255),
+    telegram_webhook_secret VARCHAR(255),
+    telegram_link_token VARCHAR(255),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_telegram_accounts (
+    telegram_account_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    telegram_chat_id BIGINT UNIQUE NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS task_notification_settings (
+    task_id INTEGER NOT NULL PRIMARY KEY,
+    is_muted BOOLEAN DEFAULT 0
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS project_notification_settings (
+    project_id INTEGER NOT NULL,
+    notification_type VARCHAR(50) NOT NULL,
+    is_enabled BOOLEAN DEFAULT 1,
+    PRIMARY KEY (project_id, notification_type)
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_github_accounts (
+    github_account_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    github_username VARCHAR(255) NOT NULL,
+    github_token VARCHAR(255) NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+    UNIQUE(user_id, github_username)
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS projects (
+    project_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    github_account_id INT NOT NULL,
+    github_repo VARCHAR(255) NOT NULL,
+    github_username VARCHAR(255),
+    roadmap_data TEXT,
+    roadmap_updated_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (github_account_id) REFERENCES user_github_accounts(github_account_id) ON DELETE CASCADE
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
+    task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    project_id INT NOT NULL,
+    issue_number INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    body TEXT,
+    status TEXT DEFAULT 'pending',
+    jules_status VARCHAR(50) DEFAULT 'pending',
+    github_state VARCHAR(20) DEFAULT 'open',
+    github_data TEXT,
+    github_pr_data TEXT,
+    github_comments_data TEXT,
+    github_data_updated_at DATETIME,
+    agent_response TEXT,
+    pr_url VARCHAR(255),
+    jules_url VARCHAR(255),
+    jules_session_id VARCHAR(255),
+    last_synced_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS task_logs (
+    task_log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    task_id INT NOT NULL,
+    level VARCHAR(20) DEFAULT 'info',
+    message TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS notifications (
+    notification_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    message TEXT NOT NULL,
+    data TEXT,
+    is_read BOOLEAN DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+)");
+
+// Create a mock user
+$pdo->exec("INSERT OR IGNORE INTO users (user_id, google_id, name, email) VALUES (1, 'google-123', 'Test User', 'test@example.com')");
+$_SESSION['user_id'] = 1;
+
+// Create mock github account
+$pdo->exec("INSERT INTO user_github_accounts (github_account_id, user_id, github_username, github_token) VALUES (1, 1, 'owner', 'fake-token')");
+
+// Create a mock project
+$pdo->exec("INSERT INTO projects (project_id, user_id, github_account_id, github_repo, github_username) VALUES (1, 1, 1, 'owner/repo', 'owner')");
+
+// Create a mock task
+$pdo->exec("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, body, status, jules_status, pr_url, jules_url)
+            VALUES (101, 1, 1, 101, 'Mock Task Title', 'This is a mock task description.', 'in_progress', 'coding', 'https://github.com/owner/repo/pull/1', 'https://jules.example.com/session/1')");
+
+// Add some logs
+$pdo->exec("INSERT INTO task_logs (task_id, user_id, level, message) VALUES (101, 1, 'info', 'Started coding phase')");
+$pdo->exec("INSERT INTO task_logs (task_id, user_id, level, message) VALUES (101, 1, 'error', 'Something went wrong, but we recovered')");
+
+// Include the actual file to test
+$_GET['id'] = 101;
+include __DIR__ . '/../../src/frontend/task.php';


### PR DESCRIPTION
The severe performance degradation was caused by synchronous GitHub API calls on every page load and PHP session locking that prevented concurrent requests.

This PR introduces a database-backed caching layer for GitHub data, significantly reducing the number of external API calls. It also releases the PHP session lock early in background AJAX requests, allowing the main page and indicators to load in parallel.

Key improvements:
1. **Task Page**: PR details and comments are now cached for 15 minutes.
2. **Project Page**: Roadmap files are cached for 1 hour.
3. **General**: session_write_close() added to sync and notification endpoints.
4. **Dashboard**: Removed redundant issue sync from the background refresh process.

Fixes #390

---
*PR created automatically by Jules for task [8606850699667888395](https://jules.google.com/task/8606850699667888395) started by @chatelao*