### PR TITLE
Rewrite Notification Concept based on Unified Task State model

### DIFF
--- a/NOTIF_CONCEPT.md
+++ b/NOTIF_CONCEPT.md
@@ -1,11 +1,11 @@
 # Concept: Notifications System
 
 ## Overview
-The notification system aims to keep users informed about critical events across their projects and tasks. It provides a multi-channel approach to ensure timely updates whether the user is actively using the dashboard or is on the move.
+The notification system aims to keep users informed about critical state transitions across their projects and tasks. By focusing on the Unified Task State model, it provides a consistent alerting experience regardless of whether the change was triggered by GitHub or the Jules agent.
 
 ## Business Cases
--   **Reduced Cycle Times**: Real-time alerts for build failures and PR availability minimize "wait time" in the development lifecycle.
--   **Improved Operational Awareness**: Provides stakeholders with immediate visibility into the progress and health of automated AI tasks without manual monitoring.
+-   **Reduced Cycle Times**: Real-time alerts for transitions to `FAILED` or `READY` states minimize "wait time" in the development lifecycle.
+-   **Improved Operational Awareness**: Provides stakeholders with immediate visibility into the progress and health of automated AI tasks without manual monitoring of external logs.
 
 ## Notification Channels
 1.  **In-App Inbox**: A centralized list of notifications within the web application dashboard.
@@ -13,28 +13,28 @@ The notification system aims to keep users informed about critical events across
 3.  **Telegram**: Instant messages delivered via the linked Telegram bot for mobile and desktop connectivity.
 
 ## Key Notification Events & Logic
-The system triggers notifications based on the following logic:
+The system triggers notifications based on transitions within the Unified Task State model.
 
 ### Event Types
--   **Build Failed**: Triggered when a GitHub Check Suite or Check Run fails.
--   **PR Available**: Triggered when a new Pull Request is discovered or created.
--   **Session Failed**: Triggered when a Jules session enters a failed or error state.
--   **Task Completed**: Triggered when a task reaches the `completed` or `implemented` status.
--   **Issue State Change**: Triggered when a GitHub issue is opened, closed, reopened, or deleted.
+-   **Transition to FAILED**: Triggered when a task enters the `FAILED` state, either due to an agent error (`FAILED_JULES`) or PR check failures (`FAILED_PR`).
+-   **Transition to READY**: Triggered when a task enters the `READY` state, indicating that all automated checks have passed and the Pull Request is ready for merge.
+-   **Transition to FINISHED**: Triggered when a task reaches the `FINISHED` status (e.g., associated GitHub issue is closed or PR is merged).
+-   **External Issue Events**: Triggered by external lifecycle events for GitHub issues, such as being `opened`, `reopened`, or `deleted`.
+-   **Agent Progress Updates**: Occasional notifications for significant progress within the `PROCESSING` group, such as when a task enters `PLANNING` or `VERIFYING`.
 
 ### Triggering Rules
 Notifications are generated consistently across multiple event sources (Event Source Parity):
 -   **Real-time Webhooks**: Immediate triggers from incoming GitHub or CI/CD webhooks.
--   **Backend Polling (`cronjob.php`)**: Periodic synchronization that detects changes missed by webhooks.
+-   **Backend Polling (`cronjob.php`)**: Periodic synchronization that detects state changes missed by webhooks.
 -   **Manual Refreshes (`project.php`)**: User-initiated synchronizations that refresh project and task states.
 
 ## Use Cases
--   **<a name="UC-N1"></a>Jump to Source (Deep Linking) (UC-N1)**: A user clicks on a "PR Available" notification and is immediately taken to the corresponding GitHub Pull Request page.
--   **<a name="UC-N2"></a>Immediate Build Failure Response (UC-N2)**: A developer receives a "Build Failed" notification on Telegram and can quickly initiate a fix, even when away from their primary workstation.
--   **<a name="UC-N3"></a>Streamlined PR Review Workflow (UC-N3)**: Reviewers are notified as soon as a new PR is ready for feedback, accelerating the path to merging.
--   **<a name="UC-N4"></a>Passive Progress Monitoring (UC-N4)**: A developer receives a "Task Completed" notification when Jules finishes a long-running task, allowing them to switch contexts at the optimal time.
+-   **<a name="UC-N1"></a>Jump to Source (Deep Linking) (UC-N1)**: A user clicks on a "Task Ready" notification and is immediately taken to the corresponding GitHub Pull Request or Jules session page.
+-   **<a name="UC-N2"></a>Immediate Failure Response (UC-N2)**: A developer receives a "Task Failed" notification (state `FAILED_PR`) on Telegram and can quickly initiate a fix, even when away from their primary workstation.
+-   **<a name="UC-N3"></a>Streamlined Review Workflow (UC-N3)**: Reviewers are notified as soon as a task enters the **`READY`** state, accelerating the path to merging.
+-   **<a name="UC-N4"></a>Passive Progress Monitoring (UC-N4)**: A developer receives a "Task Finished" notification when a task reaches the **`FINISHED`** state, allowing them to switch contexts at the optimal time.
 -   **<a name="UC-N5"></a>Noise Management for Experimental Projects (UC-N5)**: A user mutes all notifications for a specific experimental repository to maintain focus on stable production repositories.
--   **<a name="UC-N6"></a>Unified Task Oversight (UC-N6)**: A user scans their In-App Inbox to catch up on all completed and failed tasks across multiple projects in a single view.
+-   **<a name="UC-N6"></a>Unified Task Oversight (UC-N6)**: A user scans their In-App Inbox to catch up on all state transitions across multiple projects in a single view.
 
 ## Configuration & Customization
 To avoid notification fatigue, users can customize their preferences at multiple levels:
@@ -45,7 +45,7 @@ To avoid notification fatigue, users can customize their preferences at multiple
 
 ### Project-Level Settings
 - Enable or disable specific notification types for an entire repository.
-- Broadcast filters for internal task statuses.
+- Broadcast filters for internal task statuses (Unified States).
 
 ### Task-Level Settings
 - Mute notifications for specific tasks/issues.


### PR DESCRIPTION
Rewrote `NOTIF_CONCEPT.md` to transition the notification system's conceptual framework from being external-source-specific (GitHub/Jules events) to being driven by the Unified Task State model. This ensures that notifications are triggered consistently regardless of the underlying event source. Use cases and event definitions have been updated to reflect states like `READY`, `FAILED`, and `FINISHED`.

Fixes #491

---
*PR created automatically by Jules for task [12518977695304934057](https://jules.google.com/task/12518977695304934057) started by @chatelao*