### PR TITLE
Extract AG-UI API to api/openapi.yaml

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,603 @@
+openapi: 3.0.3
+info:
+  title: AG-UI Protocol
+  description: The Agent-User Interaction Protocol standardizes how AI agents connect to user-facing applications.
+  version: 1.0.0
+servers:
+  - url: http://localhost:8000
+    description: Default AG-UI server implementation
+paths:
+  /:
+    post:
+      summary: Run Agent
+      description: Initiates an agent run with the provided input and streams events back.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunAgentInput'
+      responses:
+        '200':
+          description: A stream of AG-UI events.
+          content:
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/Event'
+components:
+  schemas:
+    RunAgentInput:
+      type: object
+      required:
+        - threadId
+        - runId
+        - state
+        - messages
+        - tools
+        - context
+        - forwardedProps
+      properties:
+        threadId:
+          type: string
+          description: ID of the conversation thread
+        runId:
+          type: string
+          description: ID of the current run
+        parentRunId:
+          type: string
+          description: ID of the run that spawned this run
+        state:
+          type: object
+          description: Current state of the agent
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+          description: Array of messages in the conversation
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/Tool'
+          description: Array of tools available to the agent
+        context:
+          type: array
+          items:
+            $ref: '#/components/schemas/Context'
+          description: Array of context objects provided to the agent
+        forwardedProps:
+          type: object
+          description: Additional properties forwarded to the agent
+
+    Message:
+      oneOf:
+        - $ref: '#/components/schemas/DeveloperMessage'
+        - $ref: '#/components/schemas/SystemMessage'
+        - $ref: '#/components/schemas/AssistantMessage'
+        - $ref: '#/components/schemas/UserMessage'
+        - $ref: '#/components/schemas/ToolMessage'
+        - $ref: '#/components/schemas/ActivityMessage'
+        - $ref: '#/components/schemas/ReasoningMessage'
+      discriminator:
+        propertyName: role
+        mapping:
+          developer: '#/components/schemas/DeveloperMessage'
+          system: '#/components/schemas/SystemMessage'
+          assistant: '#/components/schemas/AssistantMessage'
+          user: '#/components/schemas/UserMessage'
+          tool: '#/components/schemas/ToolMessage'
+          activity: '#/components/schemas/ActivityMessage'
+          reasoning: '#/components/schemas/ReasoningMessage'
+
+    Role:
+      type: string
+      enum:
+        - developer
+        - system
+        - assistant
+        - user
+        - tool
+        - activity
+        - reasoning
+
+    DeveloperMessage:
+      type: object
+      required: [id, role, content]
+      properties:
+        id: { type: string }
+        role: { type: string, enum: [developer] }
+        content: { type: string }
+        name: { type: string }
+
+    SystemMessage:
+      type: object
+      required: [id, role, content]
+      properties:
+        id: { type: string }
+        role: { type: string, enum: [system] }
+        content: { type: string }
+        name: { type: string }
+
+    AssistantMessage:
+      type: object
+      required: [id, role]
+      properties:
+        id: { type: string }
+        role: { type: string, enum: [assistant] }
+        content: { type: string }
+        name: { type: string }
+        toolCalls:
+          type: array
+          items: { $ref: '#/components/schemas/ToolCall' }
+
+    UserMessage:
+      type: object
+      required: [id, role, content]
+      properties:
+        id: { type: string }
+        role: { type: string, enum: [user] }
+        content:
+          oneOf:
+            - type: string
+            - type: array
+              items: { $ref: '#/components/schemas/InputContent' }
+        name: { type: string }
+
+    ToolMessage:
+      type: object
+      required: [id, role, content, toolCallId]
+      properties:
+        id: { type: string }
+        role: { type: string, enum: [tool] }
+        content: { type: string }
+        toolCallId: { type: string }
+        error: { type: string }
+        encryptedValue: { type: string }
+
+    ActivityMessage:
+      type: object
+      required: [id, role, activityType, content]
+      properties:
+        id: { type: string }
+        role: { type: string, enum: [activity] }
+        activityType: { type: string }
+        content: { type: object }
+
+    ReasoningMessage:
+      type: object
+      required: [id, role, content]
+      properties:
+        id: { type: string }
+        role: { type: string, enum: [reasoning] }
+        content: { type: string }
+        encryptedValue: { type: string }
+
+    InputContent:
+      oneOf:
+        - $ref: '#/components/schemas/TextInputContent'
+        - $ref: '#/components/schemas/ImageInputContent'
+        - $ref: '#/components/schemas/AudioInputContent'
+        - $ref: '#/components/schemas/VideoInputContent'
+        - $ref: '#/components/schemas/DocumentInputContent'
+
+    TextInputContent:
+      type: object
+      required: [type, text]
+      properties:
+        type: { type: string, enum: [text] }
+        text: { type: string }
+
+    ImageInputContent:
+      type: object
+      required: [type, source]
+      properties:
+        type: { type: string, enum: [image] }
+        source: { $ref: '#/components/schemas/InputContentSource' }
+        metadata: { type: object }
+
+    AudioInputContent:
+      type: object
+      required: [type, source]
+      properties:
+        type: { type: string, enum: [audio] }
+        source: { $ref: '#/components/schemas/InputContentSource' }
+        metadata: { type: object }
+
+    VideoInputContent:
+      type: object
+      required: [type, source]
+      properties:
+        type: { type: string, enum: [video] }
+        source: { $ref: '#/components/schemas/InputContentSource' }
+        metadata: { type: object }
+
+    DocumentInputContent:
+      type: object
+      required: [type, source]
+      properties:
+        type: { type: string, enum: [document] }
+        source: { $ref: '#/components/schemas/InputContentSource' }
+        metadata: { type: object }
+
+    InputContentSource:
+      oneOf:
+        - type: object
+          required: [type, value, mimeType]
+          properties:
+            type: { type: string, enum: [data] }
+            value: { type: string }
+            mimeType: { type: string }
+        - type: object
+          required: [type, value]
+          properties:
+            type: { type: string, enum: [url] }
+            value: { type: string }
+            mimeType: { type: string }
+
+    ToolCall:
+      type: object
+      required: [id, type, function]
+      properties:
+        id: { type: string }
+        type: { type: string, enum: [function] }
+        function: { $ref: '#/components/schemas/FunctionCall' }
+        encryptedValue: { type: string }
+
+    FunctionCall:
+      type: object
+      required: [name, arguments]
+      properties:
+        name: { type: string }
+        arguments: { type: string, description: "JSON-encoded string of arguments to the function" }
+
+    Context:
+      type: object
+      required: [description, value]
+      properties:
+        description: { type: string }
+        value: { type: string }
+
+    Tool:
+      type: object
+      required: [name, description, parameters]
+      properties:
+        name: { type: string }
+        description: { type: string }
+        parameters: { type: object, description: "JSON Schema defining the parameters for the tool" }
+
+    Event:
+      oneOf:
+        - $ref: '#/components/schemas/RunStartedEvent'
+        - $ref: '#/components/schemas/RunFinishedEvent'
+        - $ref: '#/components/schemas/RunErrorEvent'
+        - $ref: '#/components/schemas/StepStartedEvent'
+        - $ref: '#/components/schemas/StepFinishedEvent'
+        - $ref: '#/components/schemas/TextMessageStartEvent'
+        - $ref: '#/components/schemas/TextMessageContentEvent'
+        - $ref: '#/components/schemas/TextMessageEndEvent'
+        - $ref: '#/components/schemas/TextMessageChunkEvent'
+        - $ref: '#/components/schemas/ToolCallStartEvent'
+        - $ref: '#/components/schemas/ToolCallArgsEvent'
+        - $ref: '#/components/schemas/ToolCallEndEvent'
+        - $ref: '#/components/schemas/ToolCallResultEvent'
+        - $ref: '#/components/schemas/ToolCallChunkEvent'
+        - $ref: '#/components/schemas/StateSnapshotEvent'
+        - $ref: '#/components/schemas/StateDeltaEvent'
+        - $ref: '#/components/schemas/MessagesSnapshotEvent'
+        - $ref: '#/components/schemas/ActivitySnapshotEvent'
+        - $ref: '#/components/schemas/ActivityDeltaEvent'
+        - $ref: '#/components/schemas/ReasoningStartEvent'
+        - $ref: '#/components/schemas/ReasoningMessageStartEvent'
+        - $ref: '#/components/schemas/ReasoningMessageContentEvent'
+        - $ref: '#/components/schemas/ReasoningMessageEndEvent'
+        - $ref: '#/components/schemas/ReasoningMessageChunkEvent'
+        - $ref: '#/components/schemas/ReasoningEndEvent'
+        - $ref: '#/components/schemas/ReasoningEncryptedValueEvent'
+      discriminator:
+        propertyName: type
+        mapping:
+          RUN_STARTED: '#/components/schemas/RunStartedEvent'
+          RUN_FINISHED: '#/components/schemas/RunFinishedEvent'
+          RUN_ERROR: '#/components/schemas/RunErrorEvent'
+          STEP_STARTED: '#/components/schemas/StepStartedEvent'
+          STEP_FINISHED: '#/components/schemas/StepFinishedEvent'
+          TEXT_MESSAGE_START: '#/components/schemas/TextMessageStartEvent'
+          TEXT_MESSAGE_CONTENT: '#/components/schemas/TextMessageContentEvent'
+          TEXT_MESSAGE_END: '#/components/schemas/TextMessageEndEvent'
+          TEXT_MESSAGE_CHUNK: '#/components/schemas/TextMessageChunkEvent'
+          TOOL_CALL_START: '#/components/schemas/ToolCallStartEvent'
+          TOOL_CALL_ARGS: '#/components/schemas/ToolCallArgsEvent'
+          TOOL_CALL_END: '#/components/schemas/ToolCallEndEvent'
+          TOOL_CALL_RESULT: '#/components/schemas/ToolCallResultEvent'
+          TOOL_CALL_CHUNK: '#/components/schemas/ToolCallChunkEvent'
+          STATE_SNAPSHOT: '#/components/schemas/StateSnapshotEvent'
+          STATE_DELTA: '#/components/schemas/StateDeltaEvent'
+          MESSAGES_SNAPSHOT: '#/components/schemas/MessagesSnapshotEvent'
+          ACTIVITY_SNAPSHOT: '#/components/schemas/ActivitySnapshotEvent'
+          ACTIVITY_DELTA: '#/components/schemas/ActivityDeltaEvent'
+          REASONING_START: '#/components/schemas/ReasoningStartEvent'
+          REASONING_MESSAGE_START: '#/components/schemas/ReasoningMessageStartEvent'
+          REASONING_MESSAGE_CONTENT: '#/components/schemas/ReasoningMessageContentEvent'
+          REASONING_MESSAGE_END: '#/components/schemas/ReasoningMessageEndEvent'
+          REASONING_MESSAGE_CHUNK: '#/components/schemas/ReasoningMessageChunkEvent'
+          REASONING_END: '#/components/schemas/ReasoningEndEvent'
+          REASONING_ENCRYPTED_VALUE: '#/components/schemas/ReasoningEncryptedValueEvent'
+
+    BaseEvent:
+      type: object
+      required: [type]
+      properties:
+        type: { type: string }
+        timestamp: { type: number }
+        rawEvent: { type: object }
+
+    RunStartedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [threadId, runId]
+          properties:
+            type: { type: string, enum: [RUN_STARTED] }
+            threadId: { type: string }
+            runId: { type: string }
+            parentRunId: { type: string }
+            input: { $ref: '#/components/schemas/RunAgentInput' }
+
+    RunFinishedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [threadId, runId]
+          properties:
+            type: { type: string, enum: [RUN_FINISHED] }
+            threadId: { type: string }
+            runId: { type: string }
+            outcome:
+              oneOf:
+                - type: object
+                  required: [type]
+                  properties:
+                    type: { type: string, enum: [success] }
+                - type: object
+                  required: [type, interrupts]
+                  properties:
+                    type: { type: string, enum: [interrupt] }
+                    interrupts: { type: array, items: { type: object } }
+            result: { type: object }
+
+    RunErrorEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [message]
+          properties:
+            type: { type: string, enum: [RUN_ERROR] }
+            message: { type: string }
+            code: { type: string }
+
+    StepStartedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [stepName]
+          properties:
+            type: { type: string, enum: [STEP_STARTED] }
+            stepName: { type: string }
+
+    StepFinishedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [stepName]
+          properties:
+            type: { type: string, enum: [STEP_FINISHED] }
+            stepName: { type: string }
+
+    TextMessageStartEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId, role]
+          properties:
+            type: { type: string, enum: [TEXT_MESSAGE_START] }
+            messageId: { type: string }
+            role: { $ref: '#/components/schemas/Role' }
+
+    TextMessageContentEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId, delta]
+          properties:
+            type: { type: string, enum: [TEXT_MESSAGE_CONTENT] }
+            messageId: { type: string }
+            delta: { type: string }
+
+    TextMessageEndEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId]
+          properties:
+            type: { type: string, enum: [TEXT_MESSAGE_END] }
+            messageId: { type: string }
+
+    TextMessageChunkEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          properties:
+            type: { type: string, enum: [TEXT_MESSAGE_CHUNK] }
+            messageId: { type: string }
+            role: { $ref: '#/components/schemas/Role' }
+            delta: { type: string }
+
+    ToolCallStartEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [toolCallId, toolCallName]
+          properties:
+            type: { type: string, enum: [TOOL_CALL_START] }
+            toolCallId: { type: string }
+            toolCallName: { type: string }
+            parentMessageId: { type: string }
+
+    ToolCallArgsEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [toolCallId, delta]
+          properties:
+            type: { type: string, enum: [TOOL_CALL_ARGS] }
+            toolCallId: { type: string }
+            delta: { type: string }
+
+    ToolCallEndEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [toolCallId]
+          properties:
+            type: { type: string, enum: [TOOL_CALL_END] }
+            toolCallId: { type: string }
+
+    ToolCallResultEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId, toolCallId, content]
+          properties:
+            type: { type: string, enum: [TOOL_CALL_RESULT] }
+            messageId: { type: string }
+            toolCallId: { type: string }
+            content: { type: string }
+            role: { type: string }
+
+    ToolCallChunkEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          properties:
+            type: { type: string, enum: [TOOL_CALL_CHUNK] }
+            toolCallId: { type: string }
+            toolCallName: { type: string }
+            parentMessageId: { type: string }
+            delta: { type: string }
+
+    StateSnapshotEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [snapshot]
+          properties:
+            type: { type: string, enum: [STATE_SNAPSHOT] }
+            snapshot: { type: object }
+
+    StateDeltaEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [delta]
+          properties:
+            type: { type: string, enum: [STATE_DELTA] }
+            delta: { type: array, items: { type: object } }
+
+    MessagesSnapshotEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messages]
+          properties:
+            type: { type: string, enum: [MESSAGES_SNAPSHOT] }
+            messages: { type: array, items: { $ref: '#/components/schemas/Message' } }
+
+    ActivitySnapshotEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId, activityType, content]
+          properties:
+            type: { type: string, enum: [ACTIVITY_SNAPSHOT] }
+            messageId: { type: string }
+            activityType: { type: string }
+            content: { type: object }
+            replace: { type: boolean, default: true }
+
+    ActivityDeltaEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId, activityType, patch]
+          properties:
+            type: { type: string, enum: [ACTIVITY_DELTA] }
+            messageId: { type: string }
+            activityType: { type: string }
+            patch: { type: array, items: { type: object } }
+
+    ReasoningStartEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId]
+          properties:
+            type: { type: string, enum: [REASONING_START] }
+            messageId: { type: string }
+
+    ReasoningMessageStartEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId, role]
+          properties:
+            type: { type: string, enum: [REASONING_MESSAGE_START] }
+            messageId: { type: string }
+            role: { type: string, enum: [reasoning] }
+
+    ReasoningMessageContentEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId, delta]
+          properties:
+            type: { type: string, enum: [REASONING_MESSAGE_CONTENT] }
+            messageId: { type: string }
+            delta: { type: string }
+
+    ReasoningMessageEndEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId]
+          properties:
+            type: { type: string, enum: [REASONING_MESSAGE_END] }
+            messageId: { type: string }
+
+    ReasoningMessageChunkEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId, delta]
+          properties:
+            type: { type: string, enum: [REASONING_MESSAGE_CHUNK] }
+            messageId: { type: string }
+            delta: { type: string }
+
+    ReasoningEndEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [messageId]
+          properties:
+            type: { type: string, enum: [REASONING_END] }
+            messageId: { type: string }
+
+    ReasoningEncryptedValueEvent:
+      allOf:
+        - $ref: '#/components/schemas/BaseEvent'
+        - type: object
+          required: [subtype, entityId, encryptedValue]
+          properties:
+            type: { type: string, enum: [REASONING_ENCRYPTED_VALUE] }
+            subtype: { type: string, enum: [message, tool-call] }
+            entityId: { type: string }
+            encryptedValue: { type: string }


### PR DESCRIPTION
The AG-UI Protocol API has been extracted and formalized into `api/openapi.yaml`. This specification was synthesized from the official AG-UI documentation and SDK types to provide a complete reference for the streaming event-based architecture used by AI agents. It includes definitions for:
- `RunAgentInput`: The standard input payload for agent execution.
- `Message` models: Comprehensive roles including assistant, user, system, tool, activity, and reasoning.
- `Event` models: The full set of protocol events for real-time interaction, lifecycle management, and state synchronization.

This addition ensures that the project has a clear, machine-readable definition of the protocol it implements and supports.

Fixes #535

---
*PR created automatically by Jules for task [12792814459847691364](https://jules.google.com/task/12792814459847691364) started by @chatelao*