### PR TITLE
Standardize Notification Formatting with Repository Name

### DIFF
--- a/UX_CONCEPT.md
+++ b/UX_CONCEPT.md
@@ -45,3 +45,13 @@ A user receives a Telegram notification that a Jules session has failed. Instead
 
 ### <a name="UC-UX4"></a>Template-Driven Workflow (UC-UX4)
 To start a recurring task, a user selects a pre-defined "Feature Request" template on the project page. They fill in 1-2 parameters (e.g., Feature Name) and tap "Create". The system handles GitHub issue creation and agent triggering automatically.
+
+## UX/Formatting
+
+### 1. Multi-Line Notifications
+To provide clear context and maintain continuity across channels, all notifications follow a standardized three-line structure:
+1.  **Line 1: Title & Emoji**: A brief, emoji-prefixed summary of the event (e.g., `✅ Task Completed: #123`).
+2.  **Line 2: Context (Repository)**: The name of the GitHub repository where the event occurred (italicized or secondary text).
+3.  **Line 3: Detail Message**: A descriptive sentence explaining the specific change or action required.
+
+A blank line is inserted between the Context and the Detail Message in Telegram and long-form views to improve readability.

--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -19,6 +19,16 @@ class NotificationService
 
     public function notify(int $userId, string $type, string $title, string $message, array $data = [], array $actions = []): bool
     {
+        // 0. Auto-populate github_repo if project_id is present
+        if (isset($data['project_id']) && !isset($data['github_repo'])) {
+            $stmt = $this->db->getConnection()->prepare("SELECT github_repo FROM projects WHERE project_id = ?");
+            $stmt->execute([$data['project_id']]);
+            $repo = $stmt->fetchColumn();
+            if ($repo) {
+                $data['github_repo'] = $repo;
+            }
+        }
+
         // 1. Check task-level mute (if task_id is provided)
         if (isset($data['task_id']) && $this->isTaskMuted($data['task_id'])) {
             return false;
@@ -385,9 +395,28 @@ class NotificationService
     public function getNotifications(int $userId, int $limit = 50, int $offset = 0): array
     {
         $stmt = $this->db->getConnection()->prepare(
-            "SELECT * FROM notifications WHERE user_id = ? ORDER BY created_at DESC, notification_id DESC LIMIT ? OFFSET ?"
+            "SELECT n.*, p.github_repo
+             FROM notifications n
+             LEFT JOIN projects p ON n.project_id = p.project_id
+             WHERE n.user_id = ?
+             ORDER BY n.created_at DESC, n.notification_id DESC
+             LIMIT ? OFFSET ?"
         );
         $stmt->execute([$userId, $limit, $offset]);
+        return $stmt->fetchAll();
+    }
+
+    public function getLatestUnread(int $userId, int $limit = 5): array
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "SELECT n.*, p.github_repo
+             FROM notifications n
+             LEFT JOIN projects p ON n.project_id = p.project_id
+             WHERE n.user_id = ? AND n.is_read = 0
+             ORDER BY n.created_at DESC, n.notification_id DESC
+             LIMIT ?"
+        );
+        $stmt->execute([$userId, $limit]);
         return $stmt->fetchAll();
     }
 

--- a/src/backend/TelegramChannelHandler.php
+++ b/src/backend/TelegramChannelHandler.php
@@ -31,12 +31,16 @@ class TelegramChannelHandler implements NotificationChannelInterface
 
         $taskModel = new Task($this->userModel->getDb());
         $title = htmlspecialchars($notification['title']);
+        $repo = $notification['data']['github_repo'] ?? '';
         // convertImagesToLinks already performs htmlspecialchars on non-link text
         $message = $taskModel->convertImagesToLinks($notification['message']);
         $sourceUrl = $notification['data']['source_url'] ?? null;
 
-        $text = "<b>" . $title . "</b>\n\n";
-        $text .= $message;
+        $text = "<b>" . $title . "</b>\n";
+        if ($repo) {
+            $text .= "<i>" . htmlspecialchars($repo) . "</i>\n";
+        }
+        $text .= "\n" . $message;
 
         if ($sourceUrl) {
             $text .= "\n\n<a href=\"" . htmlspecialchars($sourceUrl) . "\">View Source</a>";

--- a/src/frontend/ajax-notifications.php
+++ b/src/frontend/ajax-notifications.php
@@ -40,11 +40,7 @@ try {
         $latestUnread = [];
         if ($unreadCount > 0) {
             // Get latest 5 unread notifications
-            $stmt = $db->getConnection()->prepare(
-                "SELECT * FROM notifications WHERE user_id = ? AND is_read = 0 ORDER BY created_at DESC, notification_id DESC LIMIT 5"
-            );
-            $stmt->execute([$userId]);
-            $latestUnread = $stmt->fetchAll();
+            $latestUnread = $notificationService->getLatestUnread($userId, 5);
             foreach ($latestUnread as &$n) {
                 if (isset($n['data']) && is_string($n['data'])) {
                     $n['data'] = json_decode($n['data'], true);
@@ -52,7 +48,7 @@ try {
                 // We keep titles/messages raw for browser notifications (browser handles escaping)
                 // but we process GitHub images if they are embedded.
                 $n['title_plain'] = strip_tags($n['title']);
-                $n['message_plain'] = strip_tags($n['message']);
+                $n['message_plain'] = ($n['github_repo'] ? ($n['github_repo'] . "\n") : "") . strip_tags($n['message']);
             }
         }
 

--- a/src/frontend/navbar-icons.php
+++ b/src/frontend/navbar-icons.php
@@ -276,6 +276,9 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
                             <div class="text-xs font-bold text-gray-900 markdown-body" x-html="n.title"></div>
                             <span class="text-[10px] text-gray-400 shrink-0 ml-2" x-text="new Date(n.created_at).toLocaleDateString()"></span>
                         </div>
+                        <template x-if="n.github_repo">
+                            <div class="text-[10px] text-gray-500 italic mt-0.5" x-text="n.github_repo"></div>
+                        </template>
                         <div class="text-xs text-gray-600 mt-1 markdown-body" x-html="n.message"></div>
                         <template x-if="!n.is_read">
                             <div class="absolute top-3 right-3 w-2 h-2 bg-blue-600 rounded-full"></div>

--- a/src/frontend/notifications.php
+++ b/src/frontend/notifications.php
@@ -139,6 +139,9 @@ $totalPages = ceil($totalNotifications / $limit);
                                                         <span class="ml-2 w-2 h-2 bg-blue-600 rounded-full"></span>
                                                     <?php endif; ?>
                                                 </div>
+                                                <?php if (!empty($n['github_repo'])) : ?>
+                                                    <div class="text-xs text-gray-500 italic mt-0.5"><?= htmlspecialchars($n['github_repo']) ?></div>
+                                                <?php endif; ?>
                                                 <div class="text-sm text-gray-600 mt-1 markdown-body">
                                                     <?= $parsedown->text($taskModel->processGitHubImages($n['message'])) ?>
                                                 </div>

--- a/test/Unit/Services/NotificationServiceTest.php
+++ b/test/Unit/Services/NotificationServiceTest.php
@@ -37,11 +37,18 @@ class NotificationServiceTest extends TestCase
         $this->pdo->exec("DROP TABLE IF EXISTS project_notification_settings");
         $this->pdo->exec("DROP TABLE IF EXISTS user_event_notification_settings");
         $this->pdo->exec("DROP TABLE IF EXISTS task_notification_settings");
+        $this->pdo->exec("DROP TABLE IF EXISTS projects");
         $this->pdo->exec("DROP TABLE IF EXISTS users");
 
         $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
 
         $this->pdo->exec("CREATE TABLE users (user_id $pk, google_id VARCHAR(255) UNIQUE, name VARCHAR(255), email VARCHAR(255))");
+
+        $this->pdo->exec("CREATE TABLE projects (
+            project_id $pk,
+            user_id INT,
+            github_repo VARCHAR(255)
+        )");
 
         $this->pdo->exec("CREATE TABLE notifications (
             notification_id $pk,


### PR DESCRIPTION
Standardized notification formatting across all channels (Web, Telegram, Browser) to include the repository name on the second line. Documented this new standard in the UX concept.

Fixes #563

---
*PR created automatically by Jules for task [10953777329640873627](https://jules.google.com/task/10953777329640873627) started by @chatelao*