### PR TITLE
Fix GitHub Webhook logging and missing User import

### DIFF
--- a/src/frontend/webhook.php
+++ b/src/frontend/webhook.php
@@ -10,6 +10,7 @@ use App\JulesService;
 use App\RateLimiter;
 use App\WebhookLogger;
 use App\NotificationService;
+use App\User;
 
 $db = new Database();
 $rateLimiter = new RateLimiter($db);
@@ -83,6 +84,9 @@ if (!$verified) {
 }
 
 if ($event === 'ping') {
+    if (!empty($projects)) {
+        $logger->log($projects[0]['user_id'], 'github', $payload, $headersStr, 200, 'PONG');
+    }
     http_response_code(200);
     exit('PONG');
 }


### PR DESCRIPTION
This PR fixes an issue where GitHub webhook events were not appearing in the logs even though the webhook status showed "connected".

The root causes were:
1. The 'ping' event sent by GitHub during connection setup was not being logged by the application.
2. A missing 'use App\User;' statement in `src/frontend/webhook.php` caused a fatal error when trying to instantiate the User model during event processing, which prevented the event from being handled and logged correctly.

I've added the missing import and enabled logging for the 'ping' event. I also audited other frontend scripts to ensure no other missing namespace imports were present. All tests passed.

Fixes #453

---
*PR created automatically by Jules for task [800649771046755692](https://jules.google.com/task/800649771046755692) started by @chatelao*