### PR TITLE
Fix Auto-Repeat and Implement Merge & Close

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -22,6 +22,44 @@ class GitHubService
     /**
      * @throws Exception
      */
+    public function mergePullRequest(string $repo, int $prNumber, string $message = '', string $mergeMethod = 'merge'): array
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+
+        return $this->apiCall(
+            'GitHub API',
+            "PUT merge $repo/pull/$prNumber",
+            fn() => $this->client->api('pull_request')->merge($username, $repository, $prNumber, $message, null, $mergeMethod)
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function closeIssue(string $repo, int $issueNumber): array
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+
+        return $this->apiCall(
+            'GitHub API',
+            "PATCH issue $repo/issues/$issueNumber",
+            fn() => $this->client->api('issue')->update($username, $repository, $issueNumber, ['state' => 'closed'])
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
     private function apiCall(string $type, string $target, callable $call, ?array $context = null): mixed
     {
         $start = microtime(true);

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -165,7 +165,8 @@ class Task
             $hasAutorepeat = false;
             $labels = $githubData['labels'] ?? [];
             foreach ($labels as $label) {
-                if (($label['name'] ?? '') === 'autorepeat') {
+                $name = strtolower($label['name'] ?? '');
+                if ($name === 'autorepeat' || $name === 'auto-repeat') {
                     $hasAutorepeat = true;
                     break;
                 }

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -88,19 +88,39 @@ class WebhookHandler
             $stateReason = $issue['state_reason'] ?? '';
             $labels = $issue['labels'] ?? [];
             $hasAutorepeat = false;
+            $autorepeatLabelName = '';
+
             foreach ($labels as $label) {
-                if (($label['name'] ?? '') === 'autorepeat') {
+                $name = strtolower($label['name'] ?? '');
+                if ($name === 'autorepeat' || $name === 'auto-repeat') {
                     $hasAutorepeat = true;
+                    $autorepeatLabelName = $label['name'];
                     break;
                 }
             }
 
             if ($stateReason === 'completed' && $hasAutorepeat) {
-                $labelNames = array_map(fn($l) => $l['name'], $labels);
+                $labelNames = array_filter(
+                    array_map(fn($l) => $l['name'], $labels),
+                    fn($name) => strtolower($name) !== 'autorepeat' && strtolower($name) !== 'auto-repeat'
+                );
+
+                // Ensure 'Jules' label is present to trigger the agent for the new issue as per AUTOMATION_CONCEPT.md
+                $hasJules = false;
+                foreach ($labelNames as $ln) {
+                    if (strtolower($ln) === 'jules') {
+                        $hasJules = true;
+                        break;
+                    }
+                }
+                if (!$hasJules) {
+                    $labelNames[] = 'Jules';
+                }
+
                 $repo = $event['repository']['full_name'] ?? '';
                 if ($repo) {
-                    $githubService->createIssue($repo, $issue['title'], $issue['body'], $labelNames);
-                    $githubService->removeLabel($repo, $issue['number'], 'autorepeat');
+                    $githubService->createIssue($repo, $issue['title'], $issue['body'], array_values($labelNames));
+                    $githubService->removeLabel($repo, $issue['number'], $autorepeatLabelName);
                 }
             }
         }

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -57,6 +57,38 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_task_notificat
     }
 }
 
+// Handle Merge & Close
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
+    if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
+        die("CSRF token validation failed.");
+    }
+
+    try {
+        $githubToken = $project['github_token'] ?? null;
+        if (!$githubToken) {
+            throw new Exception("GitHub token not found for this project.");
+        }
+
+        $githubService = new \App\GitHubService(null, $githubToken);
+        $prNumber = $githubService->extractPrNumber($task['pr_url'] ?? '');
+
+        if (!$prNumber) {
+            throw new Exception("No pull request associated with this task.");
+        }
+
+        // 1. Merge the PR
+        $githubService->mergePullRequest($project['github_repo'], $prNumber, "Merged via Agent Control: " . $task['title']);
+
+        // 2. Close the issue
+        $githubService->closeIssue($project['github_repo'], $task['issue_number']);
+
+        header("Location: task.php?id=$taskId&success=merged_closed");
+        exit;
+    } catch (Exception $e) {
+        $errorMessage = "Error merging/closing: " . $e->getMessage();
+    }
+}
+
 $githubData = json_decode($task['github_data'] ?? '{}', true);
 $labels = $githubData['labels'] ?? [];
 $statusColor = $taskModel->getStatusColor($task);
@@ -216,6 +248,18 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                     <?php if (isset($_GET['success']) && $_GET['success'] === 'notifications_updated') : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Notification settings updated.
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'merged_closed') : ?>
+                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+                            <span class="font-medium">Success!</span> Pull Request merged and Issue closed.
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if (isset($errorMessage)) : ?>
+                        <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+                            <span class="font-medium">Error!</span> <?= htmlspecialchars($errorMessage) ?>
                         </div>
                     <?php endif; ?>
 
@@ -414,6 +458,19 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                                             <?= htmlspecialchars($prStatus) ?>
                                         </span>
                                     </div>
+
+                                    <?php
+                                    $isMergeable = ($prDetails && ($prDetails['state'] ?? '') === 'open' && ($prDetails['mergeable_state'] ?? '') === 'clean' && !($prDetails['draft'] ?? false));
+                                    if ($isMergeable) : ?>
+                                        <div class="mt-4 pt-4 border-t border-gray-100">
+                                            <form method="POST">
+                                                <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                                <button type="submit" name="merge_close" class="w-full text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none" onclick="return confirm('Are you sure you want to merge this PR and close the issue?')">
+                                                    Merge & Close
+                                                </button>
+                                            </form>
+                                        </div>
+                                    <?php endif; ?>
                                 </div>
 
                                 <div class="mt-6 pt-6 border-t border-gray-100">

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -96,7 +96,7 @@ class WebhookHandlerTest extends TestCase
         $githubService = $this->createMock(\App\GitHubService::class);
         $githubService->expects($this->once())
             ->method('createIssue')
-            ->with('owner/repo', 'Autorepeat Issue', 'Description', ['autorepeat']);
+            ->with('owner/repo', 'Autorepeat Issue', 'Description', ['Jules']);
         $githubService->expects($this->once())
             ->method('removeLabel')
             ->with('owner/repo', 123, 'autorepeat');

--- a/test/Integration/verify_task_ui.php
+++ b/test/Integration/verify_task_ui.php
@@ -88,6 +88,9 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     pr_url VARCHAR(255),
     jules_url VARCHAR(255),
     jules_session_id VARCHAR(255),
+    github_pr_data TEXT,
+    github_comments_data TEXT,
+    github_data_updated_at DATETIME,
     last_synced_at DATETIME,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -125,8 +128,9 @@ $pdo->exec("INSERT INTO user_github_accounts (github_account_id, user_id, github
 $pdo->exec("INSERT INTO projects (project_id, user_id, github_account_id, github_repo, github_username) VALUES (1, 1, 1, 'owner/repo', 'owner')");
 
 // Create a mock task
-$pdo->exec("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, body, status, jules_status, pr_url, jules_url)
-            VALUES (101, 1, 1, 101, 'Mock Task Title', 'This is a mock task description.', 'in_progress', 'coding', 'https://github.com/owner/repo/pull/1', 'https://jules.example.com/session/1')");
+$now = date('Y-m-d H:i:s');
+$pdo->exec("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, body, status, jules_status, pr_url, jules_url, github_pr_data, github_data_updated_at)
+            VALUES (101, 1, 1, 101, 'Mock Task Title', 'This is a mock task description.', 'in_progress', 'coding', 'https://github.com/owner/repo/pull/1', 'https://jules.example.com/session/1', '{\"state\":\"open\",\"mergeable_state\":\"clean\",\"draft\":false}', '$now')");
 
 // Add some logs
 $pdo->exec("INSERT INTO task_logs (task_id, user_id, level, message) VALUES (101, 1, 'info', 'Started coding phase')");

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -87,7 +87,7 @@ class WebhookHandlerTest extends TestCase
         $githubService = $this->createMock(\App\GitHubService::class);
         $githubService->expects($this->once())
             ->method('createIssue')
-            ->with('owner/repo', 'Test Issue', 'Body', ['autorepeat', 'bug']);
+            ->with('owner/repo', 'Test Issue', 'Body', ['bug', 'Jules']);
         $githubService->expects($this->once())
             ->method('removeLabel')
             ->with('owner/repo', 123, 'autorepeat');


### PR DESCRIPTION
Implemented the missing 'Merge & Close' functionality and fixed the case-sensitivity issues with the auto-repeat mechanism as documented in AUDIT_AUTO_REPEAT.md.

Changes include:
- `src/backend/GitHubService.php`: Added `mergePullRequest` and `closeIssue`.
- `src/backend/WebhookHandler.php`: Case-insensitive label check, proper label cleanup, and ensuring 'Jules' label on duplicated issues.
- `src/backend/Task.php`: Case-insensitive label check in `getRunningAutorepeatTasks`.
- `src/frontend/task.php`: Added UI and POST handler for 'Merge & Close'.
- Updated tests in `test/Unit/Services/WebhookHandlerTest.php` and `test/Integration/WebhookHandlerTest.php`.
- Updated mock data in `test/Integration/verify_task_ui.php` for UI verification.

Fixes #433

---
*PR created automatically by Jules for task [14610008962897116491](https://jules.google.com/task/14610008962897116491) started by @chatelao*