### PR TITLE
Add 'Jules' label to issues created from roadmap

### DIFF
--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -282,7 +282,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_from_roadmap']
             $body = "If none is available, alternativly break down bigger steps to modest ones without implementing anything, just changing the $roadmapName.";
 
             $githubService = new GitHubService(null, $githubToken);
-            $githubService->createIssue($project['github_repo'], $title, $body, []);
+            $githubService->createIssue($project['github_repo'], $title, $body, ['Jules']);
 
             header("Location: project.php?id=$projectId&success=issue_created");
             exit;


### PR DESCRIPTION
Added the 'Jules' label to the `createIssue` call in the `create_from_roadmap` POST handler within `src/frontend/project.php`. This matches the behavior of issue creation from templates and ensures that issues generated from roadmaps are correctly tagged for agent processing. verified via code review and existing unit tests.

Fixes #560

---
*PR created automatically by Jules for task [13237559760421988267](https://jules.google.com/task/13237559760421988267) started by @chatelao*