### PR TITLE
Fix "in_progress" notification broadcast bug

### DIFF
--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -298,8 +298,9 @@ class NotificationService
 
     private function isStatusBroadcastEnabled(int $projectId, string $status): bool
     {
+        $normalizedStatus = str_replace('-', '_', $status);
         $settings = $this->getStatusSettings($projectId);
-        return $settings[$status] ?? true;
+        return $settings[$normalizedStatus] ?? true;
     }
 
     private function persistNotification(int $userId, string $type, string $title, string $message, array $data): int

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -651,10 +651,8 @@ class Task
                     $mappedStatus = $task['status'];
                     $julesUrl = $julesData['url'] ?? null;
 
-                    if (in_array($newStatus, ['coding', 'testing', 'researching', 'planning'])) {
+                    if (in_array($newStatus, ['coding', 'testing', 'researching', 'planning', 'in-progress'])) {
                         $mappedStatus = str_replace('-', '_', $newStatus);
-                    } elseif ($newStatus === 'in-progress') {
-                        $mappedStatus = 'in_progress';
                     } elseif ($newStatus === 'completed' || $newStatus === 'finished') {
                         $mappedStatus = !empty($prUrl) ? 'completed' : 'implemented';
                     } elseif ($newStatus === 'failed' || $newStatus === 'error') {

--- a/test/Integration/NotificationTriggerTest.php
+++ b/test/Integration/NotificationTriggerTest.php
@@ -269,6 +269,8 @@ class NotificationTriggerTest extends TestCase
         $projectId = 1;
         // Disable 'coding' status broadcast
         $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES ($projectId, 'coding', 0)");
+        // Disable 'in_progress' status broadcast
+        $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES ($projectId, 'in_progress', 0)");
 
         // Enable a mock channel AND in_app
         $this->pdo->exec("INSERT INTO user_notification_settings (user_id, channel, is_enabled) VALUES ($userId, 'mock_channel', 1)");
@@ -296,5 +298,28 @@ class NotificationTriggerTest extends TestCase
         // Notification SHOULD still be in the inbox
         $stmt = $this->pdo->query("SELECT COUNT(*) FROM notifications WHERE type = 'task_status'");
         $this->assertEquals(1, $stmt->fetchColumn());
+    }
+
+    public function testNotificationNormalizationForHyphenatedStatus()
+    {
+        $userId = 1;
+        $projectId = 1;
+
+        // Disable 'in_progress' status broadcast
+        $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES ($projectId, 'in_progress', 0)");
+
+        // Enable a mock channel
+        $this->pdo->exec("INSERT INTO user_notification_settings (user_id, channel, is_enabled) VALUES ($userId, 'mock_channel', 1)");
+        $mockChannel = $this->createMock(NotificationChannelInterface::class);
+        $this->notificationService->registerChannel('mock_channel', $mockChannel);
+
+        // EXPECTATION: Broadcast SHOULD NOT happen because 'in-progress' is normalized to 'in_progress'
+        $mockChannel->expects($this->never())->method('send');
+
+        // Trigger notification with status 'in-progress' (with hyphen)
+        $this->notificationService->notify($userId, 'task_status', 'Title', 'Message', [
+            'project_id' => $projectId,
+            'status' => 'in-progress'
+        ]);
     }
 }


### PR DESCRIPTION
The issue was caused by a mismatch between the status string used in the application logic ("in-progress") and the keys used in the notification settings ("in_progress").

Changes:
1.  **NotificationService.php**: Added normalization in `isStatusBroadcastEnabled` to convert hyphens to underscores before checking settings.
2.  **Task.php**: Consolidated and improved status mapping from Jules API to consistently use snake_case for all statuses.
3.  **NotificationTriggerTest.php**: Added a regression test to ensure hyphenated statuses are correctly normalized and respect broadcast settings.

Fixes #442

---
*PR created automatically by Jules for task [12878075846581081177](https://jules.google.com/task/12878075846581081177) started by @chatelao*