### PR TITLE
Implement /api/tasks.php and Refine Next Gen UI Roadmap

### DIFF
--- a/NEXT_GEN_UI_ROADMAP.md
+++ b/NEXT_GEN_UI_ROADMAP.md
@@ -39,6 +39,7 @@ The goal of Phase 1 is to create the necessary backend infrastructure to support
 - 🚧 **Milestone 1.1: OpenAPI Compliance**
     - 🚧 Refactor existing PHP endpoints to serve JSON exclusively for `/api/*` routes.
         - ✅ Implemented `/api/projects.php` as a RESTful endpoint.
+        - ✅ Implemented `/api/tasks.php` as a RESTful endpoint.
     - 🚧 Validate all API responses against the `api/openapi.yaml` specification. This is the relevant API between Browser and Server to use and update if necessary.
 - 🚧 **Milestone 1.2: Modern Auth Implementation**
     - ✅ Implement JWT token issuance and validation in `App\Auth`.
@@ -49,8 +50,10 @@ The goal of Phase 1 is to create the necessary backend infrastructure to support
 The goal of Phase 2 is to achieve feature parity with the existing "Project Card" view in a new React application.
 
 - ⏳ **Milestone 2.1: Project/Task Overview**
-    - ⏳ Port the Status Square Grid to React components.
-    - ⏳ Implement TanStack Query for data fetching and synchronization.
+    - ⏳ Component: Project List Card (Port from `index.php`).
+    - ⏳ Component: Task Status Square Grid (Port from `project.php`).
+    - ⏳ Component: Task Filter Bar (By status/repository).
+    - ⏳ Data Sync: Implement background polling with TanStack Query.
 - ⏳ **Milestone 2.2: Task Detail View**
     - ⏳ Port the log viewer and interactive controls (Retry, Restart, Merge).
 - ⏳ **Milestone 2.3: Integration Testing**

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -355,7 +355,7 @@ paths:
         '401':
           description: Unauthorized
 
-  /api/projects/{id}/tasks.php:
+  /api/tasks.php:
     get:
       summary: List project tasks (JSON)
       description: Returns a list of tasks for a specific project.
@@ -363,10 +363,11 @@ paths:
         - BearerAuth: []
       parameters:
         - name: id
-          in: path
+          in: query
           required: true
           schema:
             type: integer
+          description: Project ID
       responses:
         '200':
           description: A JSON list of tasks
@@ -462,8 +463,8 @@ components:
           example: "Steps to reproduce..."
         status:
           type: string
-          enum: [pending, in_progress, completed, failed]
-          example: "pending"
+          enum: [created, analyzing, planning, executing, verifying, checking, ready, finished, implemented, failed_jules, failed_pr]
+          example: "created"
         agent_response:
           type: string
           nullable: true

--- a/src/frontend/api/tasks.php
+++ b/src/frontend/api/tasks.php
@@ -1,0 +1,67 @@
+<?php
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+use App\Database;
+use App\Auth;
+use App\Project;
+use App\Task;
+
+header('Content-Type: application/json');
+
+$auth = new Auth();
+$userId = null;
+
+// Support both Session and JWT authentication
+if ($auth->isLoggedIn()) {
+    $userId = $auth->getUserId();
+} else {
+    $headers = getallheaders();
+    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
+    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
+        $userId = $auth->validateToken($matches[1]);
+    }
+}
+
+if (!$userId) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+$projectId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if (!$projectId) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing project ID']);
+    exit;
+}
+
+$db = new Database();
+$projectModel = new Project($db);
+$taskModel = new Task($db);
+
+// Verify project ownership
+$project = $projectModel->findById($projectId);
+if (!$project || (int)$project['user_id'] !== $userId) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Project not found']);
+    exit;
+}
+
+$tasks = $taskModel->findByProjectId($projectId);
+
+// Map internal database fields to OpenAPI schema
+$output = array_map(function($task) {
+    return [
+        'id' => (int)$task['task_id'],
+        'project_id' => (int)$task['project_id'],
+        'issue_number' => (int)$task['issue_number'],
+        'title' => $task['title'],
+        'body' => $task['body'],
+        'status' => $task['status'],
+        'agent_response' => $task['agent_response'],
+        'created_at' => $task['created_at']
+    ];
+}, $tasks);
+
+echo json_encode($output);


### PR DESCRIPTION
I have implemented a key step in the Next Gen UI Roadmap by creating the `/api/tasks.php` RESTful endpoint. This endpoint allows the upcoming React-based frontend to fetch project tasks using either legacy session authentication or modern JWT (Bearer) tokens.

Additionally, I updated the `api/openapi.yaml` specification to include this new endpoint and ensure the `Task` schema reflects all possible task statuses used by the backend.

Finally, I updated the `NEXT_GEN_UI_ROADMAP.md` to track this progress and broke down Milestone 2.1 (Project/Task Overview) into smaller, more manageable steps for future implementation.

Fixes #594

---
*PR created automatically by Jules for task [1772512039403411571](https://jules.google.com/task/1772512039403411571) started by @chatelao*