### PR TITLE
docs: update TOP_CONCEPT.md entity mapping for Pull Requests

### DIFF
--- a/TOP_CONCEPT.md
+++ b/TOP_CONCEPT.md
@@ -21,7 +21,7 @@ The following table illustrates the core entities of the system and their repres
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 | **USER** | `users` table | `google_id` | `user_github_accounts` | `jules_api_key` | `user_telegram_accounts` | 1 User : N GitHub, 1 User : 1 Telegram |
 | **PROJECT** | `projects` table | - | Repository (`github_repo`) | - | - | 1 User : N Projects |
-| **TASK** | `tasks` table | - | Issue (`issue_number`) | Session Status | - | 1 Project : N Tasks |
+| **TASK** | `tasks` table | - | Issue (`issue_number`), Pull Request (`pr_url`) | Session Status | - | 1 Project : N Tasks |
 
 ## High-Level Architecture
 - **Frontend**: Web interface for users to manage projects and agents.


### PR DESCRIPTION
This PR updates the `TOP_CONCEPT.md` documentation to explicitly include Pull Requests in the Core Entities & Mapping table. The TASK entity now lists both `Issue (issue_number)` and `Pull Request (pr_url)` under the GitHub column, providing a more complete overview of how tasks are represented across integrated services.

Fixes #495

---
*PR created automatically by Jules for task [17102996246043762930](https://jules.google.com/task/17102996246043762930) started by @chatelao*