### PR TITLE
Fix GitHub webhook handling and status resolution

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -44,6 +44,8 @@ class Task
                     $suites = $checkSuitesData['check_suites'];
                 } elseif (isset($checkSuitesData['check_suite'])) {
                     $suites = [$checkSuitesData['check_suite']];
+                } elseif (isset($checkSuitesData['conclusion']) || isset($checkSuitesData['status'])) {
+                    $suites = [$checkSuitesData];
                 }
             }
 

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -166,7 +166,7 @@ class WebhookHandler
                 );
             }
 
-            $githubService->createIssue($repo, $issue['title'], $issue['body'], array_values($labelNames));
+            $githubService->createIssue($repo, $issue['title'], $issue['body'] ?? null, array_values($labelNames));
             $githubService->removeLabel($repo, $issue['number'], $autorepeatLabelName);
         }
     }
@@ -176,11 +176,11 @@ class WebhookHandler
         $action = $event['action'] ?? '';
         $pr = $event['pull_request'] ?? null;
 
-        if (!$pr || !$notificationService) {
+        if (!$pr) {
             return true;
         }
 
-        if (in_array($action, ['opened', 'closed', 'reopened', 'synchronize'])) {
+        if ($notificationService && in_array($action, ['opened', 'closed', 'reopened', 'synchronize'])) {
             $emoji = '🔗';
             $actionText = 'Updated';
 
@@ -230,7 +230,7 @@ class WebhookHandler
         $action = $event['action'] ?? '';
         $checkSuite = $event['check_suite'] ?? null;
 
-        if ($action !== 'completed' || !$checkSuite) {
+        if (!in_array($action, ['requested', 'rerequested', 'completed']) || !$checkSuite) {
             return true;
         }
 

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -106,4 +106,76 @@ class WebhookHandlerTest extends TestCase
         $result = $this->handler->handle($project, $event, $githubService);
         $this->assertTrue($result);
     }
+
+    public function testHandleAutorepeatWithoutNotificationService()
+    {
+        // Simulate human-triggered merge (sender.type === 'User')
+        $project = ['user_id' => 1, 'project_id' => 1];
+        $prUrl = 'https://github.com/owner/repo/pull/123';
+
+        // Pre-seed task
+        $githubData = [
+            'number' => 123,
+            'title' => 'Issue to autorepeat',
+            'labels' => [['name' => 'autorepeat']]
+        ];
+
+        $stmt = $this->pdo->prepare("INSERT INTO tasks (user_id, project_id, issue_number, title, github_data, pr_url, status) VALUES (?, ?, ?, ?, ?, ?, ?)");
+        $stmt->execute([1, 1, 123, 'Issue to autorepeat', json_encode($githubData), $prUrl, 'checking']);
+
+        $event = [
+            'action' => 'closed',
+            'pull_request' => [
+                'number' => 124,
+                'title' => 'PR Title',
+                'html_url' => $prUrl,
+                'merged' => true
+            ],
+            'sender' => [
+                'type' => 'User'
+            ],
+            'repository' => [
+                'full_name' => 'owner/repo'
+            ]
+        ];
+
+        $githubService = $this->createMock(\App\GitHubService::class);
+        $githubService->expects($this->once())
+            ->method('createIssue')
+            ->with('owner/repo', 'Issue to autorepeat', null, ['Jules']);
+
+        // notificationService should be null because it's User triggered
+        $result = $this->handler->handle($project, $event, $githubService, null);
+        $this->assertTrue($result);
+    }
+
+    public function testHandleCheckSuiteInProgress()
+    {
+        $project = ['user_id' => 1, 'project_id' => 1];
+        $prUrl = 'https://github.com/owner/repo/pull/123';
+
+        // Pre-seed task
+        $stmt = $this->pdo->prepare("INSERT INTO tasks (user_id, project_id, issue_number, title, pr_url, status) VALUES (?, ?, ?, ?, ?, ?)");
+        $stmt->execute([1, 1, 123, 'Issue title', $prUrl, 'implemented']);
+
+        $event = [
+            'action' => 'requested',
+            'check_suite' => [
+                'status' => 'in_progress',
+                'conclusion' => null,
+                'pull_requests' => [
+                    ['url' => 'https://api.github.com/repos/owner/repo/pulls/123']
+                ]
+            ]
+        ];
+
+        $result = $this->handler->handle($project, $event);
+        $this->assertTrue($result);
+
+        $stmt = $this->pdo->prepare("SELECT status FROM tasks WHERE pr_url = ?");
+        $stmt->execute([$prUrl]);
+        $status = $stmt->fetchColumn();
+
+        $this->assertEquals('checking', $status);
+    }
 }


### PR DESCRIPTION
I have identified and fixed several issues in the GitHub webhook handling and task status resolution logic:

1.  **Auto-Repeat Bypass**: Previously, if a Pull Request was merged by a human (sender type 'User'), the system would suppress notifications by passing a null `NotificationService`. However, `handlePullRequest` had an early return if this service was null, which also bypassed the auto-repeat logic. I removed this early return and correctly guarded only the notification calls.
2.  **Delayed Status Updates**: The webhook handler only reacted to `completed` check suites. I expanded this to include `requested` and `rerequested` actions, so the UI can reflect the "Checking" status as soon as CI starts.
3.  **Status Resolution for Webhooks**: `App\Task::resolveStatus` expected check suite data in a specific nested format. I added support for raw check suite objects, which is how they arrive in webhook payloads, ensuring that `ready` or `failed_pr` states are correctly identified in real-time.
4.  **Robustness**: Added a null-coalescing check for the issue body during auto-repeat to prevent PHP warnings when duplicating issues without a description.

I've also added integration tests to `test/Integration/WebhookHandlerTest.php` to verify these fixes and ensure no regressions. All unit and integration tests passed.

Fixes #518

---
*PR created automatically by Jules for task [785617252462964792](https://jules.google.com/task/785617252462964792) started by @chatelao*