### PR TITLE
Reformat task lists to "<id> - <issue title>"

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -181,9 +181,8 @@ $errorMessage = $errorMessage ?? null;
                                                     </a>
                                                 </td>
                                                 <td class="px-6 py-4 font-normal">
-                                                    <a href="https://github.com/<?= htmlspecialchars($task['github_repo'] ?? '') ?>/issues/<?= htmlspecialchars($task['issue_number'] ?? '') ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">#<?= htmlspecialchars($task['issue_number'] ?? '') ?></a>
-                                                    <a href="<?= htmlspecialchars($taskModel->getTargetUrl($task)) ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline markdown-body inline">
-                                                        <?= $parsedown->text($taskModel->processGitHubImages($task['title'] ?? '')) ?>
+                                                    <a href="<?= htmlspecialchars($taskModel->getTargetUrl($task)) ?>" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
+                                                        <?= htmlspecialchars($task['issue_number'] ?? '') ?> - <?= htmlspecialchars($task['title'] ?? '') ?>
                                                     </a>
                                                 </td>
                                                 <td class="px-6 py-4">

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -438,9 +438,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                             <tr class="bg-white border-b">
                                                 <td class="px-6 py-4">
                                                     <div class="text-base text-gray-900 font-normal markdown-body">
-                                                        <a href="task.php?id=<?= $task['task_id'] ?>" class="hover:underline">#<?= htmlspecialchars($task['issue_number'] ?? '') ?></a>
-                                                        <a href="<?= htmlspecialchars($taskModel->getTargetUrl($task, $project['github_repo'])) ?>" target="_blank" rel="noopener noreferrer" class="hover:underline inline">
-                                                            <?= $parsedown->text($taskModel->processGitHubImages($task['title'] ?? '')) ?>
+                                                        <a href="task.php?id=<?= $task['task_id'] ?>" class="hover:underline">
+                                                            <?= htmlspecialchars($task['issue_number'] ?? '') ?> - <?= htmlspecialchars($task['title'] ?? '') ?>
                                                         </a>
                                                     </div>
                                                     <div class="text-xs text-gray-500 markdown-body">

--- a/src/frontend/tasks.php
+++ b/src/frontend/tasks.php
@@ -119,9 +119,8 @@ $title = $filterLabels[$filter] ?? 'Tasks';
                                             </td>
                                             <td class="px-6 py-4">
                                                 <div class="text-base text-gray-900 font-normal">
-                                                    <a href="task.php?id=<?= $task['task_id'] ?>" class="hover:underline">#<?= htmlspecialchars($task['issue_number'] ?? '') ?></a>
-                                                    <a href="<?= htmlspecialchars($taskModel->getTargetUrl($task)) ?>" target="_blank" rel="noopener noreferrer" class="hover:underline">
-                                                        <?= htmlspecialchars($task['title'] ?? '') ?>
+                                                    <a href="task.php?id=<?= $task['task_id'] ?>" class="hover:underline">
+                                                        <?= htmlspecialchars($task['issue_number'] ?? '') ?> - <?= htmlspecialchars($task['title'] ?? '') ?>
                                                     </a>
                                                 </div>
                                             </td>

--- a/test/Integration/verify_index_ui.php
+++ b/test/Integration/verify_index_ui.php
@@ -1,0 +1,105 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use App\Database;
+use App\Auth;
+use App\User;
+use App\Project;
+use App\Task;
+
+// Set environment for testing
+putenv('DB_NAME=:memory:');
+
+// Initialize session if not started
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$db = new Database();
+$pdo = $db->getConnection();
+
+// Create schema
+$pdo->exec("CREATE TABLE IF NOT EXISTS users (
+    user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    google_id VARCHAR(255) UNIQUE NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    avatar VARCHAR(255),
+    role VARCHAR(20) DEFAULT 'user',
+    jules_api_key VARCHAR(255),
+    telegram_link_token VARCHAR(255),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_github_accounts (
+    github_account_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    github_username VARCHAR(255) NOT NULL,
+    github_token VARCHAR(255) NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS projects (
+    project_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    github_account_id INT NOT NULL,
+    github_repo VARCHAR(255) NOT NULL,
+    github_username VARCHAR(255),
+    webhook_secret VARCHAR(255),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
+    task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    project_id INT NOT NULL,
+    issue_number INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    body TEXT,
+    status TEXT DEFAULT 'pending',
+    github_state VARCHAR(20) DEFAULT 'open',
+    github_data TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_telegram_accounts (
+    telegram_account_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    telegram_chat_id BIGINT UNIQUE NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS notifications (
+    notification_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INT NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    message TEXT NOT NULL,
+    data TEXT,
+    is_read BOOLEAN DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)");
+
+$pdo->exec("CREATE TABLE IF NOT EXISTS user_notification_settings (
+    user_id INT NOT NULL,
+    channel VARCHAR(20) NOT NULL,
+    is_enabled BOOLEAN DEFAULT 1,
+    PRIMARY KEY (user_id, channel)
+)");
+
+// Create a mock user
+$pdo->exec("INSERT OR IGNORE INTO users (user_id, google_id, name, email) VALUES (1, 'google-123', 'Test User', 'test@example.com')");
+$_SESSION['user_id'] = 1;
+
+// Create mock project
+$pdo->exec("INSERT INTO projects (project_id, user_id, github_account_id, github_repo, github_username) VALUES (1, 1, 1, 'owner/repo', 'owner')");
+
+// Create mock task with autorepeat label
+$github_data = json_encode([
+    'state' => 'open',
+    'labels' => [['name' => 'autorepeat']]
+]);
+$pdo->exec("INSERT INTO tasks (user_id, project_id, issue_number, title, status, github_state, github_data) VALUES (1, 1, 123, 'Autorepeat Task Title', 'pending', 'open', '$github_data')");
+
+// Include index.php
+include __DIR__ . '/../../src/frontend/index.php';


### PR DESCRIPTION
This change reformats how tasks are displayed in various lists across the web interface. 

Previously, the issue number (prefixed with '#') and the task title were often separate links with different destinations. Now, they are combined into a single link with the format `<id> - <issue title>`. 

Affected files:
- `src/frontend/index.php`: Updated the "Running Autorepeat Tasks" table.
- `src/frontend/tasks.php`: Updated the "Issue" column in the filtered task table.
- `src/frontend/project.php`: Updated the "Issue" column in the project-specific task table.

The title rendering in these lists was changed from Markdown to plain text to ensure the output is clean and consistent with the requested format, especially when wrapped in a link tag.

Fixes #449

---
*PR created automatically by Jules for task [12478070145780319990](https://jules.google.com/task/12478070145780319990) started by @chatelao*