### PR TITLE
Fix undefined method call in GitHubService::getCheckSuites

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -53,7 +53,7 @@ class GitHubService
         return $this->apiCall(
             'GitHub API',
             "GET check_suites $repo/commits/$ref",
-            fn() => $this->client->api('repo')->checkSuites()->all($username, $repository, $ref)
+            fn() => $this->client->api('repo')->checkSuites()->allForReference($username, $repository, $ref)
         );
     }
 

--- a/test/Unit/GitHubServiceTest.php
+++ b/test/Unit/GitHubServiceTest.php
@@ -7,6 +7,8 @@ use App\GitHubService;
 use Github\Client;
 use Github\Api\Issue;
 use Github\Api\Issue\Comments;
+use Github\Api\Repo;
+use Github\Api\Repository\Checks\CheckSuites;
 
 class GitHubServiceTest extends TestCase
 {
@@ -36,5 +38,25 @@ class GitHubServiceTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Invalid repository name: invalid-repo");
         $service->postComment('invalid-repo', 123, 'Test comment');
+    }
+
+    public function testGetCheckSuites()
+    {
+        $mockCheckSuites = $this->createMock(CheckSuites::class);
+        $mockCheckSuites->expects($this->once())
+            ->method('allForReference')
+            ->with('owner', 'repo', 'sha')
+            ->willReturn(['check_suites' => []]);
+
+        $mockRepo = $this->createMock(Repo::class);
+        $mockRepo->method('checkSuites')->willReturn($mockCheckSuites);
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->method('api')->with('repo')->willReturn($mockRepo);
+
+        $service = new GitHubService($mockClient);
+        $result = $service->getCheckSuites('owner/repo', 'sha');
+
+        $this->assertEquals(['check_suites' => []], $result);
     }
 }


### PR DESCRIPTION
Fixed a 500 error in `GitHubService::getCheckSuites` caused by calling the undefined method `all()` on the `CheckSuites` API object. Switched to `allForReference()` which is the correct method name in the `knplabs/github-api` library. Added a unit test to `GitHubServiceTest` to ensure the correct method is called.

Fixes #540

---
*PR created automatically by Jules for task [2476548669622571944](https://jules.google.com/task/2476548669622571944) started by @chatelao*