### PR TITLE
Fix missing issue and status notifications

### DIFF
--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -355,27 +355,14 @@ class NotificationService
 
     private function getEnabledChannels(int $userId): array
     {
-        $stmt = $this->db->getConnection()->prepare(
-            "SELECT channel FROM user_notification_settings WHERE user_id = ? AND is_enabled = 1"
-        );
-        $stmt->execute([$userId]);
-        $channels = $stmt->fetchAll(PDO::FETCH_COLUMN);
-
-        // In-app channel is always "persisted", but we only explicitly return it if it's not disabled.
-        // Actually, 'in_app' should probably be in user_notification_settings too if they want to toggle it.
-        // If no settings exist, default to in_app enabled.
-        if (empty($channels)) {
-            // Check if user has ANY settings
-            $stmt = $this->db->getConnection()->prepare(
-                "SELECT COUNT(*) FROM user_notification_settings WHERE user_id = ?"
-            );
-            $stmt->execute([$userId]);
-            if ($stmt->fetchColumn() == 0) {
-                return ['in_app'];
+        $settings = $this->getUserSettings($userId);
+        $enabled = [];
+        foreach ($settings as $channel => $isEnabled) {
+            if ($isEnabled) {
+                $enabled[] = $channel;
             }
         }
-
-        return $channels;
+        return $enabled;
     }
 
     public function markAsRead(int $notificationId): bool

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -40,8 +40,8 @@ class WebhookHandler
 
         $taskModel = new Task($this->db);
 
-        // Don't trigger any notification directly from user triggered actions
-        $effectiveNotifService = $this->isUserTriggered($event) ? null : $notificationService;
+        // Use the provided notification service directly
+        $effectiveNotifService = $notificationService;
 
         if ($comment && $issue) {
             return $this->handleIssueComment($project, $event, $taskModel, $githubService, $julesService, $effectiveNotifService);

--- a/src/frontend/cronjob.php
+++ b/src/frontend/cronjob.php
@@ -8,6 +8,7 @@ use App\Project;
 use App\Task;
 use App\GitHubService;
 use App\JulesService;
+use App\NotificationService;
 
 // Basic security check
 $cronSecret = getenv('CRON_SECRET');
@@ -22,6 +23,7 @@ $projectModel = new Project($db);
 $taskModel = new Task($db);
 $githubService = new GitHubService();
 $julesService = new JulesService();
+$notificationService = new NotificationService($db);
 
 $users = $userModel->getAllUsersWithProjectCount();
 
@@ -39,7 +41,7 @@ foreach ($users as $user) {
             $taskModel->syncIssues($userId, $project['project_id'], $project['github_repo'], $scopedGithubService);
 
             $scopedJulesService = new JulesService(null, $user['jules_api_key'] ?? null);
-            $taskModel->refreshJulesStatus($userId, $scopedGithubService, $scopedJulesService, null, null, $project['project_id']);
+            $taskModel->refreshJulesStatus($userId, $scopedGithubService, $scopedJulesService, $notificationService, null, $project['project_id']);
         }
     }
 }

--- a/test/Integration/UserActionNotificationTest.php
+++ b/test/Integration/UserActionNotificationTest.php
@@ -137,11 +137,12 @@ class UserActionNotificationTest extends TestCase
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
     }
 
-    public function testHandleSkipsNotificationForUserSender()
+    public function testHandleSendsNotificationForUserSender()
     {
         $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
         $event = [
             'action' => 'opened',
+            'repository' => ['full_name' => 'owner/repo'],
             'sender' => ['type' => 'User'],
             'issue' => [
                 'number' => 101,
@@ -155,7 +156,7 @@ class UserActionNotificationTest extends TestCase
         $this->webhookHandler->handle($project, $event, null, $this->notificationService);
 
         $stmt = $this->pdo->query("SELECT COUNT(*) FROM notifications");
-        $this->assertEquals(0, $stmt->fetchColumn(), "Notification should NOT be triggered for human user action.");
+        $this->assertEquals(1, $stmt->fetchColumn(), "Notification SHOULD be triggered for human user action.");
     }
 
     public function testHandleSendsNotificationForBotSender()
@@ -201,11 +202,12 @@ class UserActionNotificationTest extends TestCase
         $this->assertEquals(1, $stmt->fetchColumn(), "Notification SHOULD be triggered if sender information is missing (backwards compatibility).");
     }
 
-    public function testHandlePrSkipsNotificationForUserSender()
+    public function testHandlePrSendsNotificationForUserSender()
     {
         $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
         $event = [
             'action' => 'opened',
+            'repository' => ['full_name' => 'owner/repo'],
             'sender' => ['type' => 'User'],
             'pull_request' => [
                 'number' => 201,
@@ -218,6 +220,6 @@ class UserActionNotificationTest extends TestCase
         $this->webhookHandler->handle($project, $event, null, $this->notificationService);
 
         $stmt = $this->pdo->query("SELECT COUNT(*) FROM notifications");
-        $this->assertEquals(0, $stmt->fetchColumn(), "Notification should NOT be triggered for human user PR action.");
+        $this->assertEquals(1, $stmt->fetchColumn(), "Notification SHOULD be triggered for human user PR action.");
     }
 }

--- a/test/Unit/Services/NotificationServiceTest.php
+++ b/test/Unit/Services/NotificationServiceTest.php
@@ -152,7 +152,8 @@ class NotificationServiceTest extends TestCase
     public function testNotifyDoesNotPersistIfInAppDisabled()
     {
         $userId = 1;
-        // Enable only some other channel, implicitly disabling in_app
+        // Explicitly disable in_app
+        $this->pdo->exec("INSERT INTO user_notification_settings (user_id, channel, is_enabled) VALUES ($userId, 'in_app', 0)");
         $this->pdo->exec("INSERT INTO user_notification_settings (user_id, channel, is_enabled) VALUES ($userId, 'other_channel', 1)");
 
         $this->notificationService->notify($userId, 'type', 'title', 'message');


### PR DESCRIPTION
This change fixes a bug where real-world issue and task status notifications were not being delivered to Telegram or the browser, even though the test broadcast worked. 

The fix involves:
1. Ensuring the 'in_app' channel (used for browser notifications) is enabled by default in `NotificationService`. Previously, it was being disabled if any other channel (like Telegram) was added to the settings.
2. Enabling notifications in the background cronjob. Background synchronization was previously passing a null notification service, meaning status changes detected during polling never triggered alerts.
3. Removing over-aggressive suppression of notifications for human-initiated actions in `WebhookHandler`. Users now receive notifications for issues and PRs they or their team open manually.

Tests have been updated and verified to ensure these notifications now flow through correctly.

Fixes #552

---
*PR created automatically by Jules for task [6554242323336763406](https://jules.google.com/task/6554242323336763406) started by @chatelao*