### PR TITLE
Implement Telegram Chat Control Actions

### DIFF
--- a/CHAT_ROADMAP.md
+++ b/CHAT_ROADMAP.md
@@ -6,14 +6,14 @@
 |-------|-------------|--------|
 | 1 | Callback Infrastructure | ✅ |
 | 2 | Action-Enabled Notifications | ✅ |
-| 3 | [UC-C1] Remote Task Recovery | 🚧 |
-| 4 | [UC-C2] One-Tap PR Merging | 🚧 |
+| 3 | [UC-C1] Remote Task Recovery | ✅ |
+| 4 | [UC-C2] One-Tap PR Merging | ✅ |
 | 5 | UX & Feedback Loop | 🚧 |
 
 ## Goals
 
 - Transform Telegram bot into an interactive management interface. ✅
-- Support common task operations (Retry, Restart, Merge) directly from chat. 🚧
+- Support common task operations (Retry, Restart, Merge) directly from chat. ✅
 - Provide immediate feedback for remote actions. ✅
 - Maintain secure, authorized access to project resources. ✅
 
@@ -31,19 +31,19 @@
 - [ ] Test button rendering in Telegram for different notification types.
 
 ## Phase 3: [UC-C1] Remote Task Recovery
-- [ ] Implement `retry` action handler in `TelegramWebhookHandler`.
-- [ ] Integrate with `JulesService` to trigger agent retries.
-- [ ] Implement `restart` action handler for fresh Jules sessions.
+- [x] Implement `retry` action handler in `TelegramWebhookHandler`.
+- [x] Integrate with `GitHubService::postComment()` to trigger agent retries via "retry" signal.
+- [x] Implement `restart` action handler for fresh Jules sessions via label toggling.
 - [ ] Verify task recovery flow from a "Failed" notification.
 
 ## Phase 4: [UC-C2] One-Tap PR Merging
-- [ ] Implement `merge` action handler in `TelegramWebhookHandler`.
-- [ ] Integrate with `GitHubService::mergePullRequest()`.
-- [ ] Ensure associated issues are closed after successful merge.
+- [x] Implement `merge` action handler in `TelegramWebhookHandler`.
+- [x] Integrate with `GitHubService::mergePullRequest()`.
+- [x] Ensure associated issues are closed after successful merge.
 - [ ] Verify PR merging flow from a "CI Success" notification.
 
 ## Phase 5: UX & Feedback Loop
-- [ ] Implement `editMessageText` in `TelegramService` to update message state after action.
-- [ ] Show "Loading..." or success/failure toasts using `answerCallbackQuery`.
-- [ ] Update original notification text to reflect new status (e.g., "🔄 Retrying...").
+- [x] Implement `editMessageText` in `TelegramService` to update message state after action.
+- [x] Show "Loading..." or success/failure toasts using `answerCallbackQuery`.
+- [x] Update original notification text to reflect new status (e.g., "✅ PR merged...").
 - [ ] Final end-to-end testing of the interactive chat experience.

--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -22,6 +22,25 @@ class GitHubService
     /**
      * @throws Exception
      */
+    public function addLabel(string $repo, int $issueNumber, string $label): void
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+
+        $this->apiCall(
+            'GitHub API',
+            "POST label $repo/issues/$issueNumber",
+            fn() => $this->client->api('issue')->labels()->add($username, $repository, $issueNumber, $label)
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
     public function mergePullRequest(string $repo, int $prNumber, string $message = '', string $mergeMethod = 'merge'): array
     {
         $parts = explode('/', $repo);

--- a/src/backend/TelegramWebhookHandler.php
+++ b/src/backend/TelegramWebhookHandler.php
@@ -9,6 +9,7 @@ class TelegramWebhookHandler
     public function __construct(
         private User $userModel,
         private TelegramService $telegramService,
+        private GitHubService $githubService,
         private ?string $webhookSecret
     ) {
     }
@@ -105,9 +106,52 @@ class TelegramWebhookHandler
             'text' => "Processing " . ucfirst($action) . "..."
         ]);
 
-        // Note: Actual execution via GHS or JS will be implemented in Phase 3 & 4.
-        // For now, we just acknowledge that the infrastructure is ready.
-        $this->telegramService->sendMessage($chatId, "Infrastructure for <b>$action</b> is ready. Actual execution will be implemented soon.");
+        try {
+            $projectModel = new Project($this->userModel->getDb());
+            $project = $projectModel->findById($task['project_id']);
+            if (!$project || !$project['github_token']) {
+                throw new \Exception("Project or GitHub token not found.");
+            }
+
+            $ghs = $this->githubService;
+            $repo = $project['github_repo'];
+            $issueNumber = (int)$task['issue_number'];
+
+            $messageId = $callbackQuery['message']['message_id'] ?? null;
+            $originalText = $callbackQuery['message']['text'] ?? '';
+
+            if ($action === 'merge') {
+                $prNumber = $ghs->extractPrNumber($task['pr_url'] ?? '');
+                if (!$prNumber) {
+                    throw new \Exception("No pull request associated with this task.");
+                }
+
+                $ghs->mergePullRequest($repo, $prNumber, "Merged via Telegram: " . $task['title']);
+                $ghs->closeIssue($repo, $issueNumber);
+
+                $statusText = "✅ PR #$prNumber merged and Issue #$issueNumber closed.";
+            } elseif ($action === 'restart') {
+                $ghs->removeLabel($repo, $issueNumber, 'Jules');
+                $ghs->addLabel($repo, $issueNumber, 'Jules');
+
+                $statusText = "🔄 Jules session restarted for Issue #$issueNumber.";
+            } elseif ($action === 'retry') {
+                $ghs->postComment($repo, $issueNumber, "retry");
+
+                $statusText = "🚀 Retry signal sent to Issue #$issueNumber.";
+            } else {
+                $statusText = "Infrastructure for <b>$action</b> is ready. Actual execution will be implemented soon.";
+            }
+
+            if ($messageId) {
+                $this->telegramService->editMessageText($chatId, $messageId, $originalText . "\n\n" . $statusText);
+            } else {
+                $this->telegramService->sendMessage($chatId, $statusText);
+            }
+
+        } catch (\Exception $e) {
+            $this->telegramService->sendMessage($chatId, "❌ Error: " . $e->getMessage());
+        }
 
         return true;
     }

--- a/src/frontend/telegram-webhook.php
+++ b/src/frontend/telegram-webhook.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 use App\Database;
 use App\User;
 use App\TelegramService;
+use App\GitHubService;
 use App\TelegramWebhookHandler;
 use App\WebhookLogger;
 
@@ -28,9 +29,11 @@ if ($userId) {
 }
 
 $telegramService = new TelegramService(null, $botToken);
+$githubService = new GitHubService();
 $handler = new TelegramWebhookHandler(
     $userModel,
     $telegramService,
+    $githubService,
     $webhookSecret
 );
 

--- a/test/Integration/TelegramWebhookHandlerIntegrationTest.php
+++ b/test/Integration/TelegramWebhookHandlerIntegrationTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\TestDatabaseTrait;
+use PHPUnit\Framework\TestCase;
+use App\TelegramWebhookHandler;
+use App\User;
+use App\TelegramService;
+use App\GitHubService;
+use App\Database;
+use PDO;
+
+class TelegramWebhookHandlerIntegrationTest extends TestCase
+{
+    use TestDatabaseTrait;
+
+    private $userModel;
+    private $telegramService;
+    private $githubService;
+    private $handler;
+    private $db;
+    private $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+
+        $this->pdo->exec("DROP TABLE IF EXISTS user_telegram_accounts");
+        $this->pdo->exec("DROP TABLE IF EXISTS tasks");
+        $this->pdo->exec("DROP TABLE IF EXISTS projects");
+        $this->pdo->exec("DROP TABLE IF EXISTS user_github_accounts");
+        $this->pdo->exec("DROP TABLE IF EXISTS users");
+
+        $this->pdo->exec("CREATE TABLE users (user_id $pk, email VARCHAR(255), telegram_bot_token VARCHAR(255), jules_api_key VARCHAR(255), jules_quota_updated_at TIMESTAMP NULL)");
+        $this->pdo->exec("CREATE TABLE user_github_accounts (github_account_id $pk, user_id INT, github_username VARCHAR(255), github_token VARCHAR(255))");
+        $this->pdo->exec("CREATE TABLE projects (project_id $pk, user_id INT, github_account_id INT, github_repo VARCHAR(255))");
+        $this->pdo->exec("CREATE TABLE tasks (task_id $pk, user_id INT, project_id INT, issue_number INT, title VARCHAR(255), pr_url VARCHAR(255))");
+        $this->pdo->exec("CREATE TABLE user_telegram_accounts (telegram_account_id $pk, user_id INT, telegram_chat_id BIGINT UNIQUE)");
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        $this->userModel = new User($this->db);
+        $this->telegramService = $this->createMock(TelegramService::class);
+        $this->githubService = $this->createMock(GitHubService::class);
+
+        $this->handler = new TelegramWebhookHandler(
+            $this->userModel,
+            $this->telegramService,
+            $this->githubService,
+            'secret'
+        );
+    }
+
+    public function testHandleMergeAction()
+    {
+        $this->pdo->exec("INSERT INTO users (user_id, email) VALUES (1, 'user@example.com')");
+        $this->pdo->exec("INSERT INTO user_telegram_accounts (user_id, telegram_chat_id) VALUES (1, 123)");
+        $this->pdo->exec("INSERT INTO user_github_accounts (user_id, github_username, github_token) VALUES (1, 'ghuser', 'ghtoken')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_account_id, github_repo) VALUES (1, 1, 1, 'owner/repo')");
+        $this->pdo->exec("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, pr_url) VALUES (10, 1, 1, 100, 'Test Task', 'https://github.com/owner/repo/pull/50')");
+
+        $update = [
+            'callback_query' => [
+                'id' => 'cb123',
+                'data' => 'merge:10',
+                'message' => [
+                    'chat' => ['id' => 123],
+                    'message_id' => 456,
+                    'text' => 'Original Message'
+                ]
+            ]
+        ];
+
+        $this->githubService->expects($this->once())
+            ->method('extractPrNumber')
+            ->with('https://github.com/owner/repo/pull/50')
+            ->willReturn(50);
+
+        $this->githubService->expects($this->once())
+            ->method('mergePullRequest')
+            ->with('owner/repo', 50, $this->stringContains('Merged via Telegram'));
+
+        $this->githubService->expects($this->once())
+            ->method('closeIssue')
+            ->with('owner/repo', 100);
+
+        $this->telegramService->expects($this->once())
+            ->method('answerCallbackQuery');
+
+        $this->telegramService->expects($this->once())
+            ->method('editMessageText')
+            ->with(123, 456, $this->stringContains('✅ PR #50 merged'));
+
+        $this->assertTrue($this->handler->handle($update));
+    }
+
+    public function testHandleRestartAction()
+    {
+        $this->pdo->exec("INSERT INTO users (user_id, email) VALUES (1, 'user@example.com')");
+        $this->pdo->exec("INSERT INTO user_telegram_accounts (user_id, telegram_chat_id) VALUES (1, 123)");
+        $this->pdo->exec("INSERT INTO user_github_accounts (user_id, github_username, github_token) VALUES (1, 'ghuser', 'ghtoken')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_account_id, github_repo) VALUES (1, 1, 1, 'owner/repo')");
+        $this->pdo->exec("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title) VALUES (11, 1, 1, 101, 'Test Task')");
+
+        $update = [
+            'callback_query' => [
+                'id' => 'cb124',
+                'data' => 'restart:11',
+                'message' => [
+                    'chat' => ['id' => 123],
+                    'message_id' => 457,
+                    'text' => 'Original Message'
+                ]
+            ]
+        ];
+
+        $this->githubService->expects($this->once())
+            ->method('removeLabel')
+            ->with('owner/repo', 101, 'Jules');
+
+        $this->githubService->expects($this->once())
+            ->method('addLabel')
+            ->with('owner/repo', 101, 'Jules');
+
+        $this->telegramService->expects($this->once())
+            ->method('editMessageText')
+            ->with(123, 457, $this->stringContains('🔄 Jules session restarted'));
+
+        $this->assertTrue($this->handler->handle($update));
+    }
+
+    public function testHandleRetryAction()
+    {
+        $this->pdo->exec("INSERT INTO users (user_id, email) VALUES (1, 'user@example.com')");
+        $this->pdo->exec("INSERT INTO user_telegram_accounts (user_id, telegram_chat_id) VALUES (1, 123)");
+        $this->pdo->exec("INSERT INTO user_github_accounts (user_id, github_username, github_token) VALUES (1, 'ghuser', 'ghtoken')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_account_id, github_repo) VALUES (1, 1, 1, 'owner/repo')");
+        $this->pdo->exec("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title) VALUES (12, 1, 1, 102, 'Test Task')");
+
+        $update = [
+            'callback_query' => [
+                'id' => 'cb125',
+                'data' => 'retry:12',
+                'message' => [
+                    'chat' => ['id' => 123],
+                    'message_id' => 458,
+                    'text' => 'Original Message'
+                ]
+            ]
+        ];
+
+        $this->githubService->expects($this->once())
+            ->method('postComment')
+            ->with('owner/repo', 102, 'retry');
+
+        $this->telegramService->expects($this->once())
+            ->method('editMessageText')
+            ->with(123, 458, $this->stringContains('🚀 Retry signal sent'));
+
+        $this->assertTrue($this->handler->handle($update));
+    }
+}

--- a/test/Unit/Services/TelegramCallbackTest.php
+++ b/test/Unit/Services/TelegramCallbackTest.php
@@ -21,10 +21,11 @@ class TelegramCallbackTest extends TestCase
         $this->userModel = $this->createMock(User::class);
         $this->telegramService = $this->createMock(TelegramService::class);
         $this->db = $this->createMock(Database::class);
+        $githubService = $this->createMock(\App\GitHubService::class);
 
         $this->userModel->method('getDb')->willReturn($this->db);
 
-        $this->handler = new TelegramWebhookHandler($this->userModel, $this->telegramService, 'secret');
+        $this->handler = new TelegramWebhookHandler($this->userModel, $this->telegramService, $githubService, 'secret');
     }
 
     public function testHandleCallbackUnauthorized()

--- a/test/Unit/Services/TelegramWebhookHandlerTest.php
+++ b/test/Unit/Services/TelegramWebhookHandlerTest.php
@@ -18,7 +18,8 @@ class TelegramWebhookHandlerTest extends TestCase
     {
         $this->userModel = $this->createMock(User::class);
         $this->telegramService = $this->createMock(TelegramService::class);
-        $this->handler = new TelegramWebhookHandler($this->userModel, $this->telegramService, $this->secret);
+        $githubService = $this->createMock(\App\GitHubService::class);
+        $this->handler = new TelegramWebhookHandler($this->userModel, $this->telegramService, $githubService, $this->secret);
     }
 
     public function testVerifySecretSuccess()


### PR DESCRIPTION
Implemented the core logic for remote task management via the Telegram bot. 

Key changes:
1.  **GitHubService Enhancement**: Added `addLabel` to support the 'restart' action (which involves toggling the 'Jules' label).
2.  **TelegramWebhookHandler Implementation**:
    *   **Merge & Close**: Pulls the PR number from the task, merges it, and closes the associated issue.
    *   **Restart**: Removes and re-adds the 'Jules' label to trigger a new session.
    *   **Retry**: Posts a "retry" comment to the GitHub issue to signal the agent.
    *   **Feedback**: Uses `editMessageText` to append the result of the action to the original notification message in Telegram.
3.  **Dependency Injection**: Updated the handler to accept `GitHubService` and updated the webhook entry point to provide it.
4.  **Testing**: Verified the logic with new integration tests and ensured no regressions in existing tests.
5.  **Roadmap**: Updated `CHAT_ROADMAP.md` marking Phases 3 and 4 as largely complete.

Fixes #446

---
*PR created automatically by Jules for task [15524756148033771094](https://jules.google.com/task/15524756148033771094) started by @chatelao*