### PR TITLE
Fix "nil is not a string" error on PR merge

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -50,10 +50,13 @@ class GitHubService
 
         [$username, $repository] = $parts;
 
+        $pr = $this->getPullRequest($repo, $prNumber);
+        $sha = $pr['head']['sha'] ?? null;
+
         return $this->apiCall(
             'GitHub API',
             "PUT merge $repo/pull/$prNumber",
-            fn() => $this->client->api('pull_request')->merge($username, $repository, $prNumber, $message, null, $mergeMethod)
+            fn() => $this->client->api('pull_request')->merge($username, $repository, $prNumber, $message, $sha, $mergeMethod)
         );
     }
 

--- a/test/Unit/Services/GitHubServiceTest.php
+++ b/test/Unit/Services/GitHubServiceTest.php
@@ -108,4 +108,39 @@ class GitHubServiceTest extends TestCase
 
         $this->assertEquals(123, $result['number']);
     }
+
+    public function testMergePullRequestFetchesShaFirst(): void
+    {
+        $mockClient = $this->createMock(Client::class);
+        $mockPR = $this->createMock(\Github\Api\PullRequest::class);
+
+        $mockClient->method('api')->withAnyParameters()->willReturnCallback(function($api) use ($mockPR) {
+            if ($api === 'pull_request') {
+                return $mockPR;
+            }
+            return null;
+        });
+
+        $prNumber = 456;
+        $repo = 'chatelao/ai-brain';
+        $headSha = 'abcdef1234567890';
+        $message = 'Test Merge Message';
+
+        // Expect show() to be called to get the SHA
+        $mockPR->expects($this->once())
+            ->method('show')
+            ->with('chatelao', 'ai-brain', $prNumber)
+            ->willReturn(['head' => ['sha' => $headSha]]);
+
+        // Expect merge() to be called with the retrieved SHA
+        $mockPR->expects($this->once())
+            ->method('merge')
+            ->with('chatelao', 'ai-brain', $prNumber, $message, $headSha, 'merge')
+            ->willReturn(['merged' => true]);
+
+        $service = new GitHubService($mockClient);
+        $result = $service->mergePullRequest($repo, $prNumber, $message);
+
+        $this->assertTrue($result['merged']);
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where merging a pull request via the application (e.g., from Telegram or the Task UI) failed with a "nil is not a string" error from the GitHub API.

The issue was caused by the PHP GitHub library sending an explicit `null` for the `sha` parameter in the merge request, which the GitHub API rejected. The fix involves fetching the current head SHA of the pull request before calling the merge endpoint.

A reproduction unit test has been added to ensure that `mergePullRequest` now correctly fetches and passes the SHA.

Fixes #469

---
*PR created automatically by Jules for task [7141507503331721708](https://jules.google.com/task/7141507503331721708) started by @chatelao*