### PR TITLE
Add Chat Cleanup concept to Telegram Chat Control documentation

### DIFF
--- a/CHAT_CONCEPT.md
+++ b/CHAT_CONCEPT.md
@@ -7,11 +7,13 @@ The Telegram Chat Control feature extends the application's mobile capabilities 
 - **Increased Responsiveness**: Users can react to critical task events (like session failures or ready PRs) immediately from their mobile devices without needing to access the full web dashboard.
 - **Operational Efficiency**: Reduces the friction of common task operations (Retrying, Restarting, Merging) by providing one-tap actions.
 - **Improved Focus**: Developers can handle routine task lifecycle management during short breaks or while on the move, keeping projects moving without full context switches.
+- **Noise Reduction**: Keeps the Telegram chat environment clean by removing stale or addressed notifications, ensuring only actionable or relevant information remains visible.
 
 ## Use Cases
 - **<a name="UC-C1"></a>Remote Task Recovery (UC-C1)**: A user receives a "Jules Session Failed" notification on Telegram. Instead of opening a laptop, they tap a "Retry" or "Restart" button directly in the chat to recover the task.
 - **<a name="UC-C2"></a>One-Tap PR Merging (UC-C2)**: When a task is completed and all CI checks pass, the user is notified on Telegram and can merge the PR and close the issue with a single tap on a "Merge & Close" button.
 - **<a name="UC-C3"></a>Quick Task Acknowledgment (UC-C3)**: Users can acknowledge new tasks or state changes, clearing them from their active mental queue or providing feedback to the system that the event has been seen.
+- **<a name="UC-C4"></a>Chat Cleanup (UC-C4)**: To maintain a clear workspace, users can trigger a "Cleanup" command or the system can automatically delete messages from Telegram once the corresponding notification is marked as read in the application.
 
 ## High-Level Architecture
 - **Telegram Bot API (Callback Queries)**: Utilizes Telegram's inline keyboards and callback queries to receive user interactions.
@@ -29,3 +31,4 @@ The system prioritizes "selection over writing". Whenever an actionable event oc
 1. **Dynamic Button Generation**: The `NotificationService` must be able to attach action metadata to notifications, which the `TelegramChannelHandler` translates into inline buttons.
 2. **State Management**: The application must securely map callback data (e.g., `retry_task_123`) to specific actions and entities.
 3. **Feedback Loop**: After an action is triggered via Telegram, the bot should provide immediate feedback (e.g., an alert or a message update) confirming the action has started or succeeded.
+4. **Message Deletion**: The system must track the Telegram `message_id` for each notification sent and implement logic to call the `deleteMessage` API method when a notification is marked as read.


### PR DESCRIPTION
This change adds the concept of deleting read notifications from the Telegram chat to `CHAT_CONCEPT.md`. 

Key additions include:
- A new business case for "Noise Reduction" to maintain a clean chat environment.
- A new use case "Chat Cleanup (UC-C4)" describing how notifications can be removed once marked as read.
- A technical requirement for tracking the Telegram `message_id` and implementing the `deleteMessage` API call.

Fixes #461

---
*PR created automatically by Jules for task [7090542263248560366](https://jules.google.com/task/7090542263248560366) started by @chatelao*