### PR TITLE
Standardize Adverb Casing in Concept Documentation

### DIFF
--- a/STATE_EVENTS_CONCEPT.md
+++ b/STATE_EVENTS_CONCEPT.md
@@ -46,7 +46,7 @@ These behaviors are triggered by specific events originating from GitHub (webhoo
 | Event | Action |
 | :--- | :--- |
 | **Issue Labeled (`Jules`)** | Triggers `App\Task::triggerAgent()`. Task moves to `PROCESSING/ANALYZING` (via Jules). |
-| **Issue Closed** | Updates `github_state` to `closed`. Task moves to `FINISHED`. May trigger "Auto-Repeat". |
+| **Issue Closed** | Updates `github_state` to `closed`. Task moves to `FINISHED`; may trigger "Auto-Repeat". |
 | **Issue Reopened** | Updates `github_state` to `open`. Task moves back to `CREATED` or active state. |
 | **Issue Deleted** | Triggers a notification and removes the task from the local database. |
 | **Pull Request Created** | Links the PR to the task. Task moves to `PROCESSING/CHECKING`. |
@@ -58,7 +58,7 @@ These behaviors are triggered by specific events originating from GitHub (webhoo
 | Action | Effect |
 | :--- | :--- |
 | **Manual Sync (Refresh Icon)** | Forces a synchronization of GitHub issues and Jules statuses for the project. |
-| **Trigger Agent (Button)** | Manually starts a Jules session for a task. |
+| **Trigger Agent (Button)** | Starts a Jules session for a task manually. |
 | **Merge & Close (Button)** | Merges the associated PR and closes the GitHub issue via API (moves task to `FINISHED`). |
 | **Retry (Button)** | Sends a "retry" command to a failed Jules session. |
 | **Restart (Button)** | Aborts the current Jules session and restarts it by toggling the `Jules` label. |
@@ -117,7 +117,7 @@ To support recurring tasks, the system implements an "Auto-Repeat" mechanism.
 - A task reaches `FINISHED` state AND carried the **"Auto-Repeat"** label.
 
 **Action:**
-- The system automatically duplicates the issue.
+- The system duplicates the issue automatically.
 - The new issue **includes** the "Jules" label to trigger the agent.
 - The new issue **excludes** the "Auto-Repeat" label.
 
@@ -125,8 +125,8 @@ To support recurring tasks, the system implements an "Auto-Repeat" mechanism.
 
 The system exhibits different behaviors and interactive options depending on the unified state of a task.
 
-- **Merge & Close**: Only available if state is `READY`, PR is mergeable and checks passed.
-- **Retry / Restart**: Only available when state is `FAILED`.
+- **Merge & Close**: Available only if state is `READY`, PR is mergeable and checks passed.
+- **Retry / Restart**: Available only when state is `FAILED`.
 
 ## 6. Notifications & Broadcasts
 
@@ -150,7 +150,7 @@ The application triggers notifications for state transitions and external events
 
 ### 6.2 Event Trigger Sources
 
-Only system-triggered events with a need for human follow-up are typically broadcast to external channels to minimize noise.
+The application typically broadcasts only system-triggered events with a need for human follow-up to external channels to minimize noise.
 
 | Event | Trigger Source | Follow-up Needed | Broadcast |
 | :--- | :--- | :---: | :---: |

--- a/TOP_CONCEPT.md
+++ b/TOP_CONCEPT.md
@@ -11,7 +11,7 @@ This application aims to provide a centralized platform for controlling and coor
 ## Use Cases
 - **<a name="UC-1"></a>User Authentication (UC-1)**: Secure login using Google SSO to manage access for different users, with support for linking multiple GitHub accounts per user.
 - **<a name="UC-2"></a>Project Coordination (UC-2)**: Linking GitHub repositories and issues from any connected GitHub account to specific agent tasks.
-- **<a name="UC-3"></a>Agent Triggering (UC-3)**: Automatically or manually initiating Google Jules agents based on GitHub issue activity.
+- **<a name="UC-3"></a>Agent Triggering (UC-3)**: Initiating Google Jules agents automatically or manually based on GitHub issue activity.
 - **<a name="UC-4"></a>Status Monitoring (UC-4)**: Tracking the progress and results of agent-led tasks within the application.
 
 ## Core Entities & Mapping


### PR DESCRIPTION
I have updated `STATE_EVENTS_CONCEPT.md` and `TOP_CONCEPT.md` to ensure that adverbs and the word 'may' are always lowercase and do not start sentences or bullet points. This was achieved by rephrasing several sentences, using semicolons, or reordering words. I also verified these changes by running the project's unit tests to ensure no accidental breakage and by performing a manual review of the affected documentation.

Fixes #572

---
*PR created automatically by Jules for task [18444547603228876337](https://jules.google.com/task/18444547603228876337) started by @chatelao*