### PR TITLE
Fix status colors and labels for the new status model

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -174,7 +174,7 @@ class Task
                     COUNT(*) as total,
                     SUM(CASE WHEN github_state = 'open' THEN 1 ELSE 0 END) as open_issues,
                     SUM(CASE WHEN status = '" . self::STATUS_FINISHED . "' THEN 1 ELSE 0 END) as completed_tasks,
-                    SUM(CASE WHEN github_state = 'open' AND status IN ('" . self::STATUS_ANALYZING . "', '" . self::STATUS_PLANNING . "', '" . self::STATUS_EXECUTING . "', '" . self::STATUS_VERIFYING . "') THEN 1 ELSE 0 END) as jules_running,
+                    SUM(CASE WHEN github_state = 'open' AND status IN ('" . self::STATUS_ANALYZING . "', '" . self::STATUS_PLANNING . "', '" . self::STATUS_EXECUTING . "', '" . self::STATUS_VERIFYING . "', '" . self::STATUS_IMPLEMENTED . "') THEN 1 ELSE 0 END) as jules_running,
                     SUM(CASE WHEN github_state = 'open' AND status = '" . self::STATUS_FAILED_JULES . "' THEN 1 ELSE 0 END) as jules_failed,
                     SUM(CASE WHEN github_state = 'open' AND status = '" . self::STATUS_CHECKING . "' THEN 1 ELSE 0 END) as github_running,
                     SUM(CASE WHEN github_state = 'open' AND status = '" . self::STATUS_READY . "' THEN 1 ELSE 0 END) as github_passed,
@@ -217,7 +217,7 @@ class Task
                 $sql .= " AND t.github_state = 'open' AND t.status = '" . self::STATUS_FAILED_PR . "'";
                 break;
             case 'jules_running':
-                $sql .= " AND t.github_state = 'open' AND t.status IN ('" . self::STATUS_ANALYZING . "', '" . self::STATUS_PLANNING . "', '" . self::STATUS_EXECUTING . "', '" . self::STATUS_VERIFYING . "')";
+                $sql .= " AND t.github_state = 'open' AND t.status IN ('" . self::STATUS_ANALYZING . "', '" . self::STATUS_PLANNING . "', '" . self::STATUS_EXECUTING . "', '" . self::STATUS_VERIFYING . "', '" . self::STATUS_IMPLEMENTED . "')";
                 break;
             case 'jules_failed':
                 $sql .= " AND t.github_state = 'open' AND t.status = '" . self::STATUS_FAILED_JULES . "'";
@@ -467,6 +467,10 @@ class Task
 
         if ($status === self::STATUS_READY) {
             return 'green';
+        }
+
+        if ($status === self::STATUS_CREATED) {
+            return 'grey';
         }
 
         return 'grey';

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -112,6 +112,7 @@ $errorMessage = $errorMessage ?? null;
         .status-square.yellow { background-color: #d29922; }
         .status-square.blue { background-color: #0366d6; }
         .status-square.red { background-color: #f85149; }
+        .status-square.orange { background-color: #f0883e; }
         .status-square.purple { background-color: #8957e5; }
         .status-square.grey { background-color: #8b949e; }
         .auto-repeat-tag {
@@ -186,8 +187,40 @@ $errorMessage = $errorMessage ?? null;
                                                     </a>
                                                 </td>
                                                 <td class="px-6 py-4">
-                                                    <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap bg-green-100 text-green-800">
-                                                        🚧 Active
+                                                    <?php
+                                                    $statusColor = $taskModel->getStatusColor($task);
+                                                    $bgClass = 'bg-gray-100 text-gray-800';
+                                                    if ($statusColor === 'green') {
+                                                        $bgClass = 'bg-green-100 text-green-800';
+                                                    } elseif ($statusColor === 'yellow') {
+                                                        $bgClass = 'bg-yellow-100 text-yellow-800';
+                                                    } elseif ($statusColor === 'blue') {
+                                                        $bgClass = 'bg-blue-100 text-blue-800';
+                                                    } elseif ($statusColor === 'red') {
+                                                        $bgClass = 'bg-red-100 text-red-800';
+                                                    } elseif ($statusColor === 'purple') {
+                                                        $bgClass = 'bg-purple-100 text-purple-800';
+                                                    } elseif ($statusColor === 'orange') {
+                                                        $bgClass = 'bg-orange-100 text-orange-800';
+                                                    }
+
+                                                    $emoji = '⏳';
+                                                    $statusLabel = ucwords(str_replace('_', ' ', $task['status'] ?? ''));
+                                                    if ($task['status'] === App\Task::STATUS_CREATED) {
+                                                        $emoji = '⏳';
+                                                        $statusLabel = 'Waiting for Agent';
+                                                    } elseif ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY) {
+                                                        $emoji = '✅';
+                                                    } elseif ($task['status'] === App\Task::STATUS_CHECKING) {
+                                                        $emoji = '🔍';
+                                                    } elseif ($task['status'] === App\Task::STATUS_FAILED_JULES || $task['status'] === App\Task::STATUS_FAILED_PR) {
+                                                        $emoji = '❌';
+                                                    } elseif (in_array($task['status'], [App\Task::STATUS_ANALYZING, App\Task::STATUS_PLANNING, App\Task::STATUS_EXECUTING, App\Task::STATUS_VERIFYING, App\Task::STATUS_IMPLEMENTED])) {
+                                                        $emoji = '🚧';
+                                                    }
+                                                    ?>
+                                                    <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
+                                                        <?= $emoji ?> <?= htmlspecialchars($statusLabel) ?>
                                                     </span>
                                                 </td>
                                             </tr>
@@ -232,15 +265,17 @@ $errorMessage = $errorMessage ?? null;
 
                                                         $emoji = '⏳';
                                                         $statusLabel = ucwords(str_replace('_', ' ', $task['status'] ?? ''));
-                                                        if ($task['status'] === App\Task::STATUS_FINISHED) {
+
+                                                        if ($task['status'] === App\Task::STATUS_CREATED) {
+                                                            $emoji = '⏳';
+                                                            $statusLabel = 'Waiting for Agent';
+                                                        } elseif ($task['status'] === App\Task::STATUS_FINISHED) {
                                                             $emoji = '✅';
                                                         } elseif ($task['status'] === App\Task::STATUS_READY) {
                                                             $emoji = '✅';
                                                         } elseif ($task['status'] === App\Task::STATUS_CHECKING) {
                                                             $emoji = '🔍';
-                                                        } elseif ($task['status'] === App\Task::STATUS_FAILED_JULES) {
-                                                            $emoji = '❌';
-                                                        } elseif ($task['status'] === App\Task::STATUS_FAILED_PR) {
+                                                        } elseif ($task['status'] === App\Task::STATUS_FAILED_JULES || $task['status'] === App\Task::STATUS_FAILED_PR) {
                                                             $emoji = '❌';
                                                         } elseif (in_array($task['status'], [App\Task::STATUS_ANALYZING, App\Task::STATUS_PLANNING, App\Task::STATUS_EXECUTING, App\Task::STATUS_VERIFYING, App\Task::STATUS_IMPLEMENTED])) {
                                                             $emoji = '🚧';

--- a/src/frontend/navbar-icons.php
+++ b/src/frontend/navbar-icons.php
@@ -205,10 +205,10 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
     </div>
 
     <!-- GitHub Status -->
-    <div class="flex items-center <?= $totalTasks > 0 ? 'text-black' : 'text-gray-300' ?>" title="GitHub PR Status: Running (Yellow), Passed (Green), Failed (Red)">
+    <div class="flex items-center <?= $totalTasks > 0 ? 'text-black' : 'text-gray-300' ?>" title="GitHub PR Status: Running (Orange), Passed (Green), Failed (Red)">
         <svg class="w-5 h-5 mr-1" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
         <span class="text-xs font-bold space-x-1">
-            <a :href="basePath + 'tasks.php?filter=github_running'" class="text-yellow-600 hover:underline" x-text="githubRunning"><?= $githubRunning ?></a>
+            <a :href="basePath + 'tasks.php?filter=github_running'" class="text-orange-600 hover:underline" x-text="githubRunning"><?= $githubRunning ?></a>
             <a :href="basePath + 'tasks.php?filter=github_passed'" class="text-green-600 hover:underline" x-text="githubPassed"><?= $githubPassed ?></a>
             <a :href="basePath + 'tasks.php?filter=github_failed'" class="text-red-600 hover:underline" x-text="githubFailed"><?= $githubFailed ?></a>
         </span>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -513,7 +513,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                     ?>
                                                     <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
                                                         <?php
-                                                        if ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY) {
+                                                        $label = ucwords(str_replace('_', ' ', $task['status'] ?? ''));
+                                                        if ($task['status'] === App\Task::STATUS_CREATED) {
+                                                            echo '⏳ ';
+                                                            $label = 'Waiting for Agent';
+                                                        } elseif ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY) {
                                                             echo '✅ ';
                                                         } elseif ($task['status'] === App\Task::STATUS_CHECKING) {
                                                             echo '🔍 ';
@@ -527,7 +531,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                             echo '⏳ ';
                                                         }
                                                         ?>
-                                                        <?= htmlspecialchars(ucwords(str_replace('_', ' ', $task['status'] ?? ''))) ?>
+                                                        <?= htmlspecialchars($label) ?>
                                                     </span>
                                                 </td>
                                                 <td class="px-6 py-4">

--- a/src/frontend/tasks.php
+++ b/src/frontend/tasks.php
@@ -138,11 +138,17 @@ $title = $filterLabels[$filter] ?? 'Tasks';
                                                     $bgClass = 'bg-red-100 text-red-800';
                                                 } elseif ($statusColor === 'purple') {
                                                     $bgClass = 'bg-purple-100 text-purple-800';
+                                                } elseif ($statusColor === 'orange') {
+                                                    $bgClass = 'bg-orange-100 text-orange-800';
                                                 }
                                                 ?>
                                                 <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
                                                     <?php
-                                                    if ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY) {
+                                                    $label = ucwords(str_replace('_', ' ', $task['status'] ?? ''));
+                                                    if ($task['status'] === App\Task::STATUS_CREATED) {
+                                                        echo '⏳ ';
+                                                        $label = 'Waiting for Agent';
+                                                    } elseif ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY) {
                                                         echo '✅ ';
                                                     } elseif ($task['status'] === App\Task::STATUS_CHECKING) {
                                                         echo '🔍 ';
@@ -156,7 +162,7 @@ $title = $filterLabels[$filter] ?? 'Tasks';
                                                         echo '⏳ ';
                                                     }
                                                     ?>
-                                                    <?= htmlspecialchars(ucwords(str_replace('_', ' ', $task['status'] ?? ''))) ?>
+                                                    <?= htmlspecialchars($label) ?>
                                                 </span>
                                             </td>
                                         </tr>


### PR DESCRIPTION
Fixed broken status colors and labels on the main page and other task listings. The changes ensure that all unified task states (including the new orange 'CHECKING' state and 'IMPLEMENTED' state) are correctly represented with consistent colors, emojis, and labels (e.g., 'Waiting for Agent' for 'CREATED') across the entire application UI and backend filtering logic.

Fixes #511

---
*PR created automatically by Jules for task [10570260848885279958](https://jules.google.com/task/10570260848885279958) started by @chatelao*