### PR TITLE
Implement Telegram Callback Infrastructure and Action-Enabled Notifications

### DIFF
--- a/CHAT_ROADMAP.md
+++ b/CHAT_ROADMAP.md
@@ -4,8 +4,8 @@
 
 | Phase | Description | Status |
 |-------|-------------|--------|
-| 1 | Callback Infrastructure | 🚧 |
-| 2 | Action-Enabled Notifications | 🚧 |
+| 1 | Callback Infrastructure | ✅ |
+| 2 | Action-Enabled Notifications | ✅ |
 | 3 | [UC-C1] Remote Task Recovery | 🚧 |
 | 4 | [UC-C2] One-Tap PR Merging | 🚧 |
 | 5 | UX & Feedback Loop | 🚧 |
@@ -14,20 +14,20 @@
 
 - Transform Telegram bot into an interactive management interface. ✅
 - Support common task operations (Retry, Restart, Merge) directly from chat. 🚧
-- Provide immediate feedback for remote actions. 🚧
-- Maintain secure, authorized access to project resources. 🚧
+- Provide immediate feedback for remote actions. ✅
+- Maintain secure, authorized access to project resources. ✅
 
 ## Phase 1: Callback Infrastructure
-- [ ] Extend `App\TelegramWebhookHandler` to process `callback_query` updates.
-- [ ] Implement secure user verification for callback queries (via `chat_id`).
-- [ ] Implement resource authorization check (verify user permissions for `taskId`).
-- [ ] Add `answerCallbackQuery` support to `App\TelegramService`.
-- [ ] Implement basic routing for callback data patterns (e.g., `action:id`).
+- [x] Extend `App\TelegramWebhookHandler` to process `callback_query` updates.
+- [x] Implement secure user verification for callback queries (via `chat_id`).
+- [x] Implement resource authorization check (verify user permissions for `taskId`).
+- [x] Add `answerCallbackQuery` support to `App\TelegramService`.
+- [x] Implement basic routing for callback data patterns (e.g., `action:id`).
 
 ## Phase 2: Action-Enabled Notifications
-- [ ] Update `NotificationService::notify` to accept an optional `actions` array.
-- [ ] Enhance `TelegramChannelHandler` to translate actions into `InlineKeyboardMarkup`.
-- [ ] Define standardized callback data format (e.g., `retry:{taskId}`, `merge:{taskId}`).
+- [x] Update `NotificationService::notify` to accept an optional `actions` array.
+- [x] Enhance `TelegramChannelHandler` to translate actions into `InlineKeyboardMarkup`.
+- [x] Define standardized callback data format (e.g., `retry:{taskId}`, `merge:{taskId}`).
 - [ ] Test button rendering in Telegram for different notification types.
 
 ## Phase 3: [UC-C1] Remote Task Recovery

--- a/src/backend/BrowserChannelHandler.php
+++ b/src/backend/BrowserChannelHandler.php
@@ -4,7 +4,7 @@ namespace App;
 
 class BrowserChannelHandler implements NotificationChannelInterface
 {
-    public function send(array $notification): bool
+    public function send(array $notification, array $actions = []): bool
     {
         // Browser notifications are handled by frontend polling.
         // This handler is a no-op to satisfy the interface.

--- a/src/backend/NotificationChannelInterface.php
+++ b/src/backend/NotificationChannelInterface.php
@@ -8,7 +8,8 @@ interface NotificationChannelInterface
      * Sends a notification through the channel.
      *
      * @param array $notification The notification data.
+     * @param array $actions Optional interactive actions.
      * @return bool True if sent successfully, false otherwise.
      */
-    public function send(array $notification): bool;
+    public function send(array $notification, array $actions = []): bool;
 }

--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -17,7 +17,7 @@ class NotificationService
         $this->channels[$name] = $channel;
     }
 
-    public function notify(int $userId, string $type, string $title, string $message, array $data = []): bool
+    public function notify(int $userId, string $type, string $title, string $message, array $data = [], array $actions = []): bool
     {
         // 1. Check task-level mute (if task_id is provided)
         if (isset($data['task_id']) && $this->isTaskMuted($data['task_id'])) {
@@ -75,7 +75,7 @@ class NotificationService
             $channel = $this->getChannelInstance($channelName);
 
             if ($channel) {
-                $channel->send($notification);
+                $channel->send($notification, $actions);
             }
         }
 

--- a/src/backend/TelegramChannelHandler.php
+++ b/src/backend/TelegramChannelHandler.php
@@ -14,7 +14,7 @@ class TelegramChannelHandler implements NotificationChannelInterface
     ) {
     }
 
-    public function send(array $notification): bool
+    public function send(array $notification, array $actions = []): bool
     {
         $userId = $notification['user_id'];
         $user = $this->userModel->findById($userId);
@@ -42,8 +42,27 @@ class TelegramChannelHandler implements NotificationChannelInterface
             $text .= "\n\n<a href=\"" . htmlspecialchars($sourceUrl) . "\">View Source</a>";
         }
 
+        $extraParams = [];
+        if (!empty($actions) && isset($notification['data']['task_id'])) {
+            $taskId = $notification['data']['task_id'];
+            $buttons = [];
+            foreach ($actions as $action) {
+                $label = ucfirst($action);
+                if ($action === 'merge') {
+                    $label = 'Merge & Close';
+                }
+                $buttons[] = [
+                    'text' => $label,
+                    'callback_data' => "$action:$taskId"
+                ];
+            }
+            $extraParams['reply_markup'] = [
+                'inline_keyboard' => [$buttons]
+            ];
+        }
+
         try {
-            return $this->telegramService->withToken($botToken)->sendMessage($chatId, $text);
+            return $this->telegramService->withToken($botToken)->sendMessage($chatId, $text, $extraParams);
         } catch (\Exception $e) {
             error_log("Telegram Send Error for user $userId: " . $e->getMessage());
             return false;

--- a/src/backend/TelegramService.php
+++ b/src/backend/TelegramService.php
@@ -26,6 +26,37 @@ class TelegramService
     }
 
     /**
+     * @throws Exception
+     */
+    public function answerCallbackQuery(string $callbackQueryId, array $extraParams = []): bool
+    {
+        $params = array_merge([
+            'callback_query_id' => $callbackQueryId,
+        ], $extraParams);
+
+        $this->apiRequest('answerCallbackQuery', $params);
+
+        return true;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function editMessageText(int $chatId, int $messageId, string $text, array $extraParams = []): bool
+    {
+        $params = array_merge([
+            'chat_id' => $chatId,
+            'message_id' => $messageId,
+            'text' => $text,
+            'parse_mode' => 'HTML'
+        ], $extraParams);
+
+        $this->apiRequest('editMessageText', $params);
+
+        return true;
+    }
+
+    /**
      * @throws GuzzleException
      * @throws Exception
      */

--- a/src/backend/TelegramWebhookHandler.php
+++ b/src/backend/TelegramWebhookHandler.php
@@ -2,6 +2,8 @@
 
 namespace App;
 
+use App\Task;
+
 class TelegramWebhookHandler
 {
     public function __construct(
@@ -23,6 +25,10 @@ class TelegramWebhookHandler
 
     public function handle(array $update): bool
     {
+        if (isset($update['callback_query'])) {
+            return $this->handleCallback($update['callback_query']);
+        }
+
         $message = $update['message'] ?? null;
         if (!$message) {
             return false;
@@ -46,6 +52,64 @@ class TelegramWebhookHandler
         }
 
         return false;
+    }
+
+    private function handleCallback(array $callbackQuery): bool
+    {
+        $callbackId = $callbackQuery['id'];
+        $data = $callbackQuery['data'] ?? '';
+        $chatId = $callbackQuery['message']['chat']['id'] ?? null;
+
+        if (!$chatId) {
+            return false;
+        }
+
+        // 1. Authenticate user by chatId
+        $user = $this->userModel->findByTelegramChatId($chatId);
+        if (!$user) {
+            $this->telegramService->answerCallbackQuery($callbackId, [
+                'text' => "Unauthorized. Please link your account.",
+                'show_alert' => true
+            ]);
+            return false;
+        }
+
+        // 2. Parse action and taskId
+        // Expected format: "action:taskId"
+        $parts = explode(':', $data);
+        $action = $parts[0] ?? '';
+        $taskId = isset($parts[1]) ? (int)$parts[1] : null;
+
+        if (!$taskId || !in_array($action, ['retry', 'restart', 'merge'])) {
+            $this->telegramService->answerCallbackQuery($callbackId, [
+                'text' => "Invalid action.",
+                'show_alert' => true
+            ]);
+            return false;
+        }
+
+        // 3. Verify project permissions
+        $taskModel = new Task($this->userModel->getDb());
+        $task = $taskModel->findById($taskId);
+
+        if (!$task || (int)$task['user_id'] !== (int)$user['user_id']) {
+            $this->telegramService->answerCallbackQuery($callbackId, [
+                'text' => "Task not found or access denied.",
+                'show_alert' => true
+            ]);
+            return false;
+        }
+
+        // 4. Acknowledge the query
+        $this->telegramService->answerCallbackQuery($callbackId, [
+            'text' => "Processing " . ucfirst($action) . "..."
+        ]);
+
+        // Note: Actual execution via GHS or JS will be implemented in Phase 3 & 4.
+        // For now, we just acknowledge that the infrastructure is ready.
+        $this->telegramService->sendMessage($chatId, "Infrastructure for <b>$action</b> is ready. Actual execution will be implemented soon.");
+
+        return true;
     }
 
     private function handleLink(int $chatId, string $token): bool

--- a/src/backend/User.php
+++ b/src/backend/User.php
@@ -155,6 +155,18 @@ class User
         return $result ? (int)$result['telegram_chat_id'] : null;
     }
 
+    public function findByTelegramChatId(int $chatId): ?array
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "SELECT u.* FROM users u
+             JOIN user_telegram_accounts uta ON u.user_id = uta.user_id
+             WHERE uta.telegram_chat_id = ?"
+        );
+        $stmt->execute([$chatId]);
+        $user = $stmt->fetch();
+        return $user ?: null;
+    }
+
     public function updateJulesApiKey(int $userId, ?string $apiKey): bool
     {
         $stmt = $this->db->getConnection()->prepare(

--- a/test/Unit/Services/TelegramCallbackTest.php
+++ b/test/Unit/Services/TelegramCallbackTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use PHPUnit\Framework\TestCase;
+use App\TelegramWebhookHandler;
+use App\User;
+use App\Task;
+use App\Database;
+use App\TelegramService;
+
+class TelegramCallbackTest extends TestCase
+{
+    private $userModel;
+    private $telegramService;
+    private $handler;
+    private $db;
+
+    protected function setUp(): void
+    {
+        $this->userModel = $this->createMock(User::class);
+        $this->telegramService = $this->createMock(TelegramService::class);
+        $this->db = $this->createMock(Database::class);
+
+        $this->userModel->method('getDb')->willReturn($this->db);
+
+        $this->handler = new TelegramWebhookHandler($this->userModel, $this->telegramService, 'secret');
+    }
+
+    public function testHandleCallbackUnauthorized()
+    {
+        $update = [
+            'callback_query' => [
+                'id' => 'cb123',
+                'data' => 'retry:456',
+                'message' => ['chat' => ['id' => 123]]
+            ]
+        ];
+
+        $this->userModel->expects($this->once())
+            ->method('findByTelegramChatId')
+            ->with(123)
+            ->willReturn(null);
+
+        $this->telegramService->expects($this->once())
+            ->method('answerCallbackQuery')
+            ->with('cb123', $this->callback(fn($params) => strpos($params['text'], 'Unauthorized') !== false));
+
+        $this->assertFalse($this->handler->handle($update));
+    }
+
+    public function testHandleCallbackInvalidAction()
+    {
+        $update = [
+            'callback_query' => [
+                'id' => 'cb123',
+                'data' => 'invalid:456',
+                'message' => ['chat' => ['id' => 123]]
+            ]
+        ];
+
+        $this->userModel->method('findByTelegramChatId')->willReturn(['user_id' => 1]);
+
+        $this->telegramService->expects($this->once())
+            ->method('answerCallbackQuery')
+            ->with('cb123', $this->callback(fn($params) => strpos($params['text'], 'Invalid action') !== false));
+
+        $this->assertFalse($this->handler->handle($update));
+    }
+}


### PR DESCRIPTION
This PR implements Phase 1 and most of Phase 2 of the Telegram Chat Control roadmap.

Key changes:
1.  **TelegramService**: Added `answerCallbackQuery` and `editMessageText` methods to support standard Telegram interactive features.
2.  **User Model**: Added `findByTelegramChatId` to allow identifying and authenticating users when they interact with the bot.
3.  **TelegramWebhookHandler**: Extended to handle `callback_query` updates. It now parses action data (e.g., `retry:123`), authenticates the user, and verifies they have permissions for the specific task before acknowledging the action.
4.  **Notification System**:
    *   Updated `NotificationService::notify` and `NotificationChannelInterface` to accept an optional `actions` array.
    *   Enhanced `TelegramChannelHandler` to translate these actions into `InlineKeyboardMarkup` buttons (e.g., "Retry", "Merge & Close").
    *   Updated `BrowserChannelHandler` to maintain interface compatibility.
5.  **Roadmap**: Updated `CHAT_ROADMAP.md` to reflect completed steps and current progress.

These changes provide the foundational infrastructure for remote task management directly from Telegram. Actual execution of 'retry', 'restart', and 'merge' actions will follow in subsequent roadmap phases.

Fixes #441

---
*PR created automatically by Jules for task [6198607287701435014](https://jules.google.com/task/6198607287701435014) started by @chatelao*