### PR TITLE
Consolidate Cron Job State Documentation

### DIFF
--- a/CRONJOB_CONCEPT.md
+++ b/CRONJOB_CONCEPT.md
@@ -14,4 +14,4 @@ The Cron Job system provides a periodic trigger mechanism to perform background 
 - **<a name="UC-CJ3"></a>Multi-User Background Processing (UC-CJ3)**: The cron job iterates through all registered users and their projects, performing maintenance tasks at scale.
 
 ## Logic Flow
-The cron system implements "Event Source Parity", ensuring that system events are triggered consistently whether they arrive via real-time webhooks, periodic polling, or manual refreshes.
+The cron system implements "Event Source Parity". For detailed information on how periodic polling affects task states and transitions, refer to [STATE_EVENTS_CONCEPT.md](STATE_EVENTS_CONCEPT.md).

--- a/CRONJOB_DESIGN.md
+++ b/CRONJOB_DESIGN.md
@@ -6,15 +6,13 @@ The Cron Job system is implemented as a set of background services triggered by 
 ## High-Level Architecture
 - **Trigger**: An external scheduler makes an HTTP GET request to the cron entry point.
 - **Entry Point**: `src/frontend/cronjob.php` serves as the execution gateway.
-- **Service Execution**:
-    - `GitHubService`: Syncs repository issues via `App\Task::syncIssues`.
-    - `JulesService`: Refreshes agent session statuses via `App\Task::refreshJulesStatus`.
+- **Service Execution**: Orchestrates calls to `App\Task::syncIssues` and `App\Task::refreshJulesStatus`. Detailed state transition logic is documented in [STATE_EVENTS_CONCEPT.md](STATE_EVENTS_CONCEPT.md).
 
 ## Logic Flow
-1. **Authentication**: Validates the request against a pre-shared secret.
+1. **Authentication**: Validates the request against a pre-shared secret (`CRON_SECRET`).
 2. **User Discovery**: Fetches all users from the database.
 3. **Project Iteration**: For each user, identifies all linked projects.
-4. **Task Processing**: Iterates through active tasks to sync with GitHub and Jules APIs.
+4. **Task Processing**: Iterates through active projects to perform issue synchronization and agent status refreshes.
 
 ## Security Considerations
 To prevent unauthorized triggering of resource-intensive synchronization tasks:

--- a/STATE_EVENTS_CONCEPT.md
+++ b/STATE_EVENTS_CONCEPT.md
@@ -59,10 +59,20 @@ These behaviors are triggered by specific events originating from GitHub (webhoo
 | **Retry (Button)** | Sends a "retry" command to a failed Jules session. |
 | **Restart (Button)** | Aborts the current Jules session and restarts it by toggling the `Jules` label. |
 
-### 3.3 Jules Status Polling
+### 3.3 Periodic Polling (Cron Job)
 
-Periodic calls to `App\Task::refreshJulesStatus` update the unified task state based on the remote Jules session state:
+The application implements "Event Source Parity", ensuring that system events are triggered consistently whether they arrive via real-time webhooks, periodic polling, or manual refreshes.
 
+The background cron job (triggered via `cronjob.php`) performs the following synchronization activities:
+
+#### 3.3.1 GitHub Issue Synchronization (`syncIssues`)
+The system periodically scans linked repositories for updates to GitHub Issues.
+- **New Issues**: Discovers and imports issues with the `Jules` label.
+- **State Changes**: Detects if an issue has been closed or reopened externally.
+- **Label Changes**: Responds to the addition or removal of relevant labels (e.g., `Jules`, `Auto-Repeat`).
+
+#### 3.3.2 Jules Status Polling (`refreshJulesStatus`)
+Periodic calls update the unified task state based on the remote Jules session state:
 - `STATE_RESEARCHING` -> `PROCESSING/ANALYZING`
 - `STATE_PLANNING` -> `PROCESSING/PLANNING`
 - `STATE_IN_PROGRESS` -> `PROCESSING/EXECUTING`
@@ -70,6 +80,11 @@ Periodic calls to `App\Task::refreshJulesStatus` update the unified task state b
 - `STATE_TESTING` -> `PROCESSING/VERIFYING`
 - `STATE_FINISHED` / `STATE_COMPLETED` -> `PROCESSING/CHECKING` (if PR exists) or `FINISHED` (if issue closed)
 - `STATE_FAILED` / `STATE_ERROR` -> `FAILED/FAILED_JULES`
+
+#### 3.3.3 Pull Request & Check Suite Discovery
+During the `refreshJulesStatus` cycle, the system also:
+- **Discovers PRs**: Links newly created GitHub Pull Requests to their corresponding tasks.
+- **Polls Check Suites**: Retrieves the latest status of GitHub Actions/Check Suites to advance tasks from `PROCESSING/CHECKING` to `READY` or `FAILED/FAILED_PR`.
 
 ## 4. Automation & Operations
 


### PR DESCRIPTION
This change centralizes the documentation of reactive behaviors and state transitions caused by the periodic polling system. 

Key changes:
- Updated `STATE_EVENTS_CONCEPT.md` to include Section 3.3 "Periodic Polling (Cron Job)", covering `syncIssues`, `refreshJulesStatus`, and PR/Check Suite discovery.
- Refined `CRONJOB_CONCEPT.md` and `CRONJOB_DESIGN.md` to remove redundant logic and point to the centralized state document.
- Maintained the "Event Source Parity" principle in the central documentation.

Fixes #490

---
*PR created automatically by Jules for task [7818330078802188191](https://jules.google.com/task/7818330078802188191) started by @chatelao*