### PR TITLE
Visual Task Status Transitions in Notifications

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -493,6 +493,40 @@ class Task
         return 'gray';
     }
 
+    public function getStatusEmoji(string $status): string
+    {
+        if ($status === self::STATUS_CREATED) {
+            return '⏳';
+        }
+
+        if ($status === self::STATUS_FINISHED || $status === self::STATUS_READY || $status === 'completed') {
+            return '✅';
+        }
+
+        if ($status === self::STATUS_CHECKING) {
+            return '🔍';
+        }
+
+        if ($status === self::STATUS_FAILED_JULES || $status === self::STATUS_FAILED_PR || $status === 'failed') {
+            return '❌';
+        }
+
+        if (in_array($status, [self::STATUS_ANALYZING, self::STATUS_PLANNING, self::STATUS_EXECUTING, self::STATUS_VERIFYING, self::STATUS_IMPLEMENTED])) {
+            return '🚧';
+        }
+
+        return '⏳';
+    }
+
+    public function getStatusLabel(string $status): string
+    {
+        if ($status === self::STATUS_CREATED) {
+            return 'Waiting for Agent';
+        }
+
+        return ucwords(str_replace('_', ' ', $status));
+    }
+
     public function hasAutorepeatLabel(array $task): bool
     {
         $githubData = json_decode($task['github_data'] ?? '{}', true);
@@ -822,7 +856,7 @@ class Task
 
                 if ($notificationService && $mappedStatus !== $task['status']) {
                     $title = "Task Update: #" . $task['issue_number'];
-                    $message = "Task \"" . $task['title'] . "\" status changed to " . ucwords(str_replace('_', ' ', $mappedStatus)) . ".";
+                    $message = "Task \"" . $task['title'] . "\" status: " . $this->getStatusEmoji($task['status']) . " ➡️ " . $this->getStatusEmoji($mappedStatus) . " " . $this->getStatusLabel($mappedStatus);
                     if ($mappedStatus === self::STATUS_FINISHED) {
                         $title = "✅ Task Completed: #" . $task['issue_number'];
                     } elseif ($mappedStatus === self::STATUS_READY) {

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -206,20 +206,8 @@ $errorMessage = $errorMessage ?? null;
                                                         $bgClass = 'bg-orange-100 text-orange-800';
                                                     }
 
-                                                    $emoji = '⏳';
-                                                    $statusLabel = ucwords(str_replace('_', ' ', $task['status'] ?? ''));
-                                                    if ($task['status'] === App\Task::STATUS_CREATED) {
-                                                        $emoji = '⏳';
-                                                        $statusLabel = 'Waiting for Agent';
-                                                    } elseif ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY || $task['status'] === 'completed') {
-                                                        $emoji = '✅';
-                                                    } elseif ($task['status'] === App\Task::STATUS_CHECKING) {
-                                                        $emoji = '🔍';
-                                                    } elseif ($task['status'] === App\Task::STATUS_FAILED_JULES || $task['status'] === App\Task::STATUS_FAILED_PR) {
-                                                        $emoji = '❌';
-                                                    } elseif (in_array($task['status'], [App\Task::STATUS_ANALYZING, App\Task::STATUS_PLANNING, App\Task::STATUS_EXECUTING, App\Task::STATUS_VERIFYING, App\Task::STATUS_IMPLEMENTED])) {
-                                                        $emoji = '🚧';
-                                                    }
+                                                    $emoji = $taskModel->getStatusEmoji($task['status'] ?? '');
+                                                    $statusLabel = $taskModel->getStatusLabel($task['status'] ?? '');
                                                     ?>
                                                     <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
                                                         <?= $emoji ?> <?= htmlspecialchars($statusLabel) ?>
@@ -265,23 +253,8 @@ $errorMessage = $errorMessage ?? null;
                                                         $isAutorepeat = $taskModel->hasAutorepeatLabel($task);
                                                         $state = $task['github_state'] ?? 'open';
 
-                                                        $emoji = '⏳';
-                                                        $statusLabel = ucwords(str_replace('_', ' ', $task['status'] ?? ''));
-
-                                                        if ($task['status'] === App\Task::STATUS_CREATED) {
-                                                            $emoji = '⏳';
-                                                            $statusLabel = 'Waiting for Agent';
-                                                        } elseif ($task['status'] === App\Task::STATUS_FINISHED) {
-                                                            $emoji = '✅';
-                                                        } elseif ($task['status'] === App\Task::STATUS_READY) {
-                                                            $emoji = '✅';
-                                                        } elseif ($task['status'] === App\Task::STATUS_CHECKING) {
-                                                            $emoji = '🔍';
-                                                        } elseif ($task['status'] === App\Task::STATUS_FAILED_JULES || $task['status'] === App\Task::STATUS_FAILED_PR) {
-                                                            $emoji = '❌';
-                                                        } elseif (in_array($task['status'], [App\Task::STATUS_ANALYZING, App\Task::STATUS_PLANNING, App\Task::STATUS_EXECUTING, App\Task::STATUS_VERIFYING, App\Task::STATUS_IMPLEMENTED])) {
-                                                            $emoji = '🚧';
-                                                        }
+                                                        $emoji = $taskModel->getStatusEmoji($task['status'] ?? '');
+                                                        $statusLabel = $taskModel->getStatusLabel($task['status'] ?? '');
                                                         ?>
                                                         <div class="relative group">
                                                             <a href="task.php?id=<?= $task['task_id'] ?>"

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -560,26 +560,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                     }
                                                     ?>
                                                     <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
-                                                        <?php
-                                                        $label = ucwords(str_replace('_', ' ', $task['status'] ?? ''));
-                                                        if ($task['status'] === App\Task::STATUS_CREATED) {
-                                                            echo '⏳ ';
-                                                            $label = 'Waiting for Agent';
-                                                        } elseif ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY || $task['status'] === 'completed') {
-                                                            echo '✅ ';
-                                                        } elseif ($task['status'] === App\Task::STATUS_CHECKING) {
-                                                            echo '🔍 ';
-                                                        } elseif ($task['status'] === App\Task::STATUS_FAILED_JULES) {
-                                                            echo '❌ Jules ';
-                                                        } elseif ($task['status'] === App\Task::STATUS_FAILED_PR) {
-                                                            echo '❌ PR ';
-                                                        } elseif (in_array($task['status'], [App\Task::STATUS_ANALYZING, App\Task::STATUS_PLANNING, App\Task::STATUS_EXECUTING, App\Task::STATUS_VERIFYING, App\Task::STATUS_IMPLEMENTED])) {
-                                                            echo '🚧 ';
-                                                        } else {
-                                                            echo '⏳ ';
-                                                        }
-                                                        ?>
-                                                        <?= htmlspecialchars($label) ?>
+                                                        <?= $taskModel->getStatusEmoji($task['status'] ?? '') ?>
+                                                        <?= htmlspecialchars($taskModel->getStatusLabel($task['status'] ?? '')) ?>
                                                     </span>
                                                 </td>
                                                 <td class="px-6 py-4">

--- a/src/frontend/tasks.php
+++ b/src/frontend/tasks.php
@@ -144,26 +144,8 @@ $title = $filterLabels[$filter] ?? 'Tasks';
                                                 }
                                                 ?>
                                                 <span class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap <?= $bgClass ?>">
-                                                    <?php
-                                                    $label = ucwords(str_replace('_', ' ', $task['status'] ?? ''));
-                                                    if ($task['status'] === App\Task::STATUS_CREATED) {
-                                                        echo '⏳ ';
-                                                        $label = 'Waiting for Agent';
-                                                    } elseif ($task['status'] === App\Task::STATUS_FINISHED || $task['status'] === App\Task::STATUS_READY) {
-                                                        echo '✅ ';
-                                                    } elseif ($task['status'] === App\Task::STATUS_CHECKING) {
-                                                        echo '🔍 ';
-                                                    } elseif ($task['status'] === App\Task::STATUS_FAILED_JULES) {
-                                                        echo '❌ Jules ';
-                                                    } elseif ($task['status'] === App\Task::STATUS_FAILED_PR) {
-                                                        echo '❌ PR ';
-                                                    } elseif (in_array($task['status'], [App\Task::STATUS_ANALYZING, App\Task::STATUS_PLANNING, App\Task::STATUS_EXECUTING, App\Task::STATUS_VERIFYING, App\Task::STATUS_IMPLEMENTED])) {
-                                                        echo '🚧 ';
-                                                    } else {
-                                                        echo '⏳ ';
-                                                    }
-                                                    ?>
-                                                    <?= htmlspecialchars($label) ?>
+                                                    <?= $taskModel->getStatusEmoji($task['status'] ?? '') ?>
+                                                    <?= htmlspecialchars($taskModel->getStatusLabel($task['status'] ?? '')) ?>
                                                 </span>
                                             </td>
                                         </tr>

--- a/test/Integration/NotificationTriggerTest.php
+++ b/test/Integration/NotificationTriggerTest.php
@@ -196,7 +196,7 @@ class NotificationTriggerTest extends TestCase
     {
         $userId = 1;
         $this->pdo->exec("INSERT INTO tasks (user_id, project_id, issue_number, title, status, jules_session_id, jules_status, github_data)
-                          VALUES (1, 1, 303, 'Task 303', 'researching', 'sess-123', 'researching', '{\"assignee\":{\"login\":\"jules\"}}')");
+                          VALUES (1, 1, 303, 'Task 303', 'analyzing', 'sess-123', 'researching', '{\"assignee\":{\"login\":\"jules\"}}')");
         $taskId = $this->pdo->lastInsertId();
 
         $githubService = $this->createMock(GitHubService::class);
@@ -214,7 +214,7 @@ class NotificationTriggerTest extends TestCase
 
         $this->assertNotFalse($notification);
         $this->assertStringContainsString('Task Update: #303', $notification['title']);
-        $this->assertStringContainsString('status changed to Executing', $notification['message']);
+        $this->assertStringContainsString('status: 🚧 ➡️ 🚧 Executing', $notification['message']);
     }
 
     public function testNotificationDispatchesToTelegram()


### PR DESCRIPTION
This change replaces the plain text "status changed to XXX" in task update notifications with a more visual transition showing the old and new status icons.

Key changes:
- `App\Task` now has `getStatusEmoji()` and `getStatusLabel()` methods.
- Notifications now use the format: `Task "[Title]" status: ⏳ ➡️ 🚧 Executing`.
- The web frontend has been refactored to use these same methods, ensuring visual consistency across the platform.
- Integration tests have been updated to verify the new notification message format.

Fixes #579

---
*PR created automatically by Jules for task [282832923837021277](https://jules.google.com/task/282832923837021277) started by @chatelao*