### PR TITLE
Fix visibility of closed issues in task list views

### DIFF
--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -237,7 +237,7 @@ class NotificationService
         }
 
         // Default settings if not present
-        $statuses = ['researching', 'planning', 'coding', 'testing', 'in_progress', 'implemented', 'completed', 'failed_jules', 'failed_pr'];
+        $statuses = ['researching', 'planning', 'coding', 'testing', 'in_progress', 'implemented', Task::STATUS_FINISHED, 'completed', 'failed_jules', 'failed_pr'];
         foreach ($statuses as $status) {
             if (!isset($settings[$status])) {
                 $settings[$status] = true;

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -111,12 +111,12 @@ class Task
 
         if (!$showAll) {
             $sql .= " AND (t1.github_state = 'open' OR (
-                t1.github_state = 'closed' AND t1.status = '" . self::STATUS_FINISHED . "'
+                t1.github_state = 'closed' AND t1.status IN ('" . self::STATUS_FINISHED . "', 'completed')
                 AND (
                     SELECT COUNT(*) FROM tasks t2
                     WHERE t2.project_id = t1.project_id
                     AND t2.github_state = 'closed'
-                    AND t2.status = '" . self::STATUS_FINISHED . "'
+                    AND t2.status IN ('" . self::STATUS_FINISHED . "', 'completed')
                     AND (t2.created_at > t1.created_at OR (t2.created_at = t1.created_at AND t2.task_id > t1.task_id))
                 ) < 3
             ))";
@@ -146,12 +146,12 @@ class Task
 
         if (!$showAll) {
             $sql .= " AND (t.github_state = 'open' OR (
-                t.github_state = 'closed' AND t.status = '" . self::STATUS_FINISHED . "'
+                t.github_state = 'closed' AND t.status IN ('" . self::STATUS_FINISHED . "', 'completed')
                 AND (
                     SELECT COUNT(*) FROM tasks t3
                     WHERE t3.user_id = ?
                     AND t3.github_state = 'closed'
-                    AND t3.status = '" . self::STATUS_FINISHED . "'
+                    AND t3.status IN ('" . self::STATUS_FINISHED . "', 'completed')
                     AND (t3.created_at > t.created_at OR (t3.created_at = t.created_at AND t3.task_id > t.task_id))
                 ) < 3
             ))";
@@ -616,7 +616,7 @@ class Task
         $issueUrl = "https://github.com/" . ($repo ?? $task['github_repo']) . "/issues/" . $task['issue_number'];
         $status = $task['status'] ?? 'pending';
 
-        if ($status === 'completed' || $status === 'failed_pr') {
+        if ($status === self::STATUS_FINISHED || $status === 'completed' || $status === 'failed_pr') {
             return $task['pr_url'] ?: $issueUrl;
         }
 
@@ -651,12 +651,12 @@ class Task
             $params[] = $projectId;
             $fiveMinutesAgo = date('Y-m-d H:i:s', strtotime('-5 minutes'));
             $sql .= " AND (t.last_synced_at IS NULL OR t.last_synced_at < ?)
-                      AND (t.status NOT IN ('completed', 'failed', 'failed_jules', 'failed_pr') OR t.jules_status NOT IN ('completed', 'failed'))";
+                      AND (t.status NOT IN ('" . self::STATUS_FINISHED . "', 'completed', 'failed', 'failed_jules', 'failed_pr') OR t.jules_status NOT IN ('completed', 'failed'))";
             $params[] = $fiveMinutesAgo;
         } else {
             $fiveMinutesAgo = date('Y-m-d H:i:s', strtotime('-5 minutes'));
             $sql .= " AND (t.last_synced_at IS NULL OR t.last_synced_at < ?)
-                      AND (t.status NOT IN ('completed', 'failed', 'failed_jules', 'failed_pr') OR t.jules_status NOT IN ('completed', 'failed'))";
+                      AND (t.status NOT IN ('" . self::STATUS_FINISHED . "', 'completed', 'failed', 'failed_jules', 'failed_pr') OR t.jules_status NOT IN ('completed', 'failed'))";
             $params[] = $fiveMinutesAgo;
         }
 

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -111,12 +111,12 @@ class Task
 
         if (!$showAll) {
             $sql .= " AND (t1.github_state = 'open' OR (
-                t1.github_state = 'closed' AND t1.status = 'completed'
+                t1.github_state = 'closed' AND t1.status = '" . self::STATUS_FINISHED . "'
                 AND (
                     SELECT COUNT(*) FROM tasks t2
                     WHERE t2.project_id = t1.project_id
                     AND t2.github_state = 'closed'
-                    AND t2.status = 'completed'
+                    AND t2.status = '" . self::STATUS_FINISHED . "'
                     AND (t2.created_at > t1.created_at OR (t2.created_at = t1.created_at AND t2.task_id > t1.task_id))
                 ) < 3
             ))";
@@ -146,12 +146,12 @@ class Task
 
         if (!$showAll) {
             $sql .= " AND (t.github_state = 'open' OR (
-                t.github_state = 'closed' AND t.status = 'completed'
+                t.github_state = 'closed' AND t.status = '" . self::STATUS_FINISHED . "'
                 AND (
                     SELECT COUNT(*) FROM tasks t3
                     WHERE t3.user_id = ?
                     AND t3.github_state = 'closed'
-                    AND t3.status = 'completed'
+                    AND t3.status = '" . self::STATUS_FINISHED . "'
                     AND (t3.created_at > t.created_at OR (t3.created_at = t.created_at AND t3.task_id > t.task_id))
                 ) < 3
             ))";
@@ -326,7 +326,7 @@ class Task
         return $stmt->execute([$status, $id]);
     }
 
-    public function updateAgentResponse(int $id, string $response, string $status = 'completed'): bool
+    public function updateAgentResponse(int $id, string $response, string $status = self::STATUS_FINISHED): bool
     {
         $stmt = $this->db->getConnection()->prepare(
             "UPDATE tasks SET agent_response = ?, status = ? WHERE task_id = ?"

--- a/test/Integration/TaskFilteringTest.php
+++ b/test/Integration/TaskFilteringTest.php
@@ -62,16 +62,16 @@ class TaskFilteringTest extends TestCase
         // Project 1
         $this->createTask(1, 1, 'open', 'pending', '2023-01-01 10:00:00');
         $this->createTask(1, 2, 'open', 'executing', '2023-01-01 11:00:00');
-        $this->createTask(1, 3, 'closed', 'completed', '2023-01-01 12:00:00'); // 5th completed globally
-        $this->createTask(1, 4, 'closed', 'completed', '2023-01-01 13:00:00'); // 4th completed globally
-        $this->createTask(1, 5, 'closed', 'completed', '2023-01-01 14:00:00'); // 3rd completed globally
-        $this->createTask(1, 6, 'closed', 'completed', '2023-01-01 15:00:00'); // 2nd completed globally
+        $this->createTask(1, 3, 'closed', Task::STATUS_FINISHED, '2023-01-01 12:00:00'); // 5th completed globally
+        $this->createTask(1, 4, 'closed', 'completed', '2023-01-01 13:00:00');          // 4th completed globally (legacy)
+        $this->createTask(1, 5, 'closed', Task::STATUS_FINISHED, '2023-01-01 14:00:00'); // 3rd completed globally
+        $this->createTask(1, 6, 'closed', 'completed', '2023-01-01 15:00:00');          // 2nd completed globally (legacy)
         $this->createTask(1, 7, 'closed', 'failed', '2023-01-01 16:00:00');    // failed, should be hidden
 
         // Project 2 (just to test findByUserProjects)
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'repo1'), (2, 1, 'repo2')");
         $this->createTask(2, 10, 'open', 'pending', '2023-01-01 10:00:00');
-        $this->createTask(2, 11, 'closed', 'completed', '2023-01-01 17:00:00'); // 1st completed globally
+        $this->createTask(2, 11, 'closed', Task::STATUS_FINISHED, '2023-01-01 17:00:00'); // 1st completed globally
 
         // Orphan and invalid tasks
         $this->createTask(1, 0, 'open', 'pending', '2023-01-01 18:00:00'); // issue_number 0

--- a/test/Unit/TaskStateTest.php
+++ b/test/Unit/TaskStateTest.php
@@ -105,6 +105,7 @@ class TaskStateTest extends TestCase
         $stmt = $this->createMock(\PDOStatement::class);
 
         $db->method('getConnection')->willReturn($pdo);
+        $stmt->method('fetchAll')->willReturn([]);
 
         $capturedSql = '';
         $pdo->method('prepare')->willReturnCallback(function ($sql) use (&$capturedSql, $stmt) {
@@ -115,8 +116,7 @@ class TaskStateTest extends TestCase
         $taskModel = new Task($db);
         $taskModel->findByProjectId(1, false);
 
-        $this->assertStringContainsString("t1.status = 'finished'", $capturedSql);
-        $this->assertStringNotContainsString("t1.status = 'completed'", $capturedSql);
+        $this->assertStringContainsString("t1.status IN ('finished', 'completed')", $capturedSql);
     }
 
     public function testFindByUserProjectsGeneratesCorrectSql()
@@ -126,6 +126,7 @@ class TaskStateTest extends TestCase
         $stmt = $this->createMock(\PDOStatement::class);
 
         $db->method('getConnection')->willReturn($pdo);
+        $stmt->method('fetchAll')->willReturn([]);
 
         $capturedSql = '';
         $pdo->method('prepare')->willReturnCallback(function ($sql) use (&$capturedSql, $stmt) {
@@ -136,7 +137,6 @@ class TaskStateTest extends TestCase
         $taskModel = new Task($db);
         $taskModel->findByUserProjects(1, false);
 
-        $this->assertStringContainsString("t.status = 'finished'", $capturedSql);
-        $this->assertStringNotContainsString("t.status = 'completed'", $capturedSql);
+        $this->assertStringContainsString("t.status IN ('finished', 'completed')", $capturedSql);
     }
 }

--- a/test/Unit/TaskStateTest.php
+++ b/test/Unit/TaskStateTest.php
@@ -97,4 +97,46 @@ class TaskStateTest extends TestCase
         $this->assertEquals('purple', $this->taskModel->getStatusColor(['status' => Task::STATUS_FINISHED, 'github_state' => 'closed']));
         $this->assertEquals('green', $this->taskModel->getStatusColor(['status' => Task::STATUS_FINISHED, 'github_state' => 'open']));
     }
+
+    public function testFindByProjectIdGeneratesCorrectSql()
+    {
+        $db = $this->createMock(Database::class);
+        $pdo = $this->createMock(\PDO::class);
+        $stmt = $this->createMock(\PDOStatement::class);
+
+        $db->method('getConnection')->willReturn($pdo);
+
+        $capturedSql = '';
+        $pdo->method('prepare')->willReturnCallback(function ($sql) use (&$capturedSql, $stmt) {
+            $capturedSql = $sql;
+            return $stmt;
+        });
+
+        $taskModel = new Task($db);
+        $taskModel->findByProjectId(1, false);
+
+        $this->assertStringContainsString("t1.status = 'finished'", $capturedSql);
+        $this->assertStringNotContainsString("t1.status = 'completed'", $capturedSql);
+    }
+
+    public function testFindByUserProjectsGeneratesCorrectSql()
+    {
+        $db = $this->createMock(Database::class);
+        $pdo = $this->createMock(\PDO::class);
+        $stmt = $this->createMock(\PDOStatement::class);
+
+        $db->method('getConnection')->willReturn($pdo);
+
+        $capturedSql = '';
+        $pdo->method('prepare')->willReturnCallback(function ($sql) use (&$capturedSql, $stmt) {
+            $capturedSql = $sql;
+            return $stmt;
+        });
+
+        $taskModel = new Task($db);
+        $taskModel->findByUserProjects(1, false);
+
+        $this->assertStringContainsString("t.status = 'finished'", $capturedSql);
+        $this->assertStringNotContainsString("t.status = 'completed'", $capturedSql);
+    }
 }


### PR DESCRIPTION
Fixed a bug where closed issues were not showing up in the project/dashboard views because of a mismatch between the hardcoded 'completed' status in SQL queries and the 'finished' status constant used by the application. Updated Task.php to use the STATUS_FINISHED constant consistently and added unit tests to verify the generated SQL.

Fixes #531

---
*PR created automatically by Jules for task [12318061770524316940](https://jules.google.com/task/12318061770524316940) started by @chatelao*