### PR TITLE
Implement Quick Task Acknowledgment for Telegram Chat Control

### DIFF
--- a/CHAT_ROADMAP.md
+++ b/CHAT_ROADMAP.md
@@ -9,7 +9,7 @@
 | 3 | [UC-C1] Remote Task Recovery | ✅ |
 | 4 | [UC-C2] One-Tap PR Merging | ✅ |
 | 5 | UX & Feedback Loop | 🚧 |
-| 6 | [UC-C3] Quick Task Acknowledgment | 🚧 |
+| 6 | [UC-C3] Quick Task Acknowledgment | ✅ |
 
 ## Goals
 
@@ -50,7 +50,7 @@
 - [ ] Final end-to-end testing of the interactive chat experience.
 
 ## Phase 6: [UC-C3] Quick Task Acknowledgment
-- [ ] Update `WebhookHandler` to include the `acknowledge` action for new 'jules' issues.
-- [ ] Implement `acknowledge` action handler in `TelegramWebhookHandler`.
-- [ ] Define what "Acknowledgment" does in the system (e.g., clear from pending queue).
-- [ ] Verify acknowledgment flow from a "New Issue" notification.
+- [x] Update `WebhookHandler` to include the `acknowledge` action for new 'jules' issues.
+- [x] Implement `acknowledge` action handler in `TelegramWebhookHandler`.
+- [x] Define what "Acknowledgment" does in the system (e.g., clear from pending queue).
+- [x] Verify acknowledgment flow from a "New Issue" notification.

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -791,12 +791,21 @@ class Task
                         $message = "PR checks for \"" . $task['title'] . "\" failed.";
                     }
 
+                    $actions = [];
+                    if ($mappedStatus === self::STATUS_READY) {
+                        $actions = ['merge'];
+                    } elseif ($mappedStatus === self::STATUS_FAILED_JULES || $mappedStatus === self::STATUS_FAILED_PR) {
+                        $actions = ['retry', 'restart'];
+                    } else {
+                        $actions = ['acknowledge'];
+                    }
+
                     $notificationService->notify($userId, 'task_status', $title, $message, [
                         'task_id' => $task['task_id'],
                         'project_id' => $task['project_id'],
                         'status' => $mappedStatus,
                         'source_url' => $this->getTargetUrl(array_merge($task, ['status' => $mappedStatus]))
-                    ]);
+                    ], $actions);
                 }
             } else {
                 // Still update last_synced_at even if no sessionId or apiKey to avoid constant retries

--- a/src/backend/TelegramChannelHandler.php
+++ b/src/backend/TelegramChannelHandler.php
@@ -45,6 +45,7 @@ class TelegramChannelHandler implements NotificationChannelInterface
         $extraParams = [];
         if (!empty($actions) && isset($notification['data']['task_id'])) {
             $taskId = $notification['data']['task_id'];
+            $notificationId = $notification['notification_id'] ?? '';
             $buttons = [];
             foreach ($actions as $action) {
                 $label = ucfirst($action);
@@ -53,7 +54,7 @@ class TelegramChannelHandler implements NotificationChannelInterface
                 }
                 $buttons[] = [
                     'text' => $label,
-                    'callback_data' => "$action:$taskId"
+                    'callback_data' => "$action:$taskId" . ($notificationId ? ":$notificationId" : "")
                 ];
             }
             $extraParams['reply_markup'] = [

--- a/src/backend/TelegramWebhookHandler.php
+++ b/src/backend/TelegramWebhookHandler.php
@@ -76,12 +76,13 @@ class TelegramWebhookHandler
         }
 
         // 2. Parse action and taskId
-        // Expected format: "action:taskId"
+        // Expected format: "action:taskId" or "action:taskId:notificationId"
         $parts = explode(':', $data);
         $action = $parts[0] ?? '';
         $taskId = isset($parts[1]) ? (int)$parts[1] : null;
+        $notificationId = isset($parts[2]) ? (int)$parts[2] : null;
 
-        if (!$taskId || !in_array($action, ['retry', 'restart', 'merge'])) {
+        if (!$taskId || !in_array($action, ['retry', 'restart', 'merge', 'acknowledge'])) {
             $this->telegramService->answerCallbackQuery($callbackId, [
                 'text' => "Invalid action.",
                 'show_alert' => true
@@ -105,6 +106,11 @@ class TelegramWebhookHandler
         $this->telegramService->answerCallbackQuery($callbackId, [
             'text' => "Processing " . ucfirst($action) . "..."
         ]);
+
+        if ($notificationId) {
+            $notificationService = new NotificationService($this->userModel->getDb());
+            $notificationService->markAsRead($notificationId);
+        }
 
         try {
             $projectModel = new Project($this->userModel->getDb());
@@ -139,12 +145,16 @@ class TelegramWebhookHandler
                 $ghs->postComment($repo, $issueNumber, "retry");
 
                 $statusText = "🚀 Retry signal sent to Issue #$issueNumber.";
+            } elseif ($action === 'acknowledge') {
+                $statusText = "✅ Acknowledged.";
             } else {
                 $statusText = "Infrastructure for <b>$action</b> is ready. Actual execution will be implemented soon.";
             }
 
             if ($messageId) {
-                $this->telegramService->editMessageText($chatId, $messageId, $originalText . "\n\n" . $statusText);
+                $this->telegramService->editMessageText($chatId, $messageId, $originalText . "\n\n" . $statusText, [
+                    'reply_markup' => ['inline_keyboard' => []]
+                ]);
             } else {
                 $this->telegramService->sendMessage($chatId, $statusText);
             }

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -62,33 +62,26 @@ class WebhookHandler
         }
 
         $result = $taskModel->upsert($project['user_id'], $project['project_id'], $issue);
+        $task = $taskModel->findByIssueNumber($project['project_id'], $issue['number']);
 
-        if ($result && $julesService && $githubService) {
-            $task = $taskModel->findByIssueNumber($project['project_id'], $issue['number']);
-            if ($task) {
-                $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $effectiveNotifService, (int)$task['task_id']);
-            }
+        if ($result && $task && $julesService && $githubService) {
+            $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $effectiveNotifService, (int)$task['task_id']);
         }
 
-        if ($result && $effectiveNotifService) {
+        if ($result && $task && $effectiveNotifService) {
+            $notificationData = [
+                'task_id' => $task['task_id'],
+                'project_id' => $project['project_id'],
+                'issue_number' => $issue['number'],
+                'source_url' => $issue['html_url']
+            ];
+
             if ($action === 'opened') {
-                $effectiveNotifService->notify($project['user_id'], 'github_issue', "🆕 Issue Opened: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was opened in " . $project['github_repo'], [
-                    'project_id' => $project['project_id'],
-                    'issue_number' => $issue['number'],
-                    'source_url' => $issue['html_url']
-                ]);
+                $effectiveNotifService->notify($project['user_id'], 'github_issue', "🆕 Issue Opened: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was opened in " . $project['github_repo'], $notificationData, ['acknowledge']);
             } elseif ($action === 'closed') {
-                $effectiveNotifService->notify($project['user_id'], 'github_issue', "🔒 Issue Closed: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was closed in " . $project['github_repo'], [
-                    'project_id' => $project['project_id'],
-                    'issue_number' => $issue['number'],
-                    'source_url' => $issue['html_url']
-                ]);
+                $effectiveNotifService->notify($project['user_id'], 'github_issue', "🔒 Issue Closed: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was closed in " . $project['github_repo'], $notificationData);
             } elseif ($action === 'reopened') {
-                $effectiveNotifService->notify($project['user_id'], 'github_issue', "🔓 Issue Reopened: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was reopened in " . $project['github_repo'], [
-                    'project_id' => $project['project_id'],
-                    'issue_number' => $issue['number'],
-                    'source_url' => $issue['html_url']
-                ]);
+                $effectiveNotifService->notify($project['user_id'], 'github_issue', "🔓 Issue Reopened: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was reopened in " . $project['github_repo'], $notificationData, ['acknowledge']);
             }
         }
 
@@ -269,12 +262,21 @@ class WebhookHandler
                     $title = $newStatus === Task::STATUS_FAILED_PR ? "❌ PR Failed: #" . $task['issue_number'] : "✅ PR Fixed: #" . $task['issue_number'];
                     $message = $newStatus === Task::STATUS_FAILED_PR ? "PR checks for \"" . $task['title'] . "\" failed." : "PR checks for \"" . $task['title'] . "\" are now passing.";
 
+                    $actions = [];
+                    if ($newStatus === Task::STATUS_READY) {
+                        $actions = ['merge'];
+                    } elseif ($newStatus === Task::STATUS_FAILED_PR) {
+                        $actions = ['retry', 'restart'];
+                    } else {
+                        $actions = ['acknowledge'];
+                    }
+
                     $notificationService->notify($project['user_id'], 'task_status', $title, $message, [
                         'task_id' => $task['task_id'],
                         'project_id' => $task['project_id'],
                         'status' => $newStatus,
                         'source_url' => $taskModel->getTargetUrl(array_merge($task, ['status' => $newStatus]))
-                    ]);
+                    ], $actions);
                 }
             }
         }

--- a/test/Integration/UserActionNotificationTest.php
+++ b/test/Integration/UserActionNotificationTest.php
@@ -114,6 +114,25 @@ class UserActionNotificationTest extends TestCase
             PRIMARY KEY (project_id, status)
         )");
 
+        // Task-level notification settings (required by NotificationService)
+        $this->pdo->exec("CREATE TABLE task_notification_settings (
+            task_id INTEGER PRIMARY KEY,
+            is_muted BOOLEAN DEFAULT FALSE
+        )");
+
+        // Performance logs (required by Logger)
+        $this->pdo->exec("CREATE TABLE IF NOT EXISTS performance_logs (
+            log_id $pk,
+            user_id INT,
+            category VARCHAR(50),
+            target VARCHAR(255),
+            duration FLOAT,
+            memory INT,
+            status_code INT,
+            error_message TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )");
+
         $this->pdo->exec("INSERT INTO users (user_id, google_id, name, email) VALUES (1, 'google-1', 'User 1', 'user1@example.com')");
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
     }

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -188,6 +188,10 @@ class WebhookHandlerTest extends TestCase
 
         $this->pdo->method('getAttribute')->with(PDO::ATTR_DRIVER_NAME)->willReturn('sqlite');
         $this->pdo->method('prepare')->willReturnCallback(function($sql) use ($stmt) {
+            // Depending on the order of calls, we might see different SQLs
+            if (str_contains($sql, 'SELECT * FROM tasks')) {
+                return $stmt;
+            }
             $this->assertStringContainsString('ON CONFLICT', $sql);
             return $stmt;
         });


### PR DESCRIPTION
This change implements Phase 6 of the CHAT_ROADMAP.md, enabling users to acknowledge tasks directly from Telegram.

Key changes:
- Added 'acknowledge' action to `TelegramWebhookHandler`.
- Updated notification triggers in `WebhookHandler` and `Task::refreshJulesStatus` to include context-aware actions (acknowledge, merge, retry, restart).
- Enhanced Telegram callback data to include `notification_id`, allowing the system to mark notifications as read when an action is performed.
- Updated `TelegramChannelHandler` to generate the new callback data format.
- Fixed integration tests by adding missing database tables (`task_notification_settings` and `performance_logs`) to the test setup.
- Updated `CHAT_ROADMAP.md` to mark Phase 6 as complete.

Fixes #508

---
*PR created automatically by Jules for task [14677601489014523528](https://jules.google.com/task/14677601489014523528) started by @chatelao*