### PR TITLE
Subscribe issue comment webhooks and handle Jules "on it" state changes

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -393,7 +393,7 @@ class GitHubService
                 'secret' => $secret,
                 'insecure_ssl' => '0'
             ],
-            'events' => ['issues', 'check_suite'],
+            'events' => ['issues', 'check_suite', 'issue_comment'],
             'active' => true,
         ]);
     }

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -586,7 +586,7 @@ class Task
     public function extractSessionId(string $text): ?string
     {
         // 1. Markdown links like [Jules Task](.../sessions/ID) or .../task/ID
-        if (preg_match('/jules\.google\.com\/(?:sessions|task)\/([a-zA-Z0-9_-]+)/', $text, $matches)) {
+        if (preg_match('/jules\.(?:google|googleapis)\.com\/(?:v1alpha\/)?(?:sessions|task)\/([a-zA-Z0-9_-]+)/', $text, $matches)) {
             return $matches[1];
         }
 

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -31,6 +31,7 @@ class WebhookHandler
         $issue = $event['issue'] ?? null;
         $pullRequest = $event['pull_request'] ?? null;
         $checkSuite = $event['check_suite'] ?? null;
+        $comment = $event['comment'] ?? null;
 
         // Skip events without an action, except for check_suite which might have different triggers
         if (empty($action) && !$checkSuite) {
@@ -41,6 +42,10 @@ class WebhookHandler
 
         // Don't trigger any notification directly from user triggered actions
         $effectiveNotifService = $this->isUserTriggered($event) ? null : $notificationService;
+
+        if ($comment && $issue) {
+            return $this->handleIssueComment($project, $event, $taskModel, $githubService, $julesService, $effectiveNotifService);
+        }
 
         if ($pullRequest) {
             return $this->handlePullRequest($project, $event, $effectiveNotifService, $githubService);
@@ -227,6 +232,38 @@ class WebhookHandler
                     // Force state_reason to 'completed' because it was merged
                     $pseudoEvent['issue']['state_reason'] = 'completed';
                     $this->maybeDuplicateTask($project, $pseudoEvent, $githubService);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private function handleIssueComment(array $project, array $event, Task $taskModel, ?GitHubService $githubService, ?JulesService $julesService, ?NotificationService $notificationService): bool
+    {
+        $issue = $event['issue'] ?? null;
+        $comment = $event['comment'] ?? null;
+
+        if (!$issue || !$comment) {
+            return true;
+        }
+
+        $login = strtolower($comment['user']['login'] ?? '');
+        $isJulesComment = ($login === 'google-labs-jules[bot]' || $login === 'jules');
+        $body = $comment['body'] ?? '';
+
+        if ($isJulesComment && stripos($body, 'on it') !== false) {
+            $sessionId = $taskModel->extractSessionId($body);
+            if ($sessionId) {
+                $task = $taskModel->findByIssueNumber($project['project_id'], $issue['number']);
+                if ($task) {
+                    $connection = $this->db->getConnection();
+                    $stmt = $connection->prepare("UPDATE tasks SET jules_session_id = ? WHERE task_id = ?");
+                    $stmt->execute([$sessionId, $task['task_id']]);
+
+                    if ($githubService && $julesService) {
+                        $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $notificationService, (int)$task['task_id']);
+                    }
                 }
             }
         }

--- a/test/Unit/WebhookHandlerCommentTest.php
+++ b/test/Unit/WebhookHandlerCommentTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\WebhookHandler;
+use App\Database;
+use App\Task;
+use App\GitHubService;
+use App\JulesService;
+use App\NotificationService;
+use PDO;
+use PDOStatement;
+
+class WebhookHandlerCommentTest extends TestCase
+{
+    private $db;
+    private $handler;
+    private $taskModel;
+    private $githubService;
+    private $julesService;
+    private $notificationService;
+
+    protected function setUp(): void
+    {
+        $this->db = $this->createMock(Database::class);
+        $this->handler = new WebhookHandler($this->db);
+        $this->taskModel = $this->createMock(Task::class);
+        $this->githubService = $this->createMock(GitHubService::class);
+        $this->julesService = $this->createMock(JulesService::class);
+        $this->notificationService = $this->createMock(NotificationService::class);
+    }
+
+    public function testHandleIssueCommentWithOnIt()
+    {
+        $project = [
+            'project_id' => 1,
+            'user_id' => 10,
+            'github_repo' => 'owner/repo'
+        ];
+
+        $event = [
+            'repository' => ['full_name' => 'owner/repo'],
+            'action' => 'created',
+            'issue' => [
+                'number' => 123
+            ],
+            'comment' => [
+                'user' => ['login' => 'google-labs-jules[bot]'],
+                'body' => 'Jules is [on it](https://jules.google.com/sessions/s123). When finished, you will see another comment.'
+            ]
+        ];
+
+        $task = [
+            'task_id' => 456,
+            'project_id' => 1,
+            'issue_number' => 123
+        ];
+
+        // Mock task model methods
+        $this->taskModel->expects($this->once())
+            ->method('extractSessionId')
+            ->with($event['comment']['body'])
+            ->willReturn('s123');
+
+        $this->taskModel->expects($this->once())
+            ->method('findByIssueNumber')
+            ->with(1, 123)
+            ->willReturn($task);
+
+        // Mock DB connection and statement
+        $pdo = $this->createMock(PDO::class);
+        $stmt = $this->createMock(PDOStatement::class);
+
+        $this->db->method('getConnection')->willReturn($pdo);
+        $pdo->method('prepare')->willReturn($stmt);
+        $stmt->expects($this->once())->method('execute')->with(['s123', 456]);
+
+        // Mock refreshJulesStatus
+        $this->taskModel->expects($this->once())
+            ->method('refreshJulesStatus')
+            ->with(10, $this->githubService, $this->julesService, null, 456);
+
+        // We need to inject the mock taskModel into the handler.
+        // Since the handler creates Task internally, we might need to adjust the test or the handler.
+        // Looking at WebhookHandler::handle, it does: $taskModel = new Task($this->db);
+        // This is hard to mock without refactoring.
+        // Let's use a partial mock or reflection if needed, but wait, Task is just a wrapper around DB.
+
+        // Let's test the private handleIssueComment method using reflection to be sure.
+        $reflection = new \ReflectionClass(WebhookHandler::class);
+        $method = $reflection->getMethod('handleIssueComment');
+        $method->setAccessible(true);
+
+        $result = $method->invokeArgs($this->handler, [
+            $project,
+            $event,
+            $this->taskModel,
+            $this->githubService,
+            $this->julesService,
+            null
+        ]);
+
+        $this->assertTrue($result);
+    }
+
+    public function testHandleIssueCommentNotJules()
+    {
+        $project = ['project_id' => 1];
+        $event = [
+            'issue' => ['number' => 123],
+            'comment' => [
+                'user' => ['login' => 'someone-else'],
+                'body' => 'on it'
+            ]
+        ];
+
+        $this->taskModel->expects($this->never())->method('extractSessionId');
+
+        $reflection = new \ReflectionClass(WebhookHandler::class);
+        $method = $reflection->getMethod('handleIssueComment');
+        $method->setAccessible(true);
+
+        $result = $method->invokeArgs($this->handler, [
+            $project,
+            $event,
+            $this->taskModel,
+            $this->githubService,
+            $this->julesService,
+            null
+        ]);
+
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
This change enables real-time synchronization of Jules session states by subscribing to GitHub `issue_comment` webhooks. When the Jules bot comments "Jules is on it", the system now automatically parses the session ID from the comment and triggers a status refresh, moving the task into the appropriate processing state without waiting for the next cron job cycle.

Fixes #532

---
*PR created automatically by Jules for task [13890352237648374300](https://jules.google.com/task/13890352237648374300) started by @chatelao*