### PR TITLE
Fix Mermaid rendering error in state event diagrams

### DIFF
--- a/STATE_EVENTS_CONCEPT.md
+++ b/STATE_EVENTS_CONCEPT.md
@@ -175,18 +175,18 @@ This section describes the task lifecycle using the [XState](https://xstate.js.o
 The diagram visually groups the core **Jules Processing** activities to distinguish them from GitHub-managed states like `CHECKING`.
 
 ```mermaid
-stateDiagram-v2
+stateDiagram
     [*] --> CREATED
 
     CREATED --> PROCESSING : JULES_STARTED
 
     state PROCESSING {
-        state "Jules Processing" as JULES_ACTIVITY #f0f6ff {
-            state ANALYZING #d1e9ff
-            state PLANNING #d1e9ff
-            state EXECUTING #fff4d1
-            state VERIFYING #fff4d1
-            state IMPLEMENTED #fff4d1
+        state "Jules Processing" as JULES_ACTIVITY {
+            state ANALYZING
+            state PLANNING
+            state EXECUTING
+            state VERIFYING
+            state IMPLEMENTED
 
             [*] --> ANALYZING
             ANALYZING --> PLANNING : RESEARCH_COMPLETE
@@ -194,7 +194,7 @@ stateDiagram-v2
             EXECUTING --> VERIFYING : CODE_COMPLETE
             VERIFYING --> IMPLEMENTED : TESTS_PASSED
         }
-        state CHECKING #ffe5b4
+        state CHECKING
 
         JULES_ACTIVITY --> CHECKING : PR_CREATED
     }
@@ -207,8 +207,8 @@ stateDiagram-v2
     READY --> FAILED_PR : NEW_COMMIT_FAILED
 
     state FAILED {
-        state FAILED_JULES #ffeef0
-        state FAILED_PR #ffeef0
+        state FAILED_JULES
+        state FAILED_PR
     }
 
     FAILED --> CREATED : RESTART

--- a/docs/TASK_XSTATE.md
+++ b/docs/TASK_XSTATE.md
@@ -5,7 +5,7 @@ This document describes the task lifecycle defined in [STATE_EVENTS_CONCEPT.md](
 ## 1. Visual Representation (Mermaid)
 
 ```mermaid
-stateDiagram-v2
+stateDiagram
     [*] --> CREATED
 
     CREATED --> PROCESSING_ANALYZING : JULES_STARTED


### PR DESCRIPTION
Fixed the Mermaid rendering error "No such shape: roundedWithTitle" by switching from `stateDiagram-v2` to `stateDiagram` (v1) in `STATE_EVENTS_CONCEPT.md` and `docs/TASK_XSTATE.md`. Hex colors were also removed from the diagrams in `STATE_EVENTS_CONCEPT.md` to ensure compatibility with the v1 renderer.

Fixes #577

---
*PR created automatically by Jules for task [5083498264687830918](https://jules.google.com/task/5083498264687830918) started by @chatelao*