### PR TITLE
Fix missing Jules and PR links in task sidebar

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -586,28 +586,35 @@ class Task
     public function extractSessionId(string $text): ?string
     {
         // 1. Markdown links like [Jules Task](.../sessions/ID) or .../task/ID
-        if (preg_match('/jules\.(?:google|googleapis)\.com\/(?:v1alpha\/)?(?:sessions|task)\/([a-zA-Z0-9_-]+)/', $text, $matches)) {
+        if (preg_match('/jules\.(?:google|googleapis)\.com\/(?:v1alpha\/)?(?:sessions|task)\/([a-zA-Z0-9_-]+)/i', $text, $matches)) {
             return $matches[1];
         }
 
         // 2. Explicit task_id or session_id labels
-        if (preg_match('/(?:task_id|session_id|sessionId|taskId)[:=]\s*([a-zA-Z0-9_-]+)/i', $text, $matches)) {
+        if (preg_match('/(?:task_id|session_id|sessionId|taskId)\s*[:=]\s*([a-zA-Z0-9_-]+)/i', $text, $matches)) {
             return $matches[1];
         }
 
         // 3. Look for a long numeric ID that looks like a session ID
-        if (preg_match('/\b(\d{15,25})\b/', $text, $matches)) {
+        if (preg_match('/\b(\d{15,30})\b/', $text, $matches)) {
             return $matches[1];
         }
 
         return null;
     }
 
-    public function extractPrUrl(string $text): ?string
+    public function extractPrUrl(string $text, ?string $repo = null): ?string
     {
-        if (preg_match('/https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/\d+/', $text, $matches)) {
+        // Full URL
+        if (preg_match('/https?:\/\/github\.com\/([^\/]+\/[^\/]+)\/pull\/(\d+)/i', $text, $matches)) {
             return $matches[0];
         }
+
+        // Relative reference like #123 or pull/#123
+        if ($repo && preg_match('/(?:pull\/|#)(\d+)/i', $text, $matches)) {
+            return "https://github.com/$repo/pull/{$matches[1]}";
+        }
+
         return null;
     }
 
@@ -707,41 +714,58 @@ class Task
 
             if (!$sessionId || !$prUrl) {
                 try {
-                    $comments = $githubService->getIssueComments($task['github_repo'], $task['issue_number']);
+                    // Fetch fresh issue to get latest body and possibly PR info
+                    $issue = $githubService->getIssue($task['github_repo'], $task['issue_number']);
 
                     if (!$sessionId) {
-                        // Reverse to find the latest "on it" comment
+                        $sessionId = $this->extractSessionId($issue['body'] ?? '');
+                    }
+
+                    if (!$prUrl) {
+                        $prUrl = $this->extractPrUrl($issue['body'] ?? '', $task['github_repo']);
+                    }
+
+                    $comments = $githubService->getIssueComments($task['github_repo'], $task['issue_number']);
+
+                    // Search for sessionId in comments if not found in body
+                    if (!$sessionId) {
+                        // Reverse to find the latest comment from Jules first
                         $julesComments = array_reverse(array_filter($comments, function ($c) {
                             $login = strtolower($c['user']['login'] ?? '');
-                            return ($login === 'google-labs-jules[bot]' || $login === 'jules') &&
-                                stripos($c['body'] ?? '', 'on it') !== false;
+                            return ($login === 'google-labs-jules[bot]' || $login === 'jules');
                         }));
 
                         foreach ($julesComments as $comment) {
                             $sessionId = $this->extractSessionId($comment['body'] ?? '');
-                            if ($sessionId) {
-                                $updateStmt = $this->db->getConnection()->prepare(
-                                    "UPDATE tasks SET jules_session_id = ? WHERE task_id = ?"
-                                );
-                                $updateStmt->execute([$sessionId, $task['task_id']]);
-                                $task['jules_session_id'] = $sessionId;
-                                break;
+                            if ($sessionId) break;
+                        }
+                    }
+
+                    // Search for prUrl in comments if not found in body
+                    if (!$prUrl) {
+                        // Check if issue object already has a PR link (GitHub does this sometimes)
+                        if (isset($issue['pull_request']['html_url'])) {
+                            $prUrl = $issue['pull_request']['html_url'];
+                        } else {
+                            foreach (array_reverse($comments) as $comment) {
+                                $prUrl = $this->extractPrUrl($comment['body'] ?? '', $task['github_repo']);
+                                if ($prUrl) break;
                             }
                         }
                     }
 
-                    if (!$prUrl) {
-                        foreach ($comments as $comment) {
-                            $prUrl = $this->extractPrUrl($comment['body'] ?? '');
-                            if ($prUrl) {
-                                $updateStmt = $this->db->getConnection()->prepare(
-                                    "UPDATE tasks SET pr_url = ? WHERE task_id = ?"
-                                );
-                                $updateStmt->execute([$prUrl, $task['task_id']]);
-                                $task['pr_url'] = $prUrl;
-                                break;
-                            }
-                        }
+                    // Update database if found
+                    if ($sessionId !== $task['jules_session_id'] || $prUrl !== $task['pr_url']) {
+                        $updateStmt = $this->db->getConnection()->prepare(
+                            "UPDATE tasks SET jules_session_id = ?, pr_url = ? WHERE task_id = ?"
+                        );
+                        $updateStmt->execute([
+                            $sessionId ?: $task['jules_session_id'],
+                            $prUrl ?: $task['pr_url'],
+                            $task['task_id']
+                        ]);
+                        $task['jules_session_id'] = $sessionId ?: $task['jules_session_id'];
+                        $task['pr_url'] = $prUrl ?: $task['pr_url'];
                     }
                 } catch (\Exception $e) {
                     // Log error if needed

--- a/src/frontend/ajax-sync.php
+++ b/src/frontend/ajax-sync.php
@@ -31,6 +31,7 @@ $userId = $auth->getUserId();
 $user = $userModel->findById($userId);
 
 $projectId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$taskId = isset($_GET['task_id']) ? (int)$_GET['task_id'] : 0;
 $julesService = new JulesService(null, $user['jules_api_key'] ?? null);
 $notificationService = new NotificationService($db);
 
@@ -63,7 +64,20 @@ try {
     }
 
     if (!$fast) {
-        if ($projectId > 0) {
+        if ($taskId > 0) {
+            $task = $taskModel->findById($taskId);
+            if ($task && $task['user_id'] === $userId) {
+                $project = $projectModel->findById($task['project_id']);
+                if ($project) {
+                    $githubToken = $project['github_token'] ?? null;
+                    if ($githubToken) {
+                        $githubService = new GitHubService(null, $githubToken);
+                        // Manual sync should not trigger notifications
+                        $taskModel->refreshJulesStatus($userId, $githubService, $julesService, null, $taskId);
+                    }
+                }
+            }
+        } elseif ($projectId > 0) {
             $project = $projectModel->findById($projectId);
             if ($project && $project['user_id'] === $userId) {
                 $githubToken = $project['github_token'] ?? null;

--- a/src/frontend/navbar-icons.php
+++ b/src/frontend/navbar-icons.php
@@ -127,8 +127,17 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
         // Fetch Sync Status
         if (!this.syncStatus) {
             this.syncing = true;
-            const projectId = new URLSearchParams(window.location.search).get('id');
-            const url = (projectId ? 'ajax-sync.php?id=' + projectId : 'ajax-sync.php');
+            const params = new URLSearchParams(window.location.search);
+            const projectId = params.get('id');
+            const isTaskPage = window.location.pathname.includes('task.php');
+
+            let url = 'ajax-sync.php';
+            if (isTaskPage && projectId) {
+                url += '?task_id=' + projectId;
+            } else if (projectId) {
+                url += '?id=' + projectId;
+            }
+
             fetch(basePath + url)
                 .then(res => res.json())
                 .then(data => {

--- a/test/Unit/TaskStateTest.php
+++ b/test/Unit/TaskStateTest.php
@@ -139,4 +139,38 @@ class TaskStateTest extends TestCase
 
         $this->assertStringContainsString("t.status IN ('finished', 'completed')", $capturedSql);
     }
+
+    public function testExtractSessionId()
+    {
+        // Markdown links
+        $this->assertEquals('123456789', $this->taskModel->extractSessionId('Jules session: [link](https://jules.google.com/task/123456789)'));
+        $this->assertEquals('abc-def', $this->taskModel->extractSessionId('https://jules.googleapis.com/v1alpha/sessions/abc-def'));
+
+        // Case insensitivity
+        $this->assertEquals('123', $this->taskModel->extractSessionId('JULES.GOOGLE.COM/TASK/123'));
+
+        // Explicit labels
+        $this->assertEquals('xyz', $this->taskModel->extractSessionId('session_id: xyz'));
+        $this->assertEquals('xyz', $this->taskModel->extractSessionId('taskId=xyz'));
+        $this->assertEquals('xyz', $this->taskModel->extractSessionId('sessionId : xyz'));
+
+        // Long numeric IDs
+        $this->assertEquals('12345678901234567890', $this->taskModel->extractSessionId('Session 12345678901234567890 started'));
+    }
+
+    public function testExtractPrUrl()
+    {
+        // Full URL
+        $url = 'https://github.com/owner/repo/pull/123';
+        $this->assertEquals($url, $this->taskModel->extractPrUrl("PR is at $url"));
+        $this->assertEquals($url, $this->taskModel->extractPrUrl($url));
+
+        // Relative reference with repo context
+        $repo = 'owner/repo';
+        $this->assertEquals("https://github.com/$repo/pull/456", $this->taskModel->extractPrUrl('Fixes #456', $repo));
+        $this->assertEquals("https://github.com/$repo/pull/789", $this->taskModel->extractPrUrl('See pull/789', $repo));
+
+        // No repo context, relative reference should return null
+        $this->assertNull($this->taskModel->extractPrUrl('Fixes #456'));
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where links to the Jules session and the associated GitHub Pull Request were often missing from the task sidebar.

Key improvements:
1. **Robust Extraction**: Updated regex patterns in `App\Task::extractSessionId` and `App\Task::extractPrUrl` to be case-insensitive and handle more variations (including relative references like #123).
2. **Enhanced Discovery**: `App\Task::refreshJulesStatus` now fetches the fresh issue object from GitHub and scans both the body and all Jules comments to discover Session IDs and PR URLs that might have been missed previously.
3. **Targeted Sync**: The frontend synchronization mechanism was updated to specifically refresh the metadata for the current task when viewing a task detail page, ensuring any newly discovered links are displayed immediately.
4. **Verified**: Added unit tests covering multiple extraction scenarios and verified the full test suite passes.

Fixes #541

---
*PR created automatically by Jules for task [5346711285839342911](https://jules.google.com/task/5346711285839342911) started by @chatelao*