### PR TITLE
Add Cron Job Concept Documentation

### DIFF
--- a/CRONJOB_CONCEPT.md
+++ b/CRONJOB_CONCEPT.md
@@ -1,0 +1,31 @@
+# Concept: Cron Job System
+
+## Overview
+The Cron Job system provides a periodic trigger mechanism to perform background synchronization and maintenance tasks. It ensures that the application's state remains consistent with external services like GitHub and Google Jules, even if real-time webhooks are delayed or missed.
+
+## Business Cases
+- **Data Integrity**: Ensures the local database eventually reflects the source of truth (GitHub) through regular synchronization.
+- **Automated Monitoring**: Maintains up-to-date agent status in the dashboard without requiring manual user refreshes.
+- **System Reliability**: Acts as a "self-healing" mechanism that recovers from missed event-driven updates (e.g., failed webhooks).
+
+## Use Cases
+- **<a name="UC-CJ1"></a>Scheduled Issue Sync (UC-CJ1)**: The system periodically scans all linked GitHub repositories for new issues, updates to existing issues, or state changes (closed/reopened) to ensure the local task list is current.
+- **<a name="UC-CJ2"></a>Periodic Agent Status Refresh (UC-CJ2)**: For all active tasks, the system polls the Google Jules API to fetch the latest execution status and logs, updating the internal state accordingly.
+- **<a name="UC-CJ3"></a>Multi-User Background Processing (UC-CJ3)**: The cron job iterates through all registered users and their respective projects, performing maintenance tasks at scale without manual intervention.
+
+## High-Level Architecture
+- **Trigger**: An external scheduler (e.g., system `crontab` or a cloud-based cron service) makes an HTTP GET request to the cron entry point.
+- **Entry Point**: `src/frontend/cronjob.php` serves as the execution gateway.
+- **Logic Flow**:
+    1. **Authentication**: Validates the request against a pre-shared secret.
+    2. **User Discovery**: Fetches all users from the database.
+    3. **Project Iteration**: For each user, identifies all linked projects.
+    4. **Service Execution**:
+        - `GitHubService`: Syncs repository issues.
+        - `JulesService`: Refreshes agent session statuses.
+
+## Security Considerations
+To prevent unauthorized triggering of resource-intensive synchronization tasks, the cron system implements:
+- **Secret Key Validation**: The `CRON_SECRET` environment variable must be configured on the server.
+- **Request Authorization**: The entry point requires a matching `key` parameter in the URL (e.g., `cronjob.php?key=YOUR_SECRET`).
+- **Access Control**: If the secret is configured but missing or incorrect in the request, the system returns a `403 Forbidden` response.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,6 +6,7 @@ running on a php webserver using a MySQL database and Google SSO login for multi
 # Structure
 
 - `CONCEPT.md`: The overall structure of the product, including Business Cases & Use Cases as well as the overall High-Level Architecture, etc.
+- `CRONJOB_CONCEPT.md`: The concept of the periodic trigger system for background synchronization and maintenance.
 - `DESIGN.md`: The detailed design of the solution, including the architecture, used tech stack for development, production and testing, etc.
 - `ROADMAP.md`: The main roadmap for the project. Specialized roadmaps like `NOTIF_ROADMAP.md` and `CHAT_ROADMAP.md` provide detailed phases for specific features. They should be grouped into Phases, Tasks and Subtasks. Checkboxes show the progress to be updated with every increment.
 - `/specification/`: External Know-How as datasheet, standards, etc. Should be converted to Markdown if PDF, etc.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ php -S localhost:8080 -t src/frontend
 ## Documentation
 - [**User Wiki**](wiki/Home.md) - Comprehensive guide for users.
 - [Concept](CONCEPT.md)
+- [Cron Job Concept](CRONJOB_CONCEPT.md)
 - [Design](DESIGN.md)
 - [Gemini Project Goal](GEMINI.md)
 - [Roadmap](ROADMAP.md)


### PR DESCRIPTION
The periodic trigger system implemented in `src/frontend/cronjob.php` was missing conceptual documentation. This PR adds `CRONJOB_CONCEPT.md` which follows the project's standard documentation structure (Business Cases, Use Cases, Architecture, etc.) by reverse-engineering the existing code. It also ensures the new document is linked in the central documentation indices (`GEMINI.md` and `README.md`).

Fixes #458

---
*PR created automatically by Jules for task [15781582001333262706](https://jules.google.com/task/15781582001333262706) started by @chatelao*