### PR TITLE
Integrate specialized roadmaps into documentation and UI

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,7 +7,7 @@ running on a php webserver using a MySQL database and Google SSO login for multi
 
 - `CONCEPT.md`: The overall structure of the product, including Business Cases & Use Cases as well as the overall High-Level Architecture, etc.
 - `DESIGN.md`: The detailed design of the solution, including the architecture, used tech stack for development, production and testing, etc.
-- `ROADMAP.md`: The list of accomplished and planned steps of the project, it should be group into Phases, Tasks and Subtasks if necessary. Checkboxes show the progress to be updated with every increment.
+- `ROADMAP.md`: The main roadmap for the project. Specialized roadmaps like `NOTIF_ROADMAP.md` and `CHAT_ROADMAP.md` provide detailed phases for specific features. They should be grouped into Phases, Tasks and Subtasks. Checkboxes show the progress to be updated with every increment.
 - `/specification/`: External Know-How as datasheet, standards, etc. Should be converted to Markdown if PDF, etc.
 - `/src/`: The source code of the projec
 - `/src/openapi.yaml`the REST-API definition used to generate the front- & backend glue-code

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ php -S localhost:8080 -t src/frontend
 - `src/sql/`: Database schema and migrations.
 - `test/`: PHPUnit tests and testing tools.
 - `specification/`: Additional documentation, mockups, and external know-how.
-- `CONCEPT.md`, `DESIGN.md`, `GEMINI.md`, `ROADMAP.md`: Project documentation.
+- `CONCEPT.md`, `DESIGN.md`, `GEMINI.md`, `ROADMAP.md`, `NOTIF_ROADMAP.md`, `CHAT_ROADMAP.md`: Project documentation.
 
 ## Documentation
 - [**User Wiki**](wiki/Home.md) - Comprehensive guide for users.
@@ -95,3 +95,5 @@ php -S localhost:8080 -t src/frontend
 - [Design](DESIGN.md)
 - [Gemini Project Goal](GEMINI.md)
 - [Roadmap](ROADMAP.md)
+- [Notification Roadmap](NOTIF_ROADMAP.md)
+- [Telegram Chat Roadmap](CHAT_ROADMAP.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,3 +39,7 @@
 - [ ] Identify coverage gaps in GitHub integration and webhook handling.
 - [ ] Identify coverage gaps in Jules agent orchestration and task management.
 - [ ] Identify coverage gaps in notification delivery (Telegram, In-App).
+
+## Specialized Roadmaps
+- [**Notification System Roadmap**](NOTIF_ROADMAP.md) - Detailed phases for the multi-channel notification system.
+- [**Telegram Chat Control Roadmap**](CHAT_ROADMAP.md) - Detailed phases for interactive Telegram bot management.

--- a/docs/chat_roadmap.rst
+++ b/docs/chat_roadmap.rst
@@ -1,0 +1,4 @@
+TELEGRAM CHAT ROADMAP
+=====================
+
+.. include:: ../CHAT_ROADMAP.md

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,8 @@ Welcome to AI Brain's documentation!
    concept
    design
    roadmap
+   notif_roadmap
+   chat_roadmap
    gemini
    howto
 

--- a/docs/notif_roadmap.rst
+++ b/docs/notif_roadmap.rst
@@ -1,0 +1,4 @@
+NOTIFICATION ROADMAP
+==================
+
+.. include:: ../NOTIF_ROADMAP.md

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -238,6 +238,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
         $githubService = new GitHubService(null, $githubToken);
         $taskModel->syncIssues($user['user_id'], $project['project_id'], $project['github_repo'], $githubService);
 
+        // Also refresh roadmap cache during sync
+        $roadmapFiles = $githubService->getRoadmapFiles($project['github_repo']);
+        $projectModel->updateRoadmapCache($projectId, $roadmapFiles);
+
         header("Location: project.php?id=$projectId&success=synced");
         exit;
     } catch (Exception $e) {

--- a/test/Unit/Services/GitHubServiceTest.php
+++ b/test/Unit/Services/GitHubServiceTest.php
@@ -26,7 +26,9 @@ class GitHubServiceTest extends TestCase
             ->willReturnMap([
                 ['chatelao', 'ai-brain', '', null, [
                     ['type' => 'file', 'name' => 'README.md', 'html_url' => 'http://example.com/readme'],
-                    ['type' => 'file', 'name' => 'ROADMAP.md', 'html_url' => 'http://example.com/roadmap']
+                    ['type' => 'file', 'name' => 'ROADMAP.md', 'html_url' => 'http://example.com/roadmap'],
+                    ['type' => 'file', 'name' => 'NOTIF_ROADMAP.md', 'html_url' => 'http://example.com/notif_roadmap'],
+                    ['type' => 'file', 'name' => 'CHAT_ROADMAP.md', 'html_url' => 'http://example.com/chat_roadmap']
                 ]],
                 ['chatelao', 'ai-brain', 'docs', null, [
                     ['type' => 'file', 'name' => 'roadmap.rst', 'html_url' => 'http://example.com/roadmap_rst'],
@@ -34,6 +36,12 @@ class GitHubServiceTest extends TestCase
                 ]],
                 ['chatelao', 'ai-brain', 'ROADMAP.md', null, [
                     'content' => base64_encode("- [x] Done task\n- [ ] Next task\n- [ ] Another task")
+                ]],
+                ['chatelao', 'ai-brain', 'NOTIF_ROADMAP.md', null, [
+                    'content' => base64_encode("- [ ] Notification task")
+                ]],
+                ['chatelao', 'ai-brain', 'CHAT_ROADMAP.md', null, [
+                    'content' => base64_encode("- [ ] Telegram task")
                 ]],
                 ['chatelao', 'ai-brain', 'docs/roadmap.rst', null, [
                     'content' => base64_encode("* [x] Already done\n* [ ] Still to do")
@@ -43,11 +51,15 @@ class GitHubServiceTest extends TestCase
         $service = new GitHubService($mockClient);
         $roadmaps = $service->getRoadmapFiles('chatelao/ai-brain');
 
-        $this->assertCount(2, $roadmaps);
+        $this->assertCount(4, $roadmaps);
         $this->assertEquals('ROADMAP.md', $roadmaps[0]['name']);
         $this->assertEquals('Next task', $roadmaps[0]['next_task']);
-        $this->assertEquals('docs/roadmap.rst', $roadmaps[1]['name']);
-        $this->assertEquals('Still to do', $roadmaps[1]['next_task']);
+        $this->assertEquals('NOTIF_ROADMAP.md', $roadmaps[1]['name']);
+        $this->assertEquals('Notification task', $roadmaps[1]['next_task']);
+        $this->assertEquals('CHAT_ROADMAP.md', $roadmaps[2]['name']);
+        $this->assertEquals('Telegram task', $roadmaps[2]['next_task']);
+        $this->assertEquals('docs/roadmap.rst', $roadmaps[3]['name']);
+        $this->assertEquals('Still to do', $roadmaps[3]['next_task']);
     }
 
     public function testGetIssueComments(): void


### PR DESCRIPTION
This change improves the visibility and management of specialized feature roadmaps (CHAT_ROADMAP.md and NOTIF_ROADMAP.md) by linking them from central documentation files (README.md, ROADMAP.md, GEMINI.md) and integrating them into the Sphinx documentation tree. 

Additionally, it enhances the application UI by ensuring that the roadmap metadata cache (which displays current progress on the project page) is refreshed whenever a user manually triggers an issue sync. This prevents the UI from showing stale roadmap information.

Unit tests for GitHubService have been updated to ensure that the system correctly identifies and processes multiple roadmap files within a repository.

Fixes #445

---
*PR created automatically by Jules for task [16200626026798303080](https://jules.google.com/task/16200626026798303080) started by @chatelao*