### PR TITLE
Implement Telegram Chat Cleanup Infrastructure

### DIFF
--- a/CHAT_ROADMAP.md
+++ b/CHAT_ROADMAP.md
@@ -10,6 +10,7 @@
 | 4 | [UC-C2] One-Tap PR Merging | ✅ |
 | 5 | UX & Feedback Loop | 🚧 |
 | 6 | [UC-C3] Quick Task Acknowledgment | ✅ |
+| 7 | [UC-C4] Chat Cleanup | 🚧 |
 
 ## Goals
 
@@ -54,3 +55,9 @@
 - [x] Implement `acknowledge` action handler in `TelegramWebhookHandler`.
 - [x] Define what "Acknowledgment" does in the system (e.g., clear from pending queue).
 - [x] Verify acknowledgment flow from a "New Issue" notification.
+
+## Phase 7: [UC-C4] Chat Cleanup
+- [x] Implement `deleteMessage` in `App\TelegramService`.
+- [x] Capture Telegram `message_id` and `chat_id` in `TelegramChannelHandler` and store in notification metadata.
+- [ ] Implement automatic message deletion when notification is marked as read.
+- [ ] Verify cleanup flow by marking a notification as read and checking Telegram.

--- a/src/backend/TelegramChannelHandler.php
+++ b/src/backend/TelegramChannelHandler.php
@@ -63,10 +63,38 @@ class TelegramChannelHandler implements NotificationChannelInterface
         }
 
         try {
-            return $this->telegramService->withToken($botToken)->sendMessage($chatId, $text, $extraParams);
+            $response = $this->telegramService->withToken($botToken)->sendMessage($chatId, $text, $extraParams);
+
+            // Capture message_id and update notification if available
+            $messageId = $response['result']['message_id'] ?? null;
+            if ($messageId && isset($notification['notification_id'])) {
+                $this->updateNotificationMetadata((int)$notification['notification_id'], (int)$chatId, (int)$messageId);
+            }
+
+            return true;
         } catch (\Exception $e) {
             error_log("Telegram Send Error for user $userId: " . $e->getMessage());
             return false;
         }
+    }
+
+    private function updateNotificationMetadata(int $notificationId, int $chatId, int $messageId): void
+    {
+        $db = $this->userModel->getDb()->getConnection();
+
+        $stmt = $db->prepare("SELECT data FROM notifications WHERE notification_id = ?");
+        $stmt->execute([$notificationId]);
+        $row = $stmt->fetch();
+
+        if (!$row) {
+            return;
+        }
+
+        $data = json_decode($row['data'], true) ?: [];
+        $data['telegram_chat_id'] = $chatId;
+        $data['telegram_message_id'] = $messageId;
+
+        $stmt = $db->prepare("UPDATE notifications SET data = ? WHERE notification_id = ?");
+        $stmt->execute([json_encode($data), $notificationId]);
     }
 }

--- a/src/backend/TelegramService.php
+++ b/src/backend/TelegramService.php
@@ -42,7 +42,7 @@ class TelegramService
     /**
      * @throws Exception
      */
-    public function editMessageText(int $chatId, int $messageId, string $text, array $extraParams = []): bool
+    public function editMessageText(int $chatId, int $messageId, string $text, array $extraParams = []): array
     {
         $params = array_merge([
             'chat_id' => $chatId,
@@ -51,16 +51,14 @@ class TelegramService
             'parse_mode' => 'HTML'
         ], $extraParams);
 
-        $this->apiRequest('editMessageText', $params);
-
-        return true;
+        return $this->apiRequest('editMessageText', $params);
     }
 
     /**
      * @throws GuzzleException
      * @throws Exception
      */
-    public function sendMessage(int $chatId, string $text, array $extraParams = []): bool
+    public function sendMessage(int $chatId, string $text, array $extraParams = []): array
     {
         $params = array_merge([
             'chat_id' => $chatId,
@@ -68,7 +66,20 @@ class TelegramService
             'parse_mode' => 'HTML'
         ], $extraParams);
 
-        $this->apiRequest('sendMessage', $params);
+        return $this->apiRequest('sendMessage', $params);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function deleteMessage(int $chatId, int $messageId): bool
+    {
+        $params = [
+            'chat_id' => $chatId,
+            'message_id' => $messageId,
+        ];
+
+        $this->apiRequest('deleteMessage', $params);
 
         return true;
     }

--- a/test/Integration/NotificationTriggerTest.php
+++ b/test/Integration/NotificationTriggerTest.php
@@ -231,7 +231,7 @@ class NotificationTriggerTest extends TestCase
         $mockWithToken->expects($this->once())
             ->method('sendMessage')
             ->with('12345', $this->anything())
-            ->willReturn(true);
+            ->willReturn(['ok' => true]);
 
         // We need to inject the mocked TelegramService into the NotificationService's channel
         $userModel = new \App\User($this->db);

--- a/test/Unit/Services/TelegramChannelHandlerTest.php
+++ b/test/Unit/Services/TelegramChannelHandlerTest.php
@@ -50,7 +50,7 @@ class TelegramChannelHandlerTest extends TestCase
         $mockService->expects($this->once())
             ->method('sendMessage')
             ->with(123456, $this->stringContains('<b>Test Notification</b>'))
-            ->willReturn(true);
+            ->willReturn(['ok' => true]);
 
         $result = $this->handler->send($notification);
         $this->assertTrue($result);
@@ -143,7 +143,7 @@ class TelegramChannelHandlerTest extends TestCase
         $customService->expects($this->once())
             ->method('sendMessage')
             ->with(123456, $this->stringContains('Test Notification'))
-            ->willReturn(true);
+            ->willReturn(['ok' => true]);
 
         $result = $this->handler->send($notification);
         $this->assertTrue($result);

--- a/test/Unit/Services/TelegramServiceTest.php
+++ b/test/Unit/Services/TelegramServiceTest.php
@@ -14,8 +14,9 @@ class TelegramServiceTest extends TestCase
 {
     public function testSendMessageSuccess()
     {
+        $responseBody = ['ok' => true, 'result' => ['message_id' => 999]];
         $mock = new MockHandler([
-            new Response(200, [], json_encode(['ok' => true])),
+            new Response(200, [], json_encode($responseBody)),
         ]);
 
         $handlerStack = HandlerStack::create($mock);
@@ -24,7 +25,9 @@ class TelegramServiceTest extends TestCase
         $service = new TelegramService($client, 'fake-token');
         $result = $service->sendMessage(123456, 'Hello World');
 
-        $this->assertTrue($result);
+        $this->assertIsArray($result);
+        $this->assertTrue($result['ok']);
+        $this->assertEquals(999, $result['result']['message_id']);
     }
 
     public function testSendMessageApiError()
@@ -60,7 +63,7 @@ class TelegramServiceTest extends TestCase
             function ($request) {
                 $body = json_decode($request->getBody()->getContents(), true);
                 if ($body['reply_markup']['force_reply'] === true) {
-                    return new Response(200, [], json_encode(['ok' => true]));
+                    return new Response(200, [], json_encode(['ok' => true, 'result' => []]));
                 }
                 return new Response(200, [], json_encode(['ok' => false]));
             },
@@ -73,6 +76,40 @@ class TelegramServiceTest extends TestCase
         $result = $service->sendMessage(123456, 'Hello World', [
             'reply_markup' => ['force_reply' => true]
         ]);
+
+        $this->assertIsArray($result);
+        $this->assertTrue($result['ok']);
+    }
+
+    public function testEditMessageTextSuccess()
+    {
+        $responseBody = ['ok' => true, 'result' => ['message_id' => 123, 'text' => 'Updated']];
+        $mock = new MockHandler([
+            new Response(200, [], json_encode($responseBody)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $service = new TelegramService($client, 'fake-token');
+        $result = $service->editMessageText(123456, 123, 'Updated');
+
+        $this->assertIsArray($result);
+        $this->assertTrue($result['ok']);
+        $this->assertEquals('Updated', $result['result']['text']);
+    }
+
+    public function testDeleteMessageSuccess()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode(['ok' => true, 'result' => true])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $service = new TelegramService($client, 'fake-token');
+        $result = $service->deleteMessage(123456, 123);
 
         $this->assertTrue($result);
     }


### PR DESCRIPTION
I have implemented the infrastructure for **[UC-C4] Chat Cleanup**, a key feature in the Telegram Chat Control roadmap. 

This phase focuses on tracking Telegram messages so they can be automatically deleted when notifications are marked as read.

### Changes:
1.  **Roadmap Update**: Added "Phase 7: [UC-C4] Chat Cleanup" to `CHAT_ROADMAP.md`.
2.  **Service Enhancements**:
    -   Implemented `App\TelegramService::deleteMessage(int $chatId, int $messageId)`.
    -   Modified `sendMessage` and `editMessageText` in `TelegramService` to return the full API response array instead of just a boolean, enabling access to the `message_id` returned by Telegram.
3.  **Metadata Tracking**:
    -   Updated `App\TelegramChannelHandler` to capture the `message_id` from the Telegram API response.
    -   Added logic to store `telegram_chat_id` and `telegram_message_id` in the `data` JSON column of the `notifications` table immediately after sending.
4.  **Testing**:
    -   Updated `test/Unit/Services/TelegramServiceTest.php` and `test/Unit/Services/TelegramChannelHandlerTest.php` to match the new return types.
    -   Updated `test/Integration/NotificationTriggerTest.php` to fix mock return types.
    -   Verified that all 160 tests in the project pass successfully.

Fixes #559

---
*PR created automatically by Jules for task [13167335299155262961](https://jules.google.com/task/13167335299155262961) started by @chatelao*