### PR TITLE
Add UML component diagram to DESIGN.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,6 +3,89 @@
 ## Architecture
 The application follows a modular architecture, separating concerns between the presentation layer, business logic, and data access.
 
+### Component Diagram
+The following diagram illustrates the high-level components and their interactions:
+
+```plantuml
+@startuml
+!theme plain
+skinparam componentStyle uml2
+
+package "Frontend (Tailwind CSS, Alpine.js)" {
+    [UI Pages] as UI
+    [AJAX Endpoints] as AJAX
+}
+
+package "Backend (PHP 8.3)" {
+    package "API Handlers" {
+        [WebhookHandler] as WH
+        [TelegramWebhookHandler] as TWH
+    }
+
+    package "Services" {
+        [GitHubService] as GHS
+        [JulesService] as JS
+        [TelegramService] as TS
+        [NotificationService] as NS
+        [MigrationService] as MS
+    }
+
+    package "Models & Data Access" {
+        [User] as UserM
+        [Project] as ProjectM
+        [Task] as TaskM
+        [Database] as DB
+        [Auth] as AuthM
+    }
+
+    package "Logging & Monitoring" {
+        [Logger] as Log
+        [WebhookLogger] as WHLog
+    }
+}
+
+database "MySQL Database" as MySQL
+
+cloud "External Systems" {
+    [GitHub API/Webhooks] as GitHub
+    [Google Jules API] as Jules
+    [Telegram API] as Telegram
+    [Google SSO] as SSO
+}
+
+' Interactions
+UI --> AJAX : fetch/post
+AJAX --> AuthM : authenticate
+AJAX --> GHS : repo/issue data
+AJAX --> JS : agent status
+AJAX --> NS : notifications
+AJAX --> UserM : profile/settings
+
+WH --> GHS : process events
+WH --> TaskM : update tasks
+WH --> NS : trigger notifications
+
+TWH --> TS : response
+TWH --> UserM : link accounts
+
+NS --> TS : external delivery
+NS --> [BrowserChannelHandler] : in-app delivery
+
+GHS --> GitHub : REST API
+JS --> Jules : REST API
+TS --> Telegram : REST API
+AuthM --> SSO : OAuth 2.0
+
+UserM --> DB
+ProjectM --> DB
+TaskM --> DB
+DB --> MySQL
+Log --> MySQL
+WHLog --> MySQL
+
+@enduml
+```
+
 ## Tech Stack
 - **Development & Production**:
     - **Language**: PHP 8.3+

--- a/architecture.puml
+++ b/architecture.puml
@@ -1,0 +1,77 @@
+@startuml
+!theme plain
+skinparam componentStyle uml2
+
+package "Frontend (Tailwind CSS, Alpine.js)" {
+    [UI Pages] as UI
+    [AJAX Endpoints] as AJAX
+}
+
+package "Backend (PHP 8.3)" {
+    package "API Handlers" {
+        [WebhookHandler] as WH
+        [TelegramWebhookHandler] as TWH
+    }
+
+    package "Services" {
+        [GitHubService] as GHS
+        [JulesService] as JS
+        [TelegramService] as TS
+        [NotificationService] as NS
+        [MigrationService] as MS
+    }
+
+    package "Models & Data Access" {
+        [User] as UserM
+        [Project] as ProjectM
+        [Task] as TaskM
+        [Database] as DB
+        [Auth] as AuthM
+    }
+
+    package "Logging & Monitoring" {
+        [Logger] as Log
+        [WebhookLogger] as WHLog
+    }
+}
+
+database "MySQL Database" as MySQL
+
+cloud "External Systems" {
+    [GitHub API/Webhooks] as GitHub
+    [Google Jules API] as Jules
+    [Telegram API] as Telegram
+    [Google SSO] as SSO
+}
+
+' Interactions
+UI --> AJAX : fetch/post
+AJAX --> AuthM : authenticate
+AJAX --> GHS : repo/issue data
+AJAX --> JS : agent status
+AJAX --> NS : notifications
+AJAX --> UserM : profile/settings
+
+WH --> GHS : process events
+WH --> TaskM : update tasks
+WH --> NS : trigger notifications
+
+TWH --> TS : response
+TWH --> UserM : link accounts
+
+NS --> TS : external delivery
+NS --> [BrowserChannelHandler] : in-app delivery
+
+GHS --> GitHub : REST API
+JS --> Jules : REST API
+TS --> Telegram : REST API
+AuthM --> SSO : OAuth 2.0
+
+UserM --> DB
+ProjectM --> DB
+TaskM --> DB
+DB --> MySQL
+Log --> MySQL
+WHLog --> MySQL
+
+@enduml


### PR DESCRIPTION
This PR adds a comprehensive UML component diagram to the project's design documentation.

Key changes:
- New file `architecture.puml`: Contains the PlantUML source for the component diagram, allowing for easier maintenance and IDE rendering.
- Updated `DESIGN.md`: Added a new "Component Diagram" subsection under "Architecture" that embeds the diagram.

The diagram visualizes:
- The separation between the presentation layer (Frontend) and business logic (Backend).
- The internal structure of the Backend (Handlers, Services, Models, Logging).
- Interactions with external systems like GitHub, Google Jules, Telegram, and Google SSO.
- Data flow between components and the database.

Fixes #426

---
*PR created automatically by Jules for task [2716368692449794487](https://jules.google.com/task/2716368692449794487) started by @chatelao*