### PR TITLE
Update Next Gen UI API References

### DIFF
--- a/NEXT_GEN_UI_CONCEPT.md
+++ b/NEXT_GEN_UI_CONCEPT.md
@@ -6,7 +6,7 @@ The "Next Gen UI" initiative aims to evolve the Agent Control application from a
 ## 1. Vision & Strategy
 The core strategy is **"API-First, Platform-Agnostic"**.
 - **Headless Architecture**: The server transitions into a pure API provider, responsible only for business logic, data persistence, and external service orchestration (GitHub, Jules, Telegram).
-- **Contract-Driven Development**: The `openapi.yaml` (Agent Control API) serves as the single source of truth for all client-server interactions.
+- **Contract-Driven Development**: The `api/openapi.yaml` (Agent Control API) serves as the single source of truth for all client-server interactions. This is the relevant API between Browser and Server to use and update if necessary.
 - **Native Experience**: Delivering native mobile apps to provide better notification handling and on-the-go agent control beyond the Telegram bot.
 
 ## 2. Proposed Tech Stack
@@ -28,7 +28,7 @@ The core strategy is **"API-First, Platform-Agnostic"**.
 Transitioning from the current PHP/Alpine.js stack will be performed in four distinct phases to ensure continuous availability.
 
 ### Phase 1: API Foundation (BFF Layer)
-- Refactor existing PHP logic into a RESTful API following the `openapi.yaml` specification.
+- Refactor existing PHP logic into a RESTful API following the `api/openapi.yaml` specification.
 - Implement JWT-based authentication alongside the existing session-based auth.
 - Result: The existing UI remains functional, but now consumes an internal JSON API.
 

--- a/NEXT_GEN_UI_DESIGN.md
+++ b/NEXT_GEN_UI_DESIGN.md
@@ -4,7 +4,7 @@
 The Next Gen UI follows a strict **Client-Server Separation** model.
 
 ### 1.1 Communication Layer
-- **RESTful API**: Standard interactions (listing projects, updating settings) use JSON over HTTP, as defined in `openapi.yaml`.
+- **RESTful API**: Standard interactions (listing projects, updating settings) use JSON over HTTP, as defined in `api/openapi.yaml`. This is the relevant API between Browser and Server to use and update if necessary.
 - **Event Streaming**: Real-time updates for task statuses (moving from `EXECUTING` to `READY`) utilize background synchronization.
 - **Client Generation**: API clients for both Web (TypeScript) and Mobile (TypeScript) are automatically generated from the OpenAPI specification to ensure type safety across the stack.
 

--- a/NEXT_GEN_UI_ROADMAP.md
+++ b/NEXT_GEN_UI_ROADMAP.md
@@ -38,7 +38,7 @@ The goal of Phase 1 is to create the necessary backend infrastructure to support
 
 - 🚧 **Milestone 1.1: OpenAPI Compliance**
     - 🚧 Refactor existing PHP endpoints to serve JSON exclusively for `/api/*` routes.
-    - 🚧 Validate all API responses against the `openapi.yaml` specification.
+    - 🚧 Validate all API responses against the `api/openapi.yaml` specification. This is the relevant API between Browser and Server to use and update if necessary.
 - ⏳ **Milestone 1.2: Modern Auth Implementation**
     - ⏳ Implement JWT token issuance and validation.
     - ⏳ Support Refresh Tokens for persistent mobile sessions.


### PR DESCRIPTION
All NEXT_GEN_UI_*.md files have been updated to reference `api/openapi.yaml` as the single source of truth for client-server interactions, with explicit mentions that it is the relevant API to use and update.

Fixes #588

---
*PR created automatically by Jules for task [2156890590802536577](https://jules.google.com/task/2156890590802536577) started by @chatelao*