### PR TITLE
Unified Task State Mapping Update

### DIFF
--- a/STATE_EVENTS_CONCEPT.md
+++ b/STATE_EVENTS_CONCEPT.md
@@ -2,130 +2,130 @@
 
 This document describes the reactive behaviors of the Agent Control application, detailing how it responds to external events and how it behaves based on its internal state.
 
-## 1. State-Event Diagram
+## 1. Unified Task State Mapping
 
-The following diagram illustrates the transitions between different states for GitHub Issues, Jules Sessions, and internal Task Statuses.
+The application defines a set of unified task states to provide a consistent view of progress across different external tools (GitHub, Jules). These states represent the "Source of Truth" for the task's lifecycle.
+
+| Unified State | Description | Mapping Logic (Source States) |
+| :--- | :--- | :--- |
+| **`QUEUED`** | Task is waiting to be processed by the agent. | `GH.Issue:open` AND `Jules.Session:none` |
+| **`ANALYZING`** | The agent is currently researching or analyzing the task. | `Jules.Session:researching` |
+| **`PLANNING`** | A plan is being created or is awaiting human approval. | `Jules.Session:planning` OR `Jules.Session:awaiting_plan_approval` |
+| **`EXECUTING`** | The agent is actively implementing the solution (coding). | `Jules.Session:in-progress` OR `Jules.Session:coding` |
+| **`VERIFYING`** | The solution is being tested or is awaiting PR check results. | `Jules.Session:testing` OR (`Jules.Session:finished` AND `GH.PR:open`) |
+| **`FINISHED`** | The task has been successfully completed and/or merged. | `GH.Issue:closed` |
+| **`FAILED`** | An error occurred during agent execution or PR verification. | `Jules.Session:failed` OR `Jules.Session:error` OR `GH.PR:checks_failed` |
+
+### 1.1 Source State Key
+- **`GH.Issue:*`**: State of the GitHub Issue (open/closed).
+- **`GH.PR:*`**: State of the associated GitHub Pull Request and its check suites.
+- **`Jules.Session:*`**: Status returned by the Google Jules API for the session.
+
+## 2. State-Event Diagram
+
+The following diagram illustrates the transitions between the unified task states and their relationship with external tool states.
 
 ![Task State-Event Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/ai-brain/main/specification/TASK_STATE_EVENTS.puml)
 
-## 2. On-Event Behaviors
+## 3. On-Event Behaviors
 
 These behaviors are triggered by specific events originating from GitHub (webhooks), user interactions, or periodic polling.
 
-### 2.1 GitHub Webhooks
+### 3.1 GitHub Webhooks
 
 | Event | Action |
 | :--- | :--- |
-| **Issue Labeled (`Jules`)** | Triggers `App\Task::triggerAgent()`. Internal status moves to `analyzed`. |
-| **Issue Closed** | Updates `github_state` to `closed`. May trigger "Auto-Repeat" if applicable. |
-| **Issue Reopened** | Updates `github_state` to `open`. |
+| **Issue Labeled (`Jules`)** | Triggers `App\Task::triggerAgent()`. Task moves to `ANALYZING` (via Jules). |
+| **Issue Closed** | Updates `github_state` to `closed`. Task moves to `FINISHED`. May trigger "Auto-Repeat". |
+| **Issue Reopened** | Updates `github_state` to `open`. Task moves back to `QUEUED` or active state. |
 | **Issue Deleted** | Triggers a notification and removes the task from the local database. |
-| **Pull Request Created** | Links the PR to the task. Internal status may move to `completed` if work was `implemented`. |
+| **Pull Request Created** | Links the PR to the task. Task moves to `VERIFYING`. |
 | **Pull Request Merged** | Triggers "Auto-Repeat" logic if the issue has the `Auto-Repeat` label. |
-| **Check Suite Completed** | If `success`, moves `failed_pr` status back to `completed`. If `failure/timeout`, moves status to `failed_pr`. |
+| **Check Suite Completed** | If `success`, task stays in `VERIFYING`. If `failure/timeout`, task moves to `FAILED`. |
 
-### 2.2 User Interactions (UI)
+### 3.2 User Interactions (UI)
 
 | Action | Effect |
 | :--- | :--- |
 | **Manual Sync (Refresh Icon)** | Forces a synchronization of GitHub issues and Jules statuses for the project. |
 | **Trigger Agent (Button)** | Manually starts a Jules session for a task. |
-| **Merge & Close (Button)** | Merges the associated PR and closes the GitHub issue via API. |
+| **Merge & Close (Button)** | Merges the associated PR and closes the GitHub issue via API (moves task to `FINISHED`). |
 | **Retry (Button)** | Sends a "retry" command to a failed Jules session. |
 | **Restart (Button)** | Aborts the current Jules session and restarts it by toggling the `Jules` label. |
 
-### 2.3 Jules Status Polling
+### 3.3 Jules Status Polling
 
-Periodic calls to `App\Task::refreshJulesStatus` update the internal task status based on the remote Jules session state:
+Periodic calls to `App\Task::refreshJulesStatus` update the unified task state based on the remote Jules session state:
 
-- `STATE_RESEARCHING` -> `researching`
-- `STATE_PLANNING` -> `planning`
-- `STATE_IN_PROGRESS` -> `in_progress`
-- `STATE_CODING` -> `coding`
-- `STATE_TESTING` -> `testing`
-- `STATE_FINISHED` / `STATE_COMPLETED` -> `completed` (if PR exists) or `implemented` (if no PR yet)
-- `STATE_FAILED` / `STATE_ERROR` -> `failed_jules`
+- `STATE_RESEARCHING` -> `ANALYZING`
+- `STATE_PLANNING` -> `PLANNING`
+- `STATE_IN_PROGRESS` -> `EXECUTING`
+- `STATE_CODING` -> `EXECUTING`
+- `STATE_TESTING` -> `VERIFYING`
+- `STATE_FINISHED` / `STATE_COMPLETED` -> `VERIFYING` (if PR exists) or `FINISHED` (if issue closed)
+- `STATE_FAILED` / `STATE_ERROR` -> `FAILED`
 
-## 3. Automation & Operations
+## 4. Automation & Operations
 
 This section details the logic for automated and manual operations within the application.
 
-### 3.1 Pull Request Operations
+### 4.1 Pull Request Operations
 
 #### Merge & Close
 When a task has an associated Pull Request (PR), it may be eligible for a "Merge & Close" operation directly from the project issue list.
 
 **Conditions for presenting the "Merge & Close" option:**
-- The issue has an associated Pull Request.
+- Task is in `VERIFYING` state.
 - The Pull Request is reported as **mergeable** by GitHub.
-- The Pull Request is reported to be **ready** (not a draft).
 - All status checks (more than 1) are in a **passed** or **skipped** state.
 
 **Action:**
 - Merges the Pull Request via the GitHub API.
-- Closes the associated GitHub issue.
+- Closes the associated GitHub issue (moves Task to `FINISHED`).
 
-### 3.2 Failed Jules Session Operations
+### 4.2 Failed Jules Session Operations
 
-When a task has a status indicating a failed Jules session (`failed_jules`), the following options are presented:
+When a task is in the `FAILED` state, the following options are presented:
 
 #### Retry
 **Action:**
 - Sends a command to the existing Jules Session: "retry to finish the task".
-- Aims to resume the current session and attempt to complete the remaining work.
+- Aims to move the Task back to an active state (`ANALYZING`, `PLANNING`, `EXECUTING`).
 
 #### Restart
 **Action:**
 - Aborts or deletes the current Jules session.
-- Removes the "Jules" label from the associated GitHub issue.
-- Re-adds the "Jules" label to the GitHub issue to trigger a fresh agent session.
+- Removes and re-adds the "Jules" label to the GitHub issue to trigger a fresh agent session.
+- Task moves back to `QUEUED`.
 
-### 3.3 Issue Lifecycle Automation
+### 4.3 Issue Lifecycle Automation
 
 #### Auto-Repeat Duplication
 To support recurring tasks, the system implements an "Auto-Repeat" mechanism.
 
 **Trigger:**
-- A Pull Request associated with an issue carrying the **"Auto-Repeat"** label is closed (typically after a merge).
+- A task reaches `FINISHED` state AND carried the **"Auto-Repeat"** label.
 
 **Action:**
 - The system automatically duplicates the issue.
 - The new issue **includes** the "Jules" label to trigger the agent.
 - The new issue **excludes** the "Auto-Repeat" label.
-- The original issue's title and body are used for the new issue.
 
-## 4. On-State Behaviors
+## 5. On-State Behaviors
 
-The system exhibits different behaviors and UI representations depending on the current state of a task.
+The system exhibits different behaviors and UI representations depending on the unified state of a task.
 
-### 4.1 Task Status Visuals (Dashboard/Project List)
+### 5.1 Task State Visuals (Dashboard/Project List)
 
-- **`pending` / `analyzed`**: Displayed as "Waiting for Agent" or "Analyzing".
-- **`researching` / `planning` / `coding` / `testing`**: Displayed with a yellow/spinning indicator to show Jules is active.
-- **`implemented`**: Yellow indicator, showing work is done but PR checks are pending or PR is not yet merged.
-- **`completed`**: Green checkmark, indicating work is done and PR is in good standing (or closed).
-- **`failed_jules` / `failed_pr`**: Red error indicator, highlighting that human intervention is needed.
+- **`QUEUED`**: Grey indicator. Displayed as "Waiting for Agent".
+- **`ANALYZING`**: Blue indicator. Displayed as "Analyzing".
+- **`PLANNING`**: Blue indicator. Jules is creating/awaiting plan.
+- **`EXECUTING`**: Yellow indicator. Jules is actively coding.
+- **`VERIFYING`**: Orange indicator. PR is created, waiting for checks or merge.
+- **`FINISHED`**: Green checkmark (or Purple if closed). Task is complete.
+- **`FAILED`**: Red error indicator. Human intervention is needed.
 
-### 4.2 Feature Availability
+### 5.2 Feature Availability
 
-- **Merge & Close**: Only available if `status` is `completed`, a PR exists, it is mergeable, not a draft, and checks have passed.
-- **Retry / Restart**: Only available when status is `failed_jules`.
-
-## 5. Unified Task State Mapping
-
-To provide a tool-independent view of task progress, the following unified states are defined.
-
-| Unified State | Description | Mapping Logic (Tool-Dependent States) |
-| :--- | :--- | :--- |
-| **`QUEUED`** | Task is waiting to be processed by the agent. | `Task:pending` |
-| **`ANALYZING`** | The agent is currently researching or analyzing the task. | `Task:analyzed` OR `Task:researching` OR `Jules:researching` |
-| **`PLANNING`** | A plan is being created or is awaiting human approval. | `Task:planning` OR `Task:awaiting_plan_approval` OR `Jules:planning` |
-| **`EXECUTING`** | The agent is actively implementing the solution (coding). | `Task:in_progress` OR `Task:coding` OR `Jules:in-progress` OR `Jules:coding` |
-| **`VERIFYING`** | The solution is being tested or is awaiting PR check results. | `Task:testing` OR `Task:implemented` OR `Jules:testing` |
-| **`FINISHED`** | The task has been successfully completed and/or merged. | `Task:completed` OR `GitHub:closed` |
-| **`FAILED`** | An error occurred during agent execution or PR verification. | `Task:failed` OR `Task:failed_jules` OR `Task:failed_pr` OR `Jules:failed` OR `Jules:error` |
-
-### 5.1 Tool-Dependent State Key
-- **`Task:*`**: Internal status stored in the `tasks` table (`status` column).
-- **`Jules:*`**: Status returned by the Google Jules API.
-- **`GitHub:*`**: State of the issue or PR on GitHub (`github_state` column).
+- **Merge & Close**: Only available if state is `VERIFYING`, PR is mergeable and checks passed.
+- **Retry / Restart**: Only available when state is `FAILED`.

--- a/specification/TASK_STATE_EVENTS.puml
+++ b/specification/TASK_STATE_EVENTS.puml
@@ -1,13 +1,13 @@
 @startuml
 title Task State-Event Diagram
 
-state "GitHub Issue" as GitHubIssue {
+state "GitHub Issue (GH.Issue)" as GitHubIssue {
     [*] --> Open
     Open --> Closed : Issue closed (Webhook)
     Closed --> Open : Issue reopened (Webhook)
 }
 
-state "Jules Session" as JulesSession {
+state "Jules Session (Jules.Session)" as JulesSession {
     [*] --> Created : triggerAgent()
     Created --> researching : STATE_RESEARCHING
     researching --> planning : STATE_PLANNING
@@ -23,80 +23,50 @@ state "Jules Session" as JulesSession {
     testing --> failed
 }
 
-state "Task Status (Internal)" as TaskStatus {
-    [*] --> pending
-    pending --> analyzed : triggerAgent() (project.php)
-
-    analyzed --> researching : refreshJulesStatus (polling)
-    researching --> planning : refreshJulesStatus (polling)
-    planning --> awaiting_plan_approval : External/Manual update
-    awaiting_plan_approval --> planning : External/Manual update
-    planning --> in_progress : refreshJulesStatus (polling)
-    in_progress --> coding : refreshJulesStatus (polling)
-    coding --> testing : refreshJulesStatus (polling)
-
-    testing --> implemented : Jules finished & no PR URL
-    testing --> completed : Jules finished & PR URL exists
-    implemented --> completed : PR URL detected (sync)
-
-    researching --> failed_jules : Jules failed/error
-    planning --> failed_jules
-    in_progress --> failed_jules
-    coding --> failed_jules
-    testing --> failed_jules
-
-    completed --> failed_pr : check_suite failure (Webhook)
-    failed_pr --> completed : check_suite success (Webhook)
-}
-
-state "Pull Request" as PR {
+state "GitHub Pull Request (GH.PR)" as PR {
     [*] --> None
-    None --> Open : PR created (polling/Webhook)
-    Open --> Merged : PR merged (Webhook)
-    Open --> ClosedPR : PR closed (Webhook)
+    None --> OpenPR : PR created (polling/Webhook)
+    OpenPR --> Merged : PR merged (Webhook)
+    OpenPR --> ClosedPR : PR closed (Webhook)
+    OpenPR --> ChecksFailed : Checks failed (Webhook)
 }
 
-Open -[dashed]-> pending : Sync / Webhook
-TaskStatus -[dashed]-> GitHubIssue : Status influences UI badges
-JulesSession -[dashed]-> TaskStatus : Jules status maps to Task status
-PR -[dashed]-> TaskStatus : PR presence/checks affect status
-
-state "Unified Task State (Conceptual)" as Unified {
+state "Unified Task State" as Unified {
     [*] --> QUEUED
-    QUEUED --> ANALYZING
-    ANALYZING --> PLANNING
-    PLANNING --> EXECUTING
-    EXECUTING --> VERIFYING
-    VERIFYING --> FINISHED
+    QUEUED --> ANALYZING : Jules starts researching
+    ANALYZING --> PLANNING : Jules starts planning
+    PLANNING --> EXECUTING : Jules starts coding
+    EXECUTING --> VERIFYING : Jules starts testing / PR created
+    VERIFYING --> FINISHED : Issue closed / PR merged
 
-    QUEUED --> FAILED
-    ANALYZING --> FAILED
-    PLANNING --> FAILED
-    EXECUTING --> FAILED
-    VERIFYING --> FAILED
+    QUEUED --> FAILED : Jules error
+    ANALYZING --> FAILED : Jules error
+    PLANNING --> FAILED : Jules error
+    EXECUTING --> FAILED : Jules error
+    VERIFYING --> FAILED : Jules error / PR checks fail
 
     state QUEUED #lightgrey
     state ANALYZING #lightblue
-    state PLANNING #lightgreen
+    state PLANNING #lightblue
     state EXECUTING #yellow
     state VERIFYING #orange
     state FINISHED #green
     state FAILED #red
 }
 
-TaskStatus -[dashed]-> Unified : mapped to
-JulesSession -[dashed]-> Unified : mapped to
-GitHubIssue -[dashed]-> Unified : mapped to
+GitHubIssue -[dashed]-> Unified : influences
+JulesSession -[dashed]-> Unified : maps to
+PR -[dashed]-> Unified : influences
 
 legend bottom
-| **Unified State** | **Mapping Logic (Tool-Dependent States)** |
-| QUEUED | Task:pending |
-| ANALYZING | Task:analyzed OR Task:researching OR Jules:researching |
-| PLANNING | Task:planning OR Task:awaiting_plan_approval OR Jules:planning |
-| EXECUTING | Task:in_progress OR Task:coding OR Jules:in-progress OR Jules:coding |
-| VERIFYING | Task:testing OR Task:implemented OR Jules:testing |
-| FINISHED | Task:completed OR GitHub:closed |
-| FAILED | Task:failed OR Task:failed_jules OR Task:failed_pr OR Jules:failed OR Jules:error |
+| **Unified State** | **Mapping Logic (Source States)** |
+| QUEUED | GH.Issue:open AND Jules.Session:none |
+| ANALYZING | Jules.Session:researching |
+| PLANNING | Jules.Session:planning OR Jules.Session:awaiting_plan_approval |
+| EXECUTING | Jules.Session:in-progress OR Jules.Session:coding |
+| VERIFYING | Jules.Session:testing OR (Jules.Session:finished AND GH.PR:open) |
+| FINISHED | GH.Issue:closed |
+| FAILED | Jules.Session:failed OR Jules.Session:error OR GH.PR:checks_failed |
 end legend
 
 @enduml


### PR DESCRIPTION
The Unified Task State Mapping has been moved to Chapter 1 of `STATE_EVENTS_CONCEPT.md`. The mapping logic was updated to use `GH.Issue`, `GH.PR`, and `Jules.Session` as the primary sources of truth. The rest of the document and the corresponding state-event diagram in `specification/TASK_STATE_EVENTS.puml` were refactored to align with this new state model.

Fixes #485

---
*PR created automatically by Jules for task [11035612440439103728](https://jules.google.com/task/11035612440439103728) started by @chatelao*