### PR TITLE
Suppress user-triggered notifications

### DIFF
--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -16,6 +16,11 @@ class WebhookHandler
         return hash_equals($hash, $signature);
     }
 
+    private function isUserTriggered(array $event): bool
+    {
+        return ($event['sender']['type'] ?? '') === 'User';
+    }
+
     public function handle(array $project, array $event, ?GitHubService $githubService = null, ?NotificationService $notificationService = null, ?JulesService $julesService = null): bool
     {
         $action = $event['action'] ?? '';
@@ -25,12 +30,15 @@ class WebhookHandler
 
         $taskModel = new Task($this->db);
 
+        // Don't trigger any notification directly from user triggered actions
+        $effectiveNotifService = $this->isUserTriggered($event) ? null : $notificationService;
+
         if ($pullRequest) {
-            return $this->handlePullRequest($project, $event, $notificationService, $githubService);
+            return $this->handlePullRequest($project, $event, $effectiveNotifService, $githubService);
         }
 
         if ($checkSuite) {
-            return $this->handleCheckSuite($project, $event, $taskModel, $notificationService);
+            return $this->handleCheckSuite($project, $event, $taskModel, $effectiveNotifService);
         }
 
         if (!$issue) {
@@ -39,8 +47,8 @@ class WebhookHandler
 
         if ($action === 'deleted') {
             $result = $taskModel->deleteByIssueNumber($project['project_id'], $issue['number']);
-            if ($result && $notificationService) {
-                $notificationService->notify($project['user_id'], 'github_issue', "🗑️ Issue Deleted: #" . $issue['number'], "Issue \"" . ($issue['title'] ?? 'Unknown') . "\" was deleted in " . $project['github_repo'], [
+            if ($result && $effectiveNotifService) {
+                $effectiveNotifService->notify($project['user_id'], 'github_issue', "🗑️ Issue Deleted: #" . $issue['number'], "Issue \"" . ($issue['title'] ?? 'Unknown') . "\" was deleted in " . $project['github_repo'], [
                     'project_id' => $project['project_id'],
                     'issue_number' => $issue['number'],
                     'source_url' => $issue['html_url'] ?? ''
@@ -58,25 +66,25 @@ class WebhookHandler
         if ($result && $julesService && $githubService) {
             $task = $taskModel->findByIssueNumber($project['project_id'], $issue['number']);
             if ($task) {
-                $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $notificationService, (int)$task['task_id']);
+                $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $effectiveNotifService, (int)$task['task_id']);
             }
         }
 
-        if ($result && $notificationService) {
+        if ($result && $effectiveNotifService) {
             if ($action === 'opened') {
-                $notificationService->notify($project['user_id'], 'github_issue', "🆕 Issue Opened: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was opened in " . $project['github_repo'], [
+                $effectiveNotifService->notify($project['user_id'], 'github_issue', "🆕 Issue Opened: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was opened in " . $project['github_repo'], [
                     'project_id' => $project['project_id'],
                     'issue_number' => $issue['number'],
                     'source_url' => $issue['html_url']
                 ]);
             } elseif ($action === 'closed') {
-                $notificationService->notify($project['user_id'], 'github_issue', "🔒 Issue Closed: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was closed in " . $project['github_repo'], [
+                $effectiveNotifService->notify($project['user_id'], 'github_issue', "🔒 Issue Closed: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was closed in " . $project['github_repo'], [
                     'project_id' => $project['project_id'],
                     'issue_number' => $issue['number'],
                     'source_url' => $issue['html_url']
                 ]);
             } elseif ($action === 'reopened') {
-                $notificationService->notify($project['user_id'], 'github_issue', "🔓 Issue Reopened: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was reopened in " . $project['github_repo'], [
+                $effectiveNotifService->notify($project['user_id'], 'github_issue', "🔓 Issue Reopened: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was reopened in " . $project['github_repo'], [
                     'project_id' => $project['project_id'],
                     'issue_number' => $issue['number'],
                     'source_url' => $issue['html_url']

--- a/src/frontend/ajax-sync.php
+++ b/src/frontend/ajax-sync.php
@@ -68,7 +68,8 @@ try {
                 $githubToken = $project['github_token'] ?? null;
                 if ($githubToken) {
                     $githubService = new GitHubService(null, $githubToken);
-                    $taskModel->refreshJulesStatus($userId, $githubService, $julesService, $notificationService, null, $projectId);
+                    // Manual sync should not trigger notifications
+                    $taskModel->refreshJulesStatus($userId, $githubService, $julesService, null, null, $projectId);
                 }
             }
         } else {
@@ -77,11 +78,13 @@ try {
             if (!empty($githubAccounts)) {
                 // Use the first account's token for refreshing Jules status
                 $githubService = new GitHubService(null, $githubAccounts[0]['github_token']);
-                $taskModel->refreshJulesStatus($userId, $githubService, $julesService, $notificationService);
+                // Manual sync should not trigger notifications
+                $taskModel->refreshJulesStatus($userId, $githubService, $julesService, null);
             } else {
                 // Fallback without token
                 $githubService = new GitHubService();
-                $taskModel->refreshJulesStatus($userId, $githubService, $julesService, $notificationService);
+                // Manual sync should not trigger notifications
+                $taskModel->refreshJulesStatus($userId, $githubService, $julesService, null);
             }
         }
     }

--- a/test/Integration/UserActionNotificationTest.php
+++ b/test/Integration/UserActionNotificationTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\WebhookHandler;
+use App\NotificationService;
+use PDO;
+use Tests\TestDatabaseTrait;
+
+class UserActionNotificationTest extends TestCase
+{
+    use TestDatabaseTrait;
+
+    private $pdo;
+    private $db;
+    private $notificationService;
+    private $webhookHandler;
+
+    protected function setUp(): void
+    {
+        $this->pdo = $this->getTestPdo();
+        $this->setUpDatabase();
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        $this->notificationService = new NotificationService($this->db);
+        $this->webhookHandler = new WebhookHandler($this->db);
+    }
+
+    private function setUpDatabase(): void
+    {
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+
+        $this->pdo->exec("DROP TABLE IF EXISTS notifications");
+        $this->pdo->exec("DROP TABLE IF EXISTS user_notification_settings");
+        $this->pdo->exec("DROP TABLE IF EXISTS project_notification_settings");
+        $this->pdo->exec("DROP TABLE IF EXISTS user_event_notification_settings");
+        $this->pdo->exec("DROP TABLE IF EXISTS project_status_notification_settings");
+        $this->pdo->exec("DROP TABLE IF EXISTS task_notification_settings");
+        $this->pdo->exec("DROP TABLE IF EXISTS tasks");
+        $this->pdo->exec("DROP TABLE IF EXISTS projects");
+        $this->pdo->exec("DROP TABLE IF EXISTS users");
+        $this->pdo->exec("DROP TABLE IF EXISTS user_event_notification_settings");
+        $this->pdo->exec("DROP TABLE IF EXISTS project_status_notification_settings");
+
+        $this->pdo->exec("CREATE TABLE users (
+            user_id $pk,
+            google_id VARCHAR(255) UNIQUE,
+            name VARCHAR(255),
+            email VARCHAR(255)
+        )");
+
+        $this->pdo->exec("CREATE TABLE projects (
+            project_id $pk,
+            user_id INT,
+            github_repo VARCHAR(255),
+            webhook_secret VARCHAR(255)
+        )");
+
+        $this->pdo->exec("CREATE TABLE tasks (
+            task_id $pk,
+            user_id INT,
+            project_id INT,
+            issue_number INT,
+            title VARCHAR(255),
+            body TEXT,
+            status VARCHAR(50) DEFAULT 'pending',
+            github_state VARCHAR(20) DEFAULT 'open',
+            github_data TEXT,
+            UNIQUE(project_id, issue_number)
+        )");
+
+        $this->pdo->exec("CREATE TABLE notifications (
+            notification_id $pk,
+            user_id INT,
+            project_id INT,
+            type VARCHAR(50),
+            title VARCHAR(255),
+            message TEXT,
+            data JSON,
+            is_read BOOLEAN DEFAULT FALSE,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )");
+
+        $this->pdo->exec("CREATE TABLE user_notification_settings (
+            user_id INT,
+            channel VARCHAR(20),
+            is_enabled BOOLEAN DEFAULT TRUE,
+            PRIMARY KEY (user_id, channel)
+        )");
+
+        $this->pdo->exec("CREATE TABLE user_event_notification_settings (
+            user_id INT,
+            notification_type VARCHAR(50),
+            is_enabled BOOLEAN DEFAULT TRUE,
+            PRIMARY KEY (user_id, notification_type)
+        )");
+
+        $this->pdo->exec("CREATE TABLE project_notification_settings (
+            project_id INT,
+            notification_type VARCHAR(50),
+            is_enabled BOOLEAN DEFAULT TRUE,
+            PRIMARY KEY (project_id, notification_type)
+        )");
+
+        $this->pdo->exec("CREATE TABLE project_status_notification_settings (
+            project_id INT,
+            status VARCHAR(50),
+            is_enabled BOOLEAN DEFAULT TRUE,
+            PRIMARY KEY (project_id, status)
+        )");
+
+        $this->pdo->exec("INSERT INTO users (user_id, google_id, name, email) VALUES (1, 'google-1', 'User 1', 'user1@example.com')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+    }
+
+    public function testHandleSkipsNotificationForUserSender()
+    {
+        $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $event = [
+            'action' => 'opened',
+            'sender' => ['type' => 'User'],
+            'issue' => [
+                'number' => 101,
+                'title' => 'Manual Issue',
+                'body' => 'Issue body',
+                'html_url' => 'https://github.com/owner/repo/issues/101',
+                'state' => 'open'
+            ]
+        ];
+
+        $this->webhookHandler->handle($project, $event, null, $this->notificationService);
+
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM notifications");
+        $this->assertEquals(0, $stmt->fetchColumn(), "Notification should NOT be triggered for human user action.");
+    }
+
+    public function testHandleSendsNotificationForBotSender()
+    {
+        $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $event = [
+            'action' => 'opened',
+            'sender' => ['type' => 'Bot'],
+            'issue' => [
+                'number' => 102,
+                'title' => 'Bot Issue',
+                'body' => 'Issue body',
+                'html_url' => 'https://github.com/owner/repo/issues/102',
+                'state' => 'open'
+            ]
+        ];
+
+        $this->webhookHandler->handle($project, $event, null, $this->notificationService);
+
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM notifications");
+        $this->assertEquals(1, $stmt->fetchColumn(), "Notification SHOULD be triggered for non-user (Bot) action.");
+    }
+
+    public function testHandleSendsNotificationWhenSenderMissing()
+    {
+        $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $event = [
+            'action' => 'opened',
+            'issue' => [
+                'number' => 103,
+                'title' => 'Unknown Sender Issue',
+                'body' => 'Issue body',
+                'html_url' => 'https://github.com/owner/repo/issues/103',
+                'state' => 'open'
+            ]
+        ];
+
+        $this->webhookHandler->handle($project, $event, null, $this->notificationService);
+
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM notifications");
+        $this->assertEquals(1, $stmt->fetchColumn(), "Notification SHOULD be triggered if sender information is missing (backwards compatibility).");
+    }
+
+    public function testHandlePrSkipsNotificationForUserSender()
+    {
+        $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $event = [
+            'action' => 'opened',
+            'sender' => ['type' => 'User'],
+            'pull_request' => [
+                'number' => 201,
+                'title' => 'Manual PR',
+                'html_url' => 'https://github.com/owner/repo/pull/201',
+                'merged' => false
+            ]
+        ];
+
+        $this->webhookHandler->handle($project, $event, null, $this->notificationService);
+
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM notifications");
+        $this->assertEquals(0, $stmt->fetchColumn(), "Notification should NOT be triggered for human user PR action.");
+    }
+}


### PR DESCRIPTION
This change prevents the application from triggering redundant or noisy notifications when a user performs manual actions on GitHub (like creating issues or merging PRs) or initiates a manual sync from the Agent Control dashboard. 

Key changes:
1. `App\WebhookHandler::isUserTriggered`: A new helper method that checks if the `sender.type` in the GitHub webhook payload is `'User'`.
2. `App\WebhookHandler::handle`: Now conditionally sets the notification service to `null` if the action was user-triggered.
3. `src/frontend/ajax-sync.php`: Updated to pass `null` for the notification service during manual refreshes.
4. `test/Integration/UserActionNotificationTest.php`: New integration tests verifying that notifications are skipped for 'User' senders, triggered for 'Bot' senders, and triggered when sender information is missing (for backwards compatibility).

Fixes #503

---
*PR created automatically by Jules for task [18231274124820902381](https://jules.google.com/task/18231274124820902381) started by @chatelao*