### PR TITLE
Handle 'stale' check suite conclusion as non-blocking

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -66,7 +66,7 @@ class Task
                     } elseif (in_array($conclusion, ['failure', 'timed_out', 'cancelled', 'action_required'])) {
                         $failed = true;
                         $success = false;
-                    } elseif ($conclusion !== 'success' && $conclusion !== 'neutral' && $conclusion !== 'skipped') {
+                    } elseif ($conclusion !== 'success' && $conclusion !== 'neutral' && $conclusion !== 'skipped' && $conclusion !== 'stale') {
                         $success = false;
                     }
                 }

--- a/test/Unit/TaskCheckSuiteTest.php
+++ b/test/Unit/TaskCheckSuiteTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\Task;
+use App\Database;
+
+class TaskCheckSuiteTest extends TestCase
+{
+    private $taskModel;
+
+    protected function setUp(): void
+    {
+        $db = $this->createMock(Database::class);
+        $this->taskModel = new Task($db);
+    }
+
+    public function testResolveStatusWithStaleCheckSuite()
+    {
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1',
+            'status' => Task::STATUS_CHECKING
+        ];
+
+        $checkSuitesData = [
+            'check_suites' => [
+                [
+                    'status' => 'completed',
+                    'conclusion' => 'success'
+                ],
+                [
+                    'status' => 'completed',
+                    'conclusion' => 'stale'
+                ]
+            ]
+        ];
+
+        // After fix, 'stale' is handled as successful/non-blocking
+        $status = $this->taskModel->resolveStatus($task, null, $checkSuitesData);
+        $this->assertEquals(Task::STATUS_READY, $status, "Stale check suite should now allow STATUS_READY");
+    }
+
+    public function testResolveStatusWithMultipleSuccessfulSuites()
+    {
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1',
+            'status' => Task::STATUS_CHECKING
+        ];
+
+        $checkSuitesData = [
+            'check_suites' => [
+                [
+                    'status' => 'completed',
+                    'conclusion' => 'success'
+                ],
+                [
+                    'status' => 'completed',
+                    'conclusion' => 'neutral'
+                ]
+            ]
+        ];
+
+        $status = $this->taskModel->resolveStatus($task, null, $checkSuitesData);
+        $this->assertEquals(Task::STATUS_READY, $status);
+    }
+}


### PR DESCRIPTION
This PR fixes a bug where tasks would get stuck in the "checking" state even after CI runs were completed. The cause was the "stale" conclusion for GitHub Check Suites, which occurs when a check is superseded by a newer run. The status resolution logic now treats "stale" as a non-blocking state, similar to "success", "neutral", or "skipped", allowing the task to proceed to "READY" if no other failures are present.

Fixes #547

---
*PR created automatically by Jules for task [2513571009129195725](https://jules.google.com/task/2513571009129195725) started by @chatelao*