### PR TITLE
Link Notification and State-Event Concepts and Refine Broadcasting Logic

### DIFF
--- a/NOTIF_CONCEPT.md
+++ b/NOTIF_CONCEPT.md
@@ -1,5 +1,8 @@
 # Concept: Notifications System
 
+### Related Concepts
+- **[On-Event and On-State Behaviors (STATE_EVENTS_CONCEPT.md)](STATE_EVENTS_CONCEPT.md)**: The primary concept defining the states and events that trigger notifications. This document must be adjusted if `STATE_EVENTS_CONCEPT.md` is updated.
+
 ## Overview
 The notification system aims to keep users informed about critical events across their projects and tasks. It provides a multi-channel approach to ensure timely updates whether the user is actively using the dashboard or is on the move.
 
@@ -27,6 +30,11 @@ Notifications are generated consistently across multiple event sources (Event So
 -   **Real-time Webhooks**: Immediate triggers from incoming GitHub or CI/CD webhooks.
 -   **Backend Polling (`cronjob.php`)**: Periodic synchronization that detects changes missed by webhooks.
 -   **Manual Refreshes (`project.php`)**: User-initiated synchronizations that refresh project and task states.
+
+### Broadcasting Logic
+To minimize notification noise, the system distinguishes between **In-App Inbox** notifications (all events) and **External Broadcasts** (Telegram/Browser).
+- Only **System-triggered** events with a need for **human follow-up** (e.g., Fails, Ready-to-merge PRs) are broadcasted.
+- Human-initiated actions do not trigger broadcasts to avoid redundant alerts for the active user.
 
 ## Use Cases
 -   **<a name="UC-N1"></a>Jump to Source (Deep Linking) (UC-N1)**: A user clicks on a "PR Available" notification and is immediately taken to the corresponding GitHub Pull Request page.

--- a/STATE_EVENTS_CONCEPT.md
+++ b/STATE_EVENTS_CONCEPT.md
@@ -2,6 +2,9 @@
 
 This document describes the reactive behaviors of the Agent Control application, detailing how it responds to external events and how it behaves based on its internal state.
 
+### Related Concepts
+- **[Notifications System (NOTIF_CONCEPT.md)](NOTIF_CONCEPT.md)**: Describes how state transitions and events trigger user alerts. (Secondary concept).
+
 ## 1. Unified Task State Mapping
 
 The application defines a set of unified task states to provide a consistent view of progress across different external tools (GitHub, Jules). These states represent the "Source of Truth" for the task's lifecycle and include a shared set of visual indicators (Colors and Emojis) used across the web dashboard and Telegram.
@@ -124,3 +127,41 @@ The system exhibits different behaviors and interactive options depending on the
 
 - **Merge & Close**: Only available if state is `READY`, PR is mergeable and checks passed.
 - **Retry / Restart**: Only available when state is `FAILED`.
+
+## 6. Notifications & Broadcasts
+
+The application triggers notifications for state transitions and external events. A "Broadcast" is a notification sent to external channels (Telegram, Browser), while all notifications are persisted in the In-App Inbox.
+
+### 6.1 State Transition Notifications
+
+| Unified State | Notification | Broadcast (Default) | Human Follow-up Required |
+| :--- | :---: | :---: | :--- |
+| `CREATED` | Yes | No | No |
+| `ANALYZING` | Yes | No | No |
+| `PLANNING` | Yes | No | No |
+| `EXECUTING` | Yes | No | No |
+| `VERIFYING` | Yes | No | No |
+| `IMPLEMENTED` | Yes | No | No |
+| `CHECKING` | Yes | No | No |
+| `READY` | Yes | **Yes** | **Yes** (Merge needed) |
+| `FINISHED` | Yes | No | No (FYI) |
+| `FAILED_JULES` | Yes | **Yes** | **Yes** (Retry/Restart needed) |
+| `FAILED_PR` | Yes | **Yes** | **Yes** (Fix needed) |
+
+### 6.2 Event Trigger Sources
+
+Only system-triggered events with a need for human follow-up are typically broadcast to external channels to minimize noise.
+
+| Event | Trigger Source | Follow-up Needed | Broadcast |
+| :--- | :--- | :---: | :---: |
+| **Issue Opened** | User (GitHub) | No | No |
+| **Issue Closed** | User (GitHub) / System (Merge) | No | No |
+| **Issue Reopened** | User (GitHub) | No | No |
+| **Issue Deleted** | User (GitHub) | No | No |
+| **PR Created** | System (Jules) | No | No |
+| **PR Merged** | User (UI) / System (Auto) | No | No |
+| **Agent Started** | User (UI) / System (Label) | No | No |
+| **Agent Completed**| System (Jules) | No | No |
+| **Check Suite Fail**| System (GitHub CI) | **Yes** | **Yes** |
+| **Check Suite Pass**| System (GitHub CI) | **Yes** | **Yes** |
+| **Auto-Repeat** | System | **Yes** | **Yes** |

--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -53,6 +53,33 @@ class NotificationService
             $shouldBroadcast = $this->isStatusBroadcastEnabled((int)$data['project_id'], $data['status']);
         }
 
+        // 6.1 Only system-triggered events with human follow-up are broadcasted
+        // If is_system is explicitly set to false, it's a human action -> no broadcast
+        if (!isset($data['is_system']) || $data['is_system'] === false) {
+            $shouldBroadcast = false;
+        }
+
+        // 6.2 Filter non-actionable system events
+        // Even if it's a system event, only broadcast if it needs human follow-up
+        if ($shouldBroadcast) {
+            $actionableTypes = ['task_status', 'github_issue', 'github_pr'];
+            if (!in_array($type, $actionableTypes)) {
+                $shouldBroadcast = false;
+            }
+
+            // For task_status, only specific states need follow-up
+            if ($type === 'task_status' && isset($data['status'])) {
+                $actionableStatuses = [
+                    Task::STATUS_READY,
+                    Task::STATUS_FAILED_JULES,
+                    Task::STATUS_FAILED_PR
+                ];
+                if (!in_array($data['status'], $actionableStatuses)) {
+                    $shouldBroadcast = false;
+                }
+            }
+        }
+
         if (!$shouldBroadcast) {
             return true;
         }
@@ -237,10 +264,31 @@ class NotificationService
         }
 
         // Default settings if not present
-        $statuses = ['researching', 'planning', 'coding', 'testing', 'in_progress', 'implemented', Task::STATUS_FINISHED, 'completed', 'failed_jules', 'failed_pr'];
+        $statuses = [
+            Task::STATUS_CREATED,
+            Task::STATUS_ANALYZING,
+            Task::STATUS_PLANNING,
+            Task::STATUS_EXECUTING,
+            Task::STATUS_VERIFYING,
+            Task::STATUS_IMPLEMENTED,
+            Task::STATUS_CHECKING,
+            Task::STATUS_READY,
+            Task::STATUS_FINISHED,
+            Task::STATUS_FAILED_JULES,
+            Task::STATUS_FAILED_PR
+        ];
+
+        // Actionable states default to broadcast enabled
+        $broadcastByDefault = [
+            Task::STATUS_READY,
+            Task::STATUS_FAILED_JULES,
+            Task::STATUS_FAILED_PR
+        ];
+
         foreach ($statuses as $status) {
-            if (!isset($settings[$status])) {
-                $settings[$status] = true;
+            $normalizedStatus = str_replace('-', '_', $status);
+            if (!isset($settings[$normalizedStatus])) {
+                $settings[$normalizedStatus] = in_array($status, $broadcastByDefault);
             }
         }
 

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -849,7 +849,8 @@ class Task
                         'task_id' => $task['task_id'],
                         'project_id' => $task['project_id'],
                         'status' => $mappedStatus,
-                        'source_url' => $this->getTargetUrl(array_merge($task, ['status' => $mappedStatus]))
+                        'source_url' => $this->getTargetUrl(array_merge($task, ['status' => $mappedStatus])),
+                        'is_system' => true // Polling/Sync is system-driven
                     ], $actions);
                 }
             } else {

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -65,7 +65,8 @@ class WebhookHandler
                 $effectiveNotifService->notify($project['user_id'], 'github_issue', "🗑️ Issue Deleted: #" . $issue['number'], "Issue \"" . ($issue['title'] ?? 'Unknown') . "\" was deleted in " . $project['github_repo'], [
                     'project_id' => $project['project_id'],
                     'issue_number' => $issue['number'],
-                    'source_url' => $issue['html_url'] ?? ''
+                    'source_url' => $issue['html_url'] ?? '',
+                    'is_system' => !$this->isUserTriggered($event)
                 ]);
             }
             return $result;
@@ -87,7 +88,8 @@ class WebhookHandler
                 'task_id' => $task['task_id'],
                 'project_id' => $project['project_id'],
                 'issue_number' => $issue['number'],
-                'source_url' => $issue['html_url']
+                'source_url' => $issue['html_url'],
+                'is_system' => !$this->isUserTriggered($event)
             ];
 
             if ($action === 'opened') {
@@ -100,13 +102,13 @@ class WebhookHandler
         }
 
         if ($result && $action === 'closed' && $githubService) {
-            $this->maybeDuplicateTask($project, $event, $githubService);
+            $this->maybeDuplicateTask($project, $event, $githubService, $effectiveNotifService);
         }
 
         return $result;
     }
 
-    private function maybeDuplicateTask(array $project, array $event, GitHubService $githubService): void
+    private function maybeDuplicateTask(array $project, array $event, GitHubService $githubService, ?NotificationService $notificationService = null): void
     {
         $issue = $event['issue'] ?? null;
         if (!$issue) {
@@ -182,6 +184,15 @@ class WebhookHandler
 
             $githubService->createIssue($repo, $issue['title'], $issue['body'] ?? null, array_values($labelNames));
             $githubService->removeLabel($repo, $issue['number'], $autorepeatLabelName);
+
+            if ($notificationService) {
+                $notificationService->notify($project['user_id'], 'github_issue', "🔁 Auto-Repeat: #" . $issue['number'], "Task \"" . $issue['title'] . "\" was merged/closed with Auto-Repeat. A new issue has been created.", [
+                    'project_id' => $project['project_id'],
+                    'issue_number' => $issue['number'],
+                    'source_url' => $issue['html_url'] ?? '',
+                    'is_system' => true
+                ]);
+            }
         }
     }
 
@@ -215,7 +226,8 @@ class WebhookHandler
             $notificationService->notify($project['user_id'], 'github_pr', "$emoji PR $actionText: #" . $pr['number'], "Pull Request \"" . $pr['title'] . "\" was $actionText in " . $project['github_repo'], [
                 'project_id' => $project['project_id'],
                 'pr_number' => $pr['number'],
-                'source_url' => $pr['html_url']
+                'source_url' => $pr['html_url'],
+                'is_system' => !$this->isUserTriggered($event)
             ]);
         }
 
@@ -231,7 +243,7 @@ class WebhookHandler
                     $pseudoEvent['issue'] = $githubData;
                     // Force state_reason to 'completed' because it was merged
                     $pseudoEvent['issue']['state_reason'] = 'completed';
-                    $this->maybeDuplicateTask($project, $pseudoEvent, $githubService);
+                    $this->maybeDuplicateTask($project, $pseudoEvent, $githubService, $notificationService);
                 }
             }
         }
@@ -325,7 +337,8 @@ class WebhookHandler
                         'task_id' => $task['task_id'],
                         'project_id' => $task['project_id'],
                         'status' => $newStatus,
-                        'source_url' => $taskModel->getTargetUrl(array_merge($task, ['status' => $newStatus]))
+                        'source_url' => $taskModel->getTargetUrl(array_merge($task, ['status' => $newStatus])),
+                        'is_system' => true // Check suite events are always system-driven
                     ], $actions);
                 }
             }

--- a/src/frontend/project-settings.php
+++ b/src/frontend/project-settings.php
@@ -69,15 +69,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_notifications'
     ];
 
     $statusSettings = [
-        'researching' => isset($_POST['broadcast_researching']),
-        'planning' => isset($_POST['broadcast_planning']),
-        'coding' => isset($_POST['broadcast_coding']),
-        'testing' => isset($_POST['broadcast_testing']),
-        'in_progress' => isset($_POST['broadcast_in_progress']),
-        'implemented' => isset($_POST['broadcast_implemented']),
-        'completed' => isset($_POST['broadcast_completed']),
-        'failed_jules' => isset($_POST['broadcast_failed_jules']),
-        'failed_pr' => isset($_POST['broadcast_failed_pr'])
+        str_replace('-', '_', Task::STATUS_CREATED) => isset($_POST['broadcast_' . Task::STATUS_CREATED]),
+        str_replace('-', '_', Task::STATUS_ANALYZING) => isset($_POST['broadcast_' . Task::STATUS_ANALYZING]),
+        str_replace('-', '_', Task::STATUS_PLANNING) => isset($_POST['broadcast_' . Task::STATUS_PLANNING]),
+        str_replace('-', '_', Task::STATUS_EXECUTING) => isset($_POST['broadcast_' . Task::STATUS_EXECUTING]),
+        str_replace('-', '_', Task::STATUS_VERIFYING) => isset($_POST['broadcast_' . Task::STATUS_VERIFYING]),
+        str_replace('-', '_', Task::STATUS_IMPLEMENTED) => isset($_POST['broadcast_' . Task::STATUS_IMPLEMENTED]),
+        str_replace('-', '_', Task::STATUS_CHECKING) => isset($_POST['broadcast_' . Task::STATUS_CHECKING]),
+        str_replace('-', '_', Task::STATUS_READY) => isset($_POST['broadcast_' . Task::STATUS_READY]),
+        str_replace('-', '_', Task::STATUS_FINISHED) => isset($_POST['broadcast_' . Task::STATUS_FINISHED]),
+        str_replace('-', '_', Task::STATUS_FAILED_JULES) => isset($_POST['broadcast_' . Task::STATUS_FAILED_JULES]),
+        str_replace('-', '_', Task::STATUS_FAILED_PR) => isset($_POST['broadcast_' . Task::STATUS_FAILED_PR])
     ];
 
     if (
@@ -328,22 +330,25 @@ if (isset($_GET['success'])) {
                                     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
                                         <?php
                                         $statuses = [
-                                            'researching' => 'Researching',
-                                            'planning' => 'Planning',
-                                            'coding' => 'Coding',
-                                            'testing' => 'Testing',
-                                            'in_progress' => 'In Progress',
-                                            'implemented' => 'Implemented',
-                                            'completed' => 'Completed',
-                                            'failed_jules' => 'Jules Failed',
-                                            'failed_pr' => 'PR Failed'
+                                            Task::STATUS_CREATED => 'Waiting for Agent',
+                                            Task::STATUS_ANALYZING => 'Analyzing',
+                                            Task::STATUS_PLANNING => 'Planning',
+                                            Task::STATUS_EXECUTING => 'Executing',
+                                            Task::STATUS_VERIFYING => 'Verifying',
+                                            Task::STATUS_IMPLEMENTED => 'Implemented',
+                                            Task::STATUS_CHECKING => 'Checking',
+                                            Task::STATUS_READY => 'Ready',
+                                            Task::STATUS_FINISHED => 'Finished',
+                                            Task::STATUS_FAILED_JULES => 'Jules Failed',
+                                            Task::STATUS_FAILED_PR => 'PR Failed'
                                         ];
                                         foreach ($statuses as $id => $label) :
+                                            $normalizedId = str_replace('-', '_', $id);
                                             ?>
                                         <div class="flex items-center justify-between p-2 bg-gray-50 rounded-lg border border-gray-100 shadow-sm">
                                             <span class="text-xs font-medium text-gray-600"><?= $label ?></span>
                                             <label class="relative inline-flex items-center cursor-pointer scale-75">
-                                                <input type="checkbox" name="broadcast_<?= $id ?>" class="sr-only peer" <?= ($statusNotifSettings[$id] ?? true) ? 'checked' : '' ?>>
+                                                <input type="checkbox" name="broadcast_<?= $id ?>" class="sr-only peer" <?= ($statusNotifSettings[$normalizedId] ?? false) ? 'checked' : '' ?>>
                                                 <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
                                             </label>
                                         </div>

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -79,7 +79,8 @@ $triggerAgent = function ($taskId) use ($taskModel, $logger, $user, $project, $j
             $notificationService->notify($user['user_id'], 'agent_event', "🤖 Agent Started: #" . $task['issue_number'], "Agent started processing \"" . $task['title'] . "\" in " . $project['github_repo'], [
                 'task_id' => $taskId,
                 'project_id' => $project['project_id'],
-                'source_url' => $taskModel->getTargetUrl($task)
+                'source_url' => $taskModel->getTargetUrl($task),
+                'is_system' => false // Human action
             ]);
 
             $logger->log($user['user_id'], $taskId, "Calling Jules API...");
@@ -97,7 +98,8 @@ $triggerAgent = function ($taskId) use ($taskModel, $logger, $user, $project, $j
             $notificationService->notify($user['user_id'], 'agent_event', "✅ Agent Completed: #" . $task['issue_number'], "Agent completed analysis for \"" . $task['title'] . "\" in " . $project['github_repo'], [
                 'task_id' => $taskId,
                 'project_id' => $project['project_id'],
-                'source_url' => $taskModel->getTargetUrl($task)
+                'source_url' => $taskModel->getTargetUrl($task),
+                'is_system' => true // The completion itself is system-driven
             ]);
 
             // Refresh tasks
@@ -118,7 +120,8 @@ $triggerAgent = function ($taskId) use ($taskModel, $logger, $user, $project, $j
             $notificationService->notify($user['user_id'], 'agent_event', "❌ Agent Failed: #" . $task['issue_number'], "Agent failed processing \"" . $task['title'] . "\": " . $e->getMessage(), [
                 'task_id' => $taskId,
                 'project_id' => $project['project_id'],
-                'source_url' => $taskModel->getTargetUrl($task)
+                'source_url' => $taskModel->getTargetUrl($task),
+                'is_system' => true // The failure itself is system-driven
             ]);
         }
     }

--- a/test/Integration/NotificationTriggerTest.php
+++ b/test/Integration/NotificationTriggerTest.php
@@ -238,7 +238,8 @@ class NotificationTriggerTest extends TestCase
         $telegramChannel = new \App\TelegramChannelHandler($userModel, $telegramService);
         $this->notificationService->registerChannel('telegram', $telegramChannel);
 
-        $this->notificationService->notify($userId, 'test_event', 'Test Title', 'Test Message');
+        // We must use an actionable type and mark as system event for broadcast to trigger
+        $this->notificationService->notify($userId, 'github_issue', 'Test Title', 'Test Message', ['is_system' => true]);
     }
 
     public function testNotificationRespectsProjectDisabledType()
@@ -314,12 +315,14 @@ class NotificationTriggerTest extends TestCase
         $this->notificationService->registerChannel('mock_channel', $mockChannel);
 
         // EXPECTATION: Broadcast SHOULD NOT happen because 'in-progress' is normalized to 'in_progress'
+        // AND 'in_progress' is not an actionable status for broadcast.
         $mockChannel->expects($this->never())->method('send');
 
         // Trigger notification with status 'in-progress' (with hyphen)
         $this->notificationService->notify($userId, 'task_status', 'Title', 'Message', [
             'project_id' => $projectId,
-            'status' => 'in-progress'
+            'status' => 'in-progress',
+            'is_system' => true
         ]);
     }
 }

--- a/test/Unit/Services/NotificationServiceTest.php
+++ b/test/Unit/Services/NotificationServiceTest.php
@@ -146,7 +146,8 @@ class NotificationServiceTest extends TestCase
         // The current implementation: if ANY settings exist, it only uses what's enabled.
         $this->pdo->exec("INSERT INTO user_notification_settings (user_id, channel, is_enabled) VALUES ($userId, 'test_channel', 1)");
 
-        $this->notificationService->notify($userId, 'type', 'title', 'message');
+        // We must use an actionable type and mark as system event for broadcast to trigger
+        $this->notificationService->notify($userId, 'github_issue', 'title', 'message', ['is_system' => true]);
     }
 
     public function testNotifyDoesNotPersistIfInAppDisabled()


### PR DESCRIPTION
This change links the notification and state-event documentation, establishes a clear relationship between the two, and implements technical controls to ensure only system-triggered events requiring human intervention are broadcasted to external channels.

Key technical changes:
1. Documentation: STATE_EVENTS_CONCEPT.md now includes detailed tables for state-transition notifications and event trigger sources. NOTIF_CONCEPT.md is explicitly linked as a secondary concept.
2. Backend logic: App\NotificationService::notify now checks an 'is_system' flag and filters for 'actionable' statuses (READY, FAILED_JULES, FAILED_PR) before broadcasting to Telegram or Browser.
3. Frontend: Project settings UI now displays the full list of unified task states for notification preference management, using standardized underscored keys.
4. Webhooks: All notification triggers in WebhookHandler and Task refresh logic now distinguish between 'User' and 'System' sources.
5. Tests: Updated Unit and Integration tests to reflect the new broadcasting requirements.

Fixes #564

---
*PR created automatically by Jules for task [14830395596348734643](https://jules.google.com/task/14830395596348734643) started by @chatelao*