### PR TITLE
Standardize status colors and handle 'completed' status

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -451,7 +451,7 @@ class Task
     {
         $status = $task['status'] ?? self::STATUS_CREATED;
 
-        if ($status === self::STATUS_FINISHED) {
+        if ($status === self::STATUS_FINISHED || $status === 'completed') {
             $githubState = $task['github_state'] ?? 'closed';
             return $githubState === 'closed' ? 'purple' : 'green';
         }
@@ -477,10 +477,10 @@ class Task
         }
 
         if ($status === self::STATUS_CREATED) {
-            return 'grey';
+            return 'gray';
         }
 
-        return 'grey';
+        return 'gray';
     }
 
     public function hasAutorepeatLabel(array $task): bool

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -190,7 +190,9 @@ $errorMessage = $errorMessage ?? null;
                                                     <?php
                                                     $statusColor = $taskModel->getStatusColor($task);
                                                     $bgClass = 'bg-gray-100 text-gray-800';
-                                                    if ($statusColor === 'green') {
+                                                    if ($statusColor === 'gray') {
+                                                        $bgClass = 'bg-gray-100 text-gray-800';
+                                                    } elseif ($statusColor === 'green') {
                                                         $bgClass = 'bg-green-100 text-green-800';
                                                     } elseif ($statusColor === 'yellow') {
                                                         $bgClass = 'bg-yellow-100 text-yellow-800';
@@ -209,7 +211,7 @@ $errorMessage = $errorMessage ?? null;
                                                     if ($task['status'] === App\Task::STATUS_CREATED) {
                                                         $emoji = '⏳';
                                                         $statusLabel = 'Waiting for Agent';
-                                                    } elseif ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY) {
+                                                    } elseif ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY || $task['status'] === 'completed') {
                                                         $emoji = '✅';
                                                     } elseif ($task['status'] === App\Task::STATUS_CHECKING) {
                                                         $emoji = '🔍';

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -497,7 +497,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                     <?php
                                                     $statusColor = $taskModel->getStatusColor($task);
                                                     $bgClass = 'bg-gray-100 text-gray-800';
-                                                    if ($statusColor === 'green') {
+                                                    if ($statusColor === 'gray') {
+                                                        $bgClass = 'bg-gray-100 text-gray-800';
+                                                    } elseif ($statusColor === 'green') {
                                                         $bgClass = 'bg-green-100 text-green-800';
                                                     } elseif ($statusColor === 'yellow') {
                                                         $bgClass = 'bg-yellow-100 text-yellow-800';
@@ -517,7 +519,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                         if ($task['status'] === App\Task::STATUS_CREATED) {
                                                             echo '⏳ ';
                                                             $label = 'Waiting for Agent';
-                                                        } elseif ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY) {
+                                                        } elseif ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY || $task['status'] === 'completed') {
                                                             echo '✅ ';
                                                         } elseif ($task['status'] === App\Task::STATUS_CHECKING) {
                                                             echo '🔍 ';

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -272,7 +272,7 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                             <div class="flex items-center space-x-2">
                                 <span class="px-4 py-1.5 text-sm font-semibold rounded-full bg-<?= $statusColor ?>-100 text-<?= $statusColor ?>-800 flex items-center shadow-sm">
                                     <?php
-                                    if ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY) {
+                                    if ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY || $task['status'] === 'completed') {
                                         echo '✅ ';
                                     } elseif (in_array($task['status'], [App\Task::STATUS_EXECUTING, App\Task::STATUS_VERIFYING, App\Task::STATUS_IMPLEMENTED])) {
                                         echo '🚧 ';


### PR DESCRIPTION
This PR fixes the issue where status colors were not appearing on the task and project pages. The fix involved standardizing the color name returned by the backend from 'grey' to 'gray' (to match Tailwind CSS conventions) and ensuring that the 'completed' status is correctly mapped to a finished visual state (green/purple with a checkmark emoji). Visual verification was performed using a custom script and Playwright.

Fixes #522

---
*PR created automatically by Jules for task [7154535400452546126](https://jules.google.com/task/7154535400452546126) started by @chatelao*