### PR TITLE
Merge Task State Visuals and Standardize Spelling

### DIFF
--- a/AUDIT_MAINSCREEN.md
+++ b/AUDIT_MAINSCREEN.md
@@ -62,4 +62,4 @@ Hovering over a square displays a tooltip in the format: `#<Issue Number>: <Emoj
 ## 4. Identified Inconsistencies & Technical Details
 - **Autorepeat Label Inconsistency**: The "Running Autorepeat Tasks" section only recognizes the label `autorepeat`, whereas the status square border logic recognizes both `autorepeat` and `auto-repeat`.
 - **Closed Task Visibility**: Tasks that are closed on GitHub but did not reach the `completed` status (e.g., `failed_jules`) are not displayed in the project grid once closed, as the "3 most recent" filter specifically looks for `status = 'completed'`.
-- **Pending Status**: In the tooltip, `pending` tasks show a `🚧` (Work in Progress) emoji, but the status square is `grey` (Neutral/Inactive).
+- **Pending Status**: In the tooltip, `pending` tasks show a `🚧` (Work in Progress) emoji, but the status square is `gray` (Neutral/Inactive).

--- a/STATE_EVENTS_CONCEPT.md
+++ b/STATE_EVENTS_CONCEPT.md
@@ -4,20 +4,21 @@ This document describes the reactive behaviors of the Agent Control application,
 
 ## 1. Unified Task State Mapping
 
-The application defines a set of unified task states to provide a consistent view of progress across different external tools (GitHub, Jules). These states represent the "Source of Truth" for the task's lifecycle.
+The application defines a set of unified task states to provide a consistent view of progress across different external tools (GitHub, Jules). These states represent the "Source of Truth" for the task's lifecycle and include a shared set of visual indicators (Colors and Emojis) used across the web dashboard and Telegram.
 
-| Unified State | Substate | Description | Mapping Logic (Source States) |
-| :--- | :--- | :--- | :--- |
-| **`CREATED`** | - | Task is waiting to be processed by the agent. | `GH.Issue:open` AND `Jules.Session:none` |
-| **`PROCESSING`** | **`ANALYZING`** | The agent is researching or analyzing the task. | `Jules.Session:researching` |
-| | **`PLANNING`** | A plan is being created or is awaiting human approval. | `Jules.Session:planning` OR `Jules.Session:awaiting_plan_approval` |
-| | **`EXECUTING`** | The agent is actively implementing the solution (coding). | `Jules.Session:in-progress` OR `Jules.Session:coding` |
-| | **`VERIFYING`** | The agent is testing the solution locally. | `Jules.Session:testing` |
-| | **`CHECKING`** | Awaiting PR check results from GitHub. | `Jules.Session:finished` AND `GH.PR:open` AND `GH.PR:checks_running` |
-| **`READY`** | - | All checks passed, task is ready for merge. | `Jules.Session:finished` AND `GH.PR:open` AND `GH.PR:checks_passed` |
-| **`FINISHED`** | - | The task has been successfully completed and/or merged. | `GH.Issue:closed` |
-| **`FAILED`** | **`FAILED_JULES`** | An error occurred during agent execution. | `Jules.Session:failed` OR `Jules.Session:error` |
-| | **`FAILED_PR`** | PR verification (checks) failed on GitHub. | `GH.PR:checks_failed` |
+| Unified State | Substate | Color (Web) | Emoji | Description | Mapping Logic (Source States) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **`CREATED`** | - | Gray | ⏳ | Task is waiting to be processed by the agent. | `GH.Issue:open` AND `Jules.Session:none` |
+| **`PROCESSING`** | **`ANALYZING`** | Blue | 🚧 | The agent is researching or analyzing the task. | `Jules.Session:researching` |
+| | **`PLANNING`** | Blue | 🚧 | A plan is being created or is awaiting approval. | `Jules.Session:planning` OR `Jules.Session:awaiting_plan_approval` |
+| | **`EXECUTING`** | Yellow | 🚧 | The agent is actively coding the solution. | `Jules.Session:in-progress` OR `Jules.Session:coding` |
+| | **`VERIFYING`** | Yellow | 🚧 | The agent is testing the solution locally. | `Jules.Session:testing` |
+| | **`IMPLEMENTED`**| Yellow | 🚧 | The agent completed implementation (no PR yet).| `Jules.Session:finished` AND `GH.PR:none` |
+| | **`CHECKING`** | Orange | 🔍 | Awaiting PR check results from GitHub. | `Jules.Session:finished` AND `GH.PR:open` AND `GH.PR:checks_running` |
+| **`READY`** | - | Green | ✅ | All checks passed, task is ready for merge. | `Jules.Session:finished` AND `GH.PR:open` AND `GH.PR:checks_passed` |
+| **`FINISHED`** | - | Purple | ✅ | The task has been successfully completed/merged.| `GH.Issue:closed` |
+| **`FAILED`** | **`FAILED_JULES`** | Red | ❌ | An error occurred during agent execution. | `Jules.Session:failed` OR `Jules.Session:error` |
+| | **`FAILED_PR`** | Red | ❌ | PR verification (checks) failed on GitHub. | `GH.PR:checks_failed` |
 
 ### 1.1 Source State Key
 - **`GH.Issue:*`**: State of the GitHub Issue (open/closed).
@@ -117,28 +118,9 @@ To support recurring tasks, the system implements an "Auto-Repeat" mechanism.
 - The new issue **includes** the "Jules" label to trigger the agent.
 - The new issue **excludes** the "Auto-Repeat" label.
 
-## 5. On-State Behaviors
+## 5. Feature Availability
 
-The system exhibits different behaviors and UI representations depending on the unified state of a task.
-
-### 5.1 Task State Visuals (Dashboard/Project List)
-
-A shared set of visual indicators (Colors and Emojis) is used across the web dashboard and Telegram to represent the unified task state.
-
-| Unified State | Substate | Color (Web) | Emoji | Meaning |
-| :--- | :--- | :--- | :--- | :--- |
-| **`CREATED`** | - | Grey | ⏳ | Waiting for agent |
-| **`PROCESSING`** | **`ANALYZING`** | Yellow | 🚧 | Agent is researching |
-| | **`PLANNING`** | LightBlue | 🚧 | Agent is planning |
-| | **`EXECUTING`** | Yellow | 🚧 | Agent is coding |
-| | **`VERIFYING`** | Yellow | 🚧 | Agent is testing locally |
-| | **`CHECKING`** | Orange | 🔍 | Awaiting PR check results |
-| **`READY`** | - | Green | ✅ | Validated and ready to merge |
-| **`FINISHED`** | - | Purple | ✅ | Task completed and closed |
-| **`FAILED`** | **`FAILED_JULES`** | Red | ❌ | Agent execution error |
-| | **`FAILED_PR`** | Red | ❌ | PR verification (CI) failed |
-
-### 5.2 Feature Availability
+The system exhibits different behaviors and interactive options depending on the unified state of a task.
 
 - **Merge & Close**: Only available if state is `READY`, PR is mergeable and checks passed.
 - **Retry / Restart**: Only available when state is `FAILED`.

--- a/UX_DESIGN.md
+++ b/UX_DESIGN.md
@@ -10,7 +10,7 @@ A shared set of visual indicators is used across all platforms to represent the 
 ### 1.1 Color & Emoji Mapping
 | Unified State | Color (Web) | Emoji (Telegram/Tooltip) | Meaning |
 | :--- | :--- | :--- | :--- |
-| **`CREATED`** | Grey | ⏳ | Waiting for agent |
+| **`CREATED`** | Gray | ⏳ | Waiting for agent |
 | **`PROCESSING`** | Blue / Yellow | 🚧 | Agent is working |
 | **`CHECKING`** | Orange | 🔍 | Awaiting CI results |
 | **`READY`** | Green | ✅ | Validated and ready to merge |

--- a/specification/TASK_STATE_EVENTS.puml
+++ b/specification/TASK_STATE_EVENTS.puml
@@ -62,7 +62,7 @@ state "Unified Task State" as Unified {
     CHECKING --> FAILED_PR : PR checks fail
     READY --> FAILED_PR : New commit / checks fail
 
-    state CREATED #lightgrey
+    state CREATED #lightgray
     state READY #green
     state FINISHED #green
 }

--- a/specification/schema.puml
+++ b/specification/schema.puml
@@ -4,11 +4,11 @@ hide circle
 skinparam linetype ortho
 
 entity "users" {
-  * <color:grey><i>user_id</i></color> : INT <<PK>>
+  * <color:gray><i>user_id</i></color> : INT <<PK>>
   --
-  * <color:grey>google_id</color> : VARCHAR(255) <<UNIQUE>>
+  * <color:gray>google_id</color> : VARCHAR(255) <<UNIQUE>>
   * name : VARCHAR(255)
-  * <color:grey>email</color> : VARCHAR(255) <<UNIQUE>>
+  * <color:gray>email</color> : VARCHAR(255) <<UNIQUE>>
   avatar : VARCHAR(255)
   role : VARCHAR(20)
   jules_api_key : VARCHAR(255)
@@ -23,20 +23,20 @@ entity "users" {
 }
 
 entity "user_github_accounts" {
-  * <color:grey><i>github_account_id</i></color> : INT <<PK>>
+  * <color:gray><i>github_account_id</i></color> : INT <<PK>>
   --
-  * <color:grey><i>user_id</i></color> : INT <<FK>>
-  * <color:grey>github_username</color> : VARCHAR(255)
+  * <color:gray><i>user_id</i></color> : INT <<FK>>
+  * <color:gray>github_username</color> : VARCHAR(255)
   * github_token : VARCHAR(255)
   created_at : TIMESTAMP
 }
 
 entity "projects" {
-  * <color:grey><i>project_id</i></color> : INT <<PK>>
+  * <color:gray><i>project_id</i></color> : INT <<PK>>
   --
-  * <color:grey><i>user_id</i></color> : INT <<FK>>
-  * <color:grey><i>github_account_id</i></color> : INT <<FK>>
-  * <color:grey>github_repo</color> : VARCHAR(255)
+  * <color:gray><i>user_id</i></color> : INT <<FK>>
+  * <color:gray><i>github_account_id</i></color> : INT <<FK>>
+  * <color:gray>github_repo</color> : VARCHAR(255)
   webhook_secret : VARCHAR(255)
   roadmap_data : TEXT
   roadmap_updated_at : TIMESTAMP
@@ -44,11 +44,11 @@ entity "projects" {
 }
 
 entity "tasks" {
-  * <color:grey><i>task_id</i></color> : INT <<PK>>
+  * <color:gray><i>task_id</i></color> : INT <<PK>>
   --
-  * <color:grey><i>user_id</i></color> : INT <<FK>>
-  * <color:grey><i>project_id</i></color> : INT <<FK>>
-  * <color:grey>issue_number</color> : INT
+  * <color:gray><i>user_id</i></color> : INT <<FK>>
+  * <color:gray><i>project_id</i></color> : INT <<FK>>
+  * <color:gray>issue_number</color> : INT
   * title : VARCHAR(255)
   body : TEXT
   status : VARCHAR(50)
@@ -68,35 +68,35 @@ entity "tasks" {
 }
 
 entity "task_logs" {
-  * <color:grey><i>task_log_id</i></color> : INT <<PK>>
+  * <color:gray><i>task_log_id</i></color> : INT <<PK>>
   --
-  * <color:grey><i>user_id</i></color> : INT <<FK>>
-  * <color:grey><i>task_id</i></color> : INT <<FK>>
+  * <color:gray><i>user_id</i></color> : INT <<FK>>
+  * <color:gray><i>task_id</i></color> : INT <<FK>>
   level : VARCHAR(20)
   * message : TEXT
   created_at : TIMESTAMP
 }
 
 entity "rate_limits" {
-  * <color:grey>rate_key</color> : VARCHAR(255) <<PK>>
+  * <color:gray>rate_key</color> : VARCHAR(255) <<PK>>
   --
   request_count : INT
   * reset_at : TIMESTAMP
 }
 
 entity "user_telegram_accounts" {
-  * <color:grey><i>telegram_account_id</i></color> : INT <<PK>>
+  * <color:gray><i>telegram_account_id</i></color> : INT <<PK>>
   --
-  * <color:grey><i>user_id</i></color> : INT <<FK>>
-  * <color:grey>telegram_chat_id</color> : BIGINT <<UNIQUE>>
+  * <color:gray><i>user_id</i></color> : INT <<FK>>
+  * <color:gray>telegram_chat_id</color> : BIGINT <<UNIQUE>>
   created_at : TIMESTAMP
 }
 
 entity "issue_templates" {
-  * <color:grey><i>issue_template_id</i></color> : INT <<PK>>
+  * <color:gray><i>issue_template_id</i></color> : INT <<PK>>
   --
-  * <color:grey><i>user_id</i></color> : INT <<FK>>
-  * <color:grey>name</color> : VARCHAR(255)
+  * <color:gray><i>user_id</i></color> : INT <<FK>>
+  * <color:gray>name</color> : VARCHAR(255)
   * title_template : VARCHAR(255)
   body_template : TEXT
   parameter_config : TEXT
@@ -104,10 +104,10 @@ entity "issue_templates" {
 }
 
 entity "notifications" {
-  * <color:grey><i>notification_id</i></color> : INT <<PK>>
+  * <color:gray><i>notification_id</i></color> : INT <<PK>>
   --
-  * <color:grey><i>user_id</i></color> : INT <<FK>>
-  * <color:grey><i>project_id</i></color> : INT <<FK>>
+  * <color:gray><i>user_id</i></color> : INT <<FK>>
+  * <color:gray><i>project_id</i></color> : INT <<FK>>
   type : VARCHAR(50)
   title : VARCHAR(255)
   message : TEXT
@@ -117,43 +117,43 @@ entity "notifications" {
 }
 
 entity "user_notification_settings" {
-  * <color:grey><i>user_id</i></color> : INT <<PK>> <<FK>>
-  * <color:grey>channel</color> : VARCHAR(20) <<PK>>
+  * <color:gray><i>user_id</i></color> : INT <<PK>> <<FK>>
+  * <color:gray>channel</color> : VARCHAR(20) <<PK>>
   --
   is_enabled : BOOLEAN
 }
 
 entity "user_event_notification_settings" {
-  * <color:grey><i>user_id</i></color> : INT <<PK>> <<FK>>
-  * <color:grey>notification_type</color> : VARCHAR(50) <<PK>>
+  * <color:gray><i>user_id</i></color> : INT <<PK>> <<FK>>
+  * <color:gray>notification_type</color> : VARCHAR(50) <<PK>>
   --
   is_enabled : BOOLEAN
 }
 
 entity "project_notification_settings" {
-  * <color:grey><i>project_id</i></color> : INT <<PK>> <<FK>>
-  * <color:grey>notification_type</color> : VARCHAR(50) <<PK>>
+  * <color:gray><i>project_id</i></color> : INT <<PK>> <<FK>>
+  * <color:gray>notification_type</color> : VARCHAR(50) <<PK>>
   --
   is_enabled : BOOLEAN
 }
 
 entity "task_notification_settings" {
-  * <color:grey><i>task_id</i></color> : INT <<PK>> <<FK>>
+  * <color:gray><i>task_id</i></color> : INT <<PK>> <<FK>>
   --
   is_muted : BOOLEAN
 }
 
 entity "project_status_notification_settings" {
-  * <color:grey><i>project_id</i></color> : INT <<PK>> <<FK>>
-  * <color:grey>status</color> : VARCHAR(50) <<PK>>
+  * <color:gray><i>project_id</i></color> : INT <<PK>> <<FK>>
+  * <color:gray>status</color> : VARCHAR(50) <<PK>>
   --
   is_enabled : BOOLEAN
 }
 
 entity "webhook_logs" {
-  * <color:grey><i>log_id</i></color> : INT <<PK>>
+  * <color:gray><i>log_id</i></color> : INT <<PK>>
   --
-  * <color:grey><i>user_id</i></color> : INT <<FK>>
+  * <color:gray><i>user_id</i></color> : INT <<FK>>
   endpoint : VARCHAR(50)
   payload : TEXT
   headers : TEXT
@@ -163,9 +163,9 @@ entity "webhook_logs" {
 }
 
 entity "performance_logs" {
-  * <color:grey><i>performance_log_id</i></color> : INT <<PK>>
+  * <color:gray><i>performance_log_id</i></color> : INT <<PK>>
   --
-  * <color:grey><i>user_id</i></color> : INT <<FK>>
+  * <color:gray><i>user_id</i></color> : INT <<FK>>
   type : VARCHAR(50)
   target : TEXT
   duration : FLOAT

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -477,10 +477,10 @@ class Task
         }
 
         if ($status === self::STATUS_CREATED) {
-            return 'grey';
+            return 'gray';
         }
 
-        return 'grey';
+        return 'gray';
     }
 
     public function hasAutorepeatLabel(array $task): bool

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -114,7 +114,7 @@ $errorMessage = $errorMessage ?? null;
         .status-square.red { background-color: #f85149; }
         .status-square.orange { background-color: #f0883e; }
         .status-square.purple { background-color: #8957e5; }
-        .status-square.grey { background-color: #8b949e; }
+        .status-square.gray { background-color: #8b949e; }
         .auto-repeat-tag {
             border: 2px solid #e82dce !important;
             box-sizing: border-box;

--- a/test/Unit/TaskStateTest.php
+++ b/test/Unit/TaskStateTest.php
@@ -81,4 +81,20 @@ class TaskStateTest extends TestCase
         $task['jules_status'] = 'testing';
         $this->assertEquals(Task::STATUS_VERIFYING, $this->taskModel->resolveStatus($task));
     }
+
+    public function testGetStatusColor()
+    {
+        $this->assertEquals('gray', $this->taskModel->getStatusColor(['status' => Task::STATUS_CREATED]));
+        $this->assertEquals('blue', $this->taskModel->getStatusColor(['status' => Task::STATUS_ANALYZING]));
+        $this->assertEquals('blue', $this->taskModel->getStatusColor(['status' => Task::STATUS_PLANNING]));
+        $this->assertEquals('yellow', $this->taskModel->getStatusColor(['status' => Task::STATUS_EXECUTING]));
+        $this->assertEquals('yellow', $this->taskModel->getStatusColor(['status' => Task::STATUS_VERIFYING]));
+        $this->assertEquals('yellow', $this->taskModel->getStatusColor(['status' => Task::STATUS_IMPLEMENTED]));
+        $this->assertEquals('orange', $this->taskModel->getStatusColor(['status' => Task::STATUS_CHECKING]));
+        $this->assertEquals('green', $this->taskModel->getStatusColor(['status' => Task::STATUS_READY]));
+        $this->assertEquals('red', $this->taskModel->getStatusColor(['status' => Task::STATUS_FAILED_JULES]));
+        $this->assertEquals('red', $this->taskModel->getStatusColor(['status' => Task::STATUS_FAILED_PR]));
+        $this->assertEquals('purple', $this->taskModel->getStatusColor(['status' => Task::STATUS_FINISHED, 'github_state' => 'closed']));
+        $this->assertEquals('green', $this->taskModel->getStatusColor(['status' => Task::STATUS_FINISHED, 'github_state' => 'open']));
+    }
 }


### PR DESCRIPTION
I have merged the task state visuals into the main state mapping table in `STATE_EVENTS_CONCEPT.md` and standardized the spelling of 'gray' throughout the repository.

Key changes:
- **STATE_EVENTS_CONCEPT.md**: Combined columns from the visuals table into the primary mapping table in Chapter 1. Added the `IMPLEMENTED` state. Promoted section 5.2 to section 5.
- **UX_DESIGN.md**: Updated color names and emojis to match the unified definitions.
- **Task.php**: Updated `getStatusColor` to return 'gray' and ensured it correctly handles all unified states (ANALYZING/PLANNING as Blue, EXECUTING/VERIFYING/IMPLEMENTED as Yellow).
- **Frontend**: Updated the CSS class in `index.php` to `.gray`.
- **Diagrams**: Updated `TASK_STATE_EVENTS.puml` and `schema.puml` to use 'gray'.
- **Testing**: Added `testGetStatusColor` to `TaskStateTest.php` and verified that all tests pass.

This consolidation ensures visual and logic consistency across the application and its documentation.

Fixes #525

---
*PR created automatically by Jules for task [5179575767036826774](https://jules.google.com/task/5179575767036826774) started by @chatelao*