### PR TITLE
Fix task status stuck in 'CHECKING' when no CI is present

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -39,6 +39,8 @@ class Task
             // Check results from check suites
             // Handle both webhook (singular 'check_suite') and API (array 'check_suites')
             $suites = [];
+            $suitesProvided = ($checkSuitesData !== null);
+
             if ($checkSuitesData) {
                 if (isset($checkSuitesData['check_suites'])) {
                     $suites = $checkSuitesData['check_suites'];
@@ -79,7 +81,7 @@ class Task
                     return self::STATUS_CHECKING;
                 }
             } elseif ($julesStatus === 'finished' || $julesStatus === 'completed') {
-                return self::STATUS_CHECKING;
+                return $suitesProvided ? self::STATUS_READY : self::STATUS_CHECKING;
             }
         }
 

--- a/test/Unit/TaskStateTest.php
+++ b/test/Unit/TaskStateTest.php
@@ -37,7 +37,16 @@ class TaskStateTest extends TestCase
     public function testResolveStatusJulesImplementedWithPrNoChecks()
     {
         $task = ['github_state' => 'open', 'jules_status' => 'finished', 'pr_url' => 'https://github.com/owner/repo/pull/1'];
-        $this->assertEquals(Task::STATUS_CHECKING, $this->taskModel->resolveStatus($task));
+        // null means no check suite data fetched yet
+        $this->assertEquals(Task::STATUS_CHECKING, $this->taskModel->resolveStatus($task, null, null));
+    }
+
+    public function testResolveStatusJulesImplementedWithPrEmptyChecks()
+    {
+        $task = ['github_state' => 'open', 'jules_status' => 'finished', 'pr_url' => 'https://github.com/owner/repo/pull/1'];
+        // empty array means data was fetched and there are no check suites
+        $checkSuitesData = ['total_count' => 0, 'check_suites' => []];
+        $this->assertEquals(Task::STATUS_READY, $this->taskModel->resolveStatus($task, null, $checkSuitesData));
     }
 
     public function testResolveStatusWithWebhookCheckSuiteSuccess()


### PR DESCRIPTION
Fixed an issue where task status was stuck in 'CHECKING' when no GitHub check suites were present. Updated `App\Task::resolveStatus` to return `STATUS_READY` when Jules is finished and check suite data is provided but empty. Updated `test/Unit/TaskStateTest.php` with a new test case.

Fixes #539

---
*PR created automatically by Jules for task [13275096429733342243](https://jules.google.com/task/13275096429733342243) started by @chatelao*