### PR TITLE
Fix Validation Failed error in Merge & Close

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -22,6 +22,25 @@ class GitHubService
     /**
      * @throws Exception
      */
+    public function getIssue(string $repo, int $issueNumber): array
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+
+        return $this->apiCall(
+            'GitHub API',
+            "GET issue $repo/issues/$issueNumber",
+            fn() => $this->client->api('issue')->show($username, $repository, $issueNumber)
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
     public function getCheckSuites(string $repo, string $ref): array
     {
         $parts = explode('/', $repo);
@@ -72,11 +91,22 @@ class GitHubService
         $pr = $this->getPullRequest($repo, $prNumber);
         $sha = $pr['head']['sha'] ?? null;
 
-        return $this->apiCall(
-            'GitHub API',
-            "PUT merge $repo/pull/$prNumber",
-            fn() => $this->client->api('pull_request')->merge($username, $repository, $prNumber, $message, $sha, $mergeMethod)
-        );
+        try {
+            return $this->apiCall(
+                'GitHub API',
+                "PUT merge $repo/pull/$prNumber",
+                fn() => $this->client->api('pull_request')->merge($username, $repository, $prNumber, $message, $sha, $mergeMethod)
+            );
+        } catch (Exception $e) {
+            // Handle case where PR is already merged (405 or 422 depending on implementation/state)
+            if ($e->getCode() === 405 || $e->getCode() === 422 || str_contains($e->getMessage(), 'Validation Failed') || str_contains($e->getMessage(), 'Method Not Allowed')) {
+                $currentPr = $this->getPullRequest($repo, $prNumber);
+                if ($currentPr['merged'] ?? false) {
+                    return $currentPr;
+                }
+            }
+            throw $e;
+        }
     }
 
     /**
@@ -96,11 +126,22 @@ class GitHubService
             $params['state_reason'] = $stateReason;
         }
 
-        return $this->apiCall(
-            'GitHub API',
-            "PATCH issue $repo/issues/$issueNumber",
-            fn() => $this->client->api('issue')->update($username, $repository, $issueNumber, $params)
-        );
+        try {
+            return $this->apiCall(
+                'GitHub API',
+                "PATCH issue $repo/issues/$issueNumber",
+                fn() => $this->client->api('issue')->update($username, $repository, $issueNumber, $params)
+            );
+        } catch (Exception $e) {
+            // Handle case where issue is already closed
+            if ($e->getCode() === 422 || str_contains($e->getMessage(), 'Validation Failed')) {
+                $issue = $this->getIssue($repo, $issueNumber);
+                if (($issue['state'] ?? '') === 'closed') {
+                    return $issue;
+                }
+            }
+            throw $e;
+        }
     }
 
     /**

--- a/test/Unit/Services/GitHubServiceTest.php
+++ b/test/Unit/Services/GitHubServiceTest.php
@@ -143,4 +143,62 @@ class GitHubServiceTest extends TestCase
 
         $this->assertTrue($result['merged']);
     }
+
+    public function testCloseIssueAlreadyClosed(): void
+    {
+        $mockClient = $this->createMock(Client::class);
+        $mockIssue = $this->createMock(\Github\Api\Issue::class);
+
+        $mockClient->method('api')->with('issue')->willReturn($mockIssue);
+
+        $repo = 'chatelao/ai-brain';
+        $issueNumber = 123;
+
+        // Expect update() to be called and throw 422
+        $mockIssue->expects($this->once())
+            ->method('update')
+            ->willThrowException(new \Exception('Validation Failed', 422));
+
+        // Expect show() to be called to check the current state
+        $mockIssue->expects($this->once())
+            ->method('show')
+            ->with('chatelao', 'ai-brain', $issueNumber)
+            ->willReturn(['number' => $issueNumber, 'state' => 'closed']);
+
+        $service = new GitHubService($mockClient);
+        $result = $service->closeIssue($repo, $issueNumber);
+
+        $this->assertEquals('closed', $result['state']);
+    }
+
+    public function testMergePullRequestAlreadyMerged(): void
+    {
+        $mockClient = $this->createMock(Client::class);
+        $mockPR = $this->createMock(\Github\Api\PullRequest::class);
+
+        $mockClient->method('api')->withAnyParameters()->willReturn($mockPR);
+
+        $prNumber = 456;
+        $repo = 'chatelao/ai-brain';
+        $headSha = 'abcdef1234567890';
+
+        // 1. First getPullRequest call inside mergePullRequest
+        $mockPR->expects($this->exactly(2))
+            ->method('show')
+            ->with('chatelao', 'ai-brain', $prNumber)
+            ->willReturnOnConsecutiveCalls(
+                ['head' => ['sha' => $headSha], 'merged' => false],
+                ['head' => ['sha' => $headSha], 'merged' => true]
+            );
+
+        // 2. merge() call throws 405
+        $mockPR->expects($this->once())
+            ->method('merge')
+            ->willThrowException(new \Exception('Method Not Allowed', 405));
+
+        $service = new GitHubService($mockClient);
+        $result = $service->mergePullRequest($repo, $prNumber, 'Merge it');
+
+        $this->assertTrue($result['merged']);
+    }
 }


### PR DESCRIPTION
I have implemented idempotent error handling in the `GitHubService` to resolve the "Validation Failed" error that occurred during the "Merge & Close" operation. 

Key changes:
1.  **Robust GitHub API Calls**: Both `mergePullRequest` and `closeIssue` now catch 405 and 422 errors. If these occur, the service fetches the current state of the Pull Request or Issue. If it's already merged or closed, it returns the current data instead of throwing an exception.
2.  **New `getIssue` Helper**: Added a `getIssue` method to `GitHubService` to easily retrieve issue details by number.
3.  **Expanded Unit Tests**: Added `testCloseIssueAlreadyClosed` and `testMergePullRequestAlreadyMerged` to `GitHubServiceTest.php` to ensure the new logic works correctly and handles mocked API failures gracefully.

These changes ensure that if a Pull Request merge automatically closes an issue (which is common GitHub behavior), the subsequent explicit "close issue" call from our application won't trigger a user-visible error.

Fixes #512

---
*PR created automatically by Jules for task [6180073142676500147](https://jules.google.com/task/6180073142676500147) started by @chatelao*