### PR TITLE
Simplify notification settings

### DIFF
--- a/NOTIF_CONCEPT.md
+++ b/NOTIF_CONCEPT.md
@@ -32,9 +32,10 @@ Notifications are generated consistently across multiple event sources (Event So
 -   **Manual Refreshes (`project.php`)**: User-initiated synchronizations that refresh project and task states.
 
 ### Broadcasting Logic
-To minimize notification noise, the system distinguishes between **In-App Inbox** notifications (all events) and **External Broadcasts** (Telegram/Browser).
-- Only **System-triggered** events with a need for **human follow-up** (e.g., Fails, Ready-to-merge PRs) are broadcasted.
+To minimize notification noise, the system distinguishes between **In-App Inbox** notifications and **External Broadcasts** (Telegram/Browser).
+- Only **System-triggered** events are eligible for broadcasting.
 - Human-initiated actions do not trigger broadcasts to avoid redundant alerts for the active user.
+- Users can granularly enable or disable notifications for specific task states via **Status Notification Preferences**.
 
 ## Use Cases
 -   **<a name="UC-N1"></a>Jump to Source (Deep Linking) (UC-N1)**: A user clicks on a "PR Available" notification and is immediately taken to the corresponding GitHub Pull Request page.

--- a/STATE_EVENTS_CONCEPT.md
+++ b/STATE_EVENTS_CONCEPT.md
@@ -134,37 +134,39 @@ The application triggers notifications for state transitions and external events
 
 ### 6.1 State Transition Notifications
 
-| Unified State | Notification | Broadcast (Default) | Human Follow-up Required |
-| :--- | :---: | :---: | :--- |
-| `CREATED` | Yes | No | No |
-| `ANALYZING` | Yes | No | No |
-| `PLANNING` | Yes | No | No |
-| `EXECUTING` | Yes | No | No |
-| `VERIFYING` | Yes | No | No |
-| `IMPLEMENTED` | Yes | No | No |
-| `CHECKING` | Yes | No | No |
-| `READY` | Yes | **Yes** | **Yes** (Merge needed) |
-| `FINISHED` | Yes | No | No (FYI) |
-| `FAILED_JULES` | Yes | **Yes** | **Yes** (Retry/Restart needed) |
-| `FAILED_PR` | Yes | **Yes** | **Yes** (Fix needed) |
+The system honors **Status Notification Preferences** configured at the project level. If a state transition is disabled, it is suppressed for both the In-App Inbox and external broadcasts.
+
+| Unified State | Default Enabled | Broadcast (System-Triggered) |
+| :--- | :---: | :---: |
+| `CREATED` | No | No |
+| `ANALYZING` | No | No |
+| `PLANNING` | No | No |
+| `EXECUTING` | No | No |
+| `VERIFYING` | No | No |
+| `IMPLEMENTED` | No | No |
+| `CHECKING` | No | No |
+| `READY` | **Yes** | **Yes** |
+| `FINISHED` | No | No |
+| `FAILED_JULES` | **Yes** | **Yes** |
+| `FAILED_PR` | **Yes** | **Yes** |
 
 ### 6.2 Event Trigger Sources
 
-Only system-triggered events with a need for human follow-up are typically broadcast to external channels to minimize noise.
+The system distinguishes between human-initiated actions and system-triggered events.
 
-| Event | Trigger Source | Follow-up Needed | Broadcast |
-| :--- | :--- | :---: | :---: |
-| **Issue opened** | User (GitHub) | No | No |
-| **Issue closed** | User (GitHub) / System (Merge) | No | No |
-| **Issue reopened** | User (GitHub) | No | No |
-| **Issue deleted** | User (GitHub) | No | No |
-| **PR created** | System (Jules) | No | No |
-| **PR merged** | User (UI) / System (Auto) | No | No |
-| **Agent started** | User (UI) / System (Label) | No | No |
-| **Agent completed**| System (Jules) | No | No |
-| **Check Suite fail**| System (GitHub CI) | **Yes** | **Yes** |
-| **Check Suite pass**| System (GitHub CI) | **Yes** | **Yes** |
-| **Auto-Repeat** | System | **Yes** | **Yes** |
+| Event | Trigger Source | Broadcast |
+| :--- | :--- | :---: |
+| **Issue opened** | User (GitHub) | No |
+| **Issue closed** | User (GitHub) / System (Merge) | No |
+| **Issue reopened** | User (GitHub) | No |
+| **Issue deleted** | User (GitHub) | No |
+| **PR created** | System (Jules) | Yes (if enabled) |
+| **PR merged** | User (UI) / System (Auto) | No |
+| **Agent started** | User (UI) / System (Label) | No |
+| **Agent completed**| System (Jules) | Yes (if enabled) |
+| **Check Suite fail**| System (GitHub CI) | Yes (if enabled) |
+| **Check Suite pass**| System (GitHub CI) | Yes (if enabled) |
+| **Auto-Repeat** | System | Yes (if enabled) |
 
 ## 7. Distinguishing Manual vs. Automated Actions
 
@@ -189,7 +191,7 @@ Actions performed directly in the web dashboard (e.g., clicking "Run Agent", "Me
 ### 7.3 Broadcasting Rules
 The `App\NotificationService` enforces the following logic for external broadcasts:
 1. **Manual Actions**: If `is_system` is `false`, the broadcast is suppressed.
-2. **System Actions**: If `is_system` is `true`, the system further checks if the event is **actionable**. Only system events that require human follow-up (e.g., a task becoming `READY` for merge, or a session failing with `FAILED_JULES`) are dispatched to Telegram or Browser notifications.
+2. **System Actions**: If `is_system` is `true`, the event is eligible for broadcasting, provided it hasn't been disabled in the **Status Notification Preferences**.
 
 ## 8. Task State Machine (XState)
 

--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -44,6 +44,13 @@ class NotificationService
             return false;
         }
 
+        // 3.1 Check if notification is enabled for this status (if it's a task_status event)
+        if ($type === 'task_status' && isset($data['project_id']) && isset($data['status'])) {
+            if (!$this->isStatusNotificationEnabled((int)$data['project_id'], $data['status'])) {
+                return false;
+            }
+        }
+
         // 4. Get enabled channels
         $enabledChannels = $this->getEnabledChannels($userId);
         if (empty($enabledChannels)) {
@@ -57,37 +64,13 @@ class NotificationService
             $notificationId = $this->persistNotification($userId, $type, $title, $message, $data);
         }
 
-        // 6. Check if broadcast is enabled for this status (if it's a task_status event)
+        // 6. Determine if we should broadcast to external channels (Telegram, Browser)
         $shouldBroadcast = true;
-        if ($type === 'task_status' && isset($data['project_id']) && isset($data['status'])) {
-            $shouldBroadcast = $this->isStatusBroadcastEnabled((int)$data['project_id'], $data['status']);
-        }
 
-        // 6.1 Only system-triggered events with human follow-up are broadcasted
+        // 6.1 Only system-triggered events are broadcasted
         // If is_system is explicitly set to false, it's a human action -> no broadcast
         if (!isset($data['is_system']) || $data['is_system'] === false) {
             $shouldBroadcast = false;
-        }
-
-        // 6.2 Filter non-actionable system events
-        // Even if it's a system event, only broadcast if it needs human follow-up
-        if ($shouldBroadcast) {
-            $actionableTypes = ['task_status', 'github_issue', 'github_pr'];
-            if (!in_array($type, $actionableTypes)) {
-                $shouldBroadcast = false;
-            }
-
-            // For task_status, only specific states need follow-up
-            if ($type === 'task_status' && isset($data['status'])) {
-                $actionableStatuses = [
-                    Task::STATUS_READY,
-                    Task::STATUS_FAILED_JULES,
-                    Task::STATUS_FAILED_PR
-                ];
-                if (!in_array($data['status'], $actionableStatuses)) {
-                    $shouldBroadcast = false;
-                }
-            }
         }
 
         if (!$shouldBroadcast) {
@@ -354,7 +337,7 @@ class NotificationService
         return $settings[$type] ?? true;
     }
 
-    private function isStatusBroadcastEnabled(int $projectId, string $status): bool
+    private function isStatusNotificationEnabled(int $projectId, string $status): bool
     {
         $normalizedStatus = str_replace('-', '_', $status);
         $settings = $this->getStatusSettings($projectId);

--- a/src/frontend/project-settings.php
+++ b/src/frontend/project-settings.php
@@ -325,8 +325,8 @@ if (isset($_GET['success'])) {
                                 </div>
 
                                 <div class="border-t border-gray-100 pt-4">
-                                    <h4 class="text-sm font-bold text-gray-900 mb-2 uppercase tracking-wider">Status Broadcast Preferences</h4>
-                                    <p class="text-xs text-gray-500 mb-4">Choose which status changes trigger a broadcast (Telegram/Browser). All events still appear in the inbox.</p>
+                                    <h4 class="text-sm font-bold text-gray-900 mb-2 uppercase tracking-wider">Status Notification Preferences</h4>
+                                    <p class="text-xs text-gray-500 mb-4">Choose which status changes trigger a notification. Disabling a status here will suppress both in-app inbox alerts and external broadcasts (Telegram/Browser).</p>
                                     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
                                         <?php
                                         $statuses = [

--- a/test/Integration/NotificationTriggerTest.php
+++ b/test/Integration/NotificationTriggerTest.php
@@ -195,6 +195,10 @@ class NotificationTriggerTest extends TestCase
     public function testRefreshJulesStatusTriggersNotificationOnStatusChange()
     {
         $userId = 1;
+        $projectId = 1;
+        // Enable 'executing' status notification
+        $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES ($projectId, 'executing', 1)");
+
         $this->pdo->exec("INSERT INTO tasks (user_id, project_id, issue_number, title, status, jules_session_id, jules_status, github_data)
                           VALUES (1, 1, 303, 'Task 303', 'analyzing', 'sess-123', 'researching', '{\"assignee\":{\"login\":\"jules\"}}')");
         $taskId = $this->pdo->lastInsertId();
@@ -266,11 +270,11 @@ class NotificationTriggerTest extends TestCase
         $this->assertEquals(0, $stmt->fetchColumn());
     }
 
-    public function testNotificationRespectsStatusDisabledForBroadcastButKeepsInbox()
+    public function testNotificationRespectsStatusDisabledCompletely()
     {
         $userId = 1;
         $projectId = 1;
-        // Disable 'executing' status broadcast
+        // Disable 'executing' status completely
         $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES ($projectId, 'executing', 0)");
 
         // Enable a mock channel AND in_app
@@ -279,7 +283,7 @@ class NotificationTriggerTest extends TestCase
         $mockChannel = $this->createMock(NotificationChannelInterface::class);
         $this->notificationService->registerChannel('mock_channel', $mockChannel);
 
-        // Broadcast SHOULD NOT happen
+        // Neither Broadcast NOR Persistence SHOULD happen
         $mockChannel->expects($this->never())->method('send');
 
         $this->pdo->exec("INSERT INTO tasks (user_id, project_id, issue_number, title, status, jules_session_id, jules_status, github_data)
@@ -290,15 +294,15 @@ class NotificationTriggerTest extends TestCase
         $julesService = $this->createMock(JulesService::class);
 
         $julesService->method('fetchSessionStatus')->willReturn([
-            'status' => 'coding',
+            'status' => 'coding', // coding maps to executing
             'url' => '...'
         ]);
 
         $this->taskModel->refreshJulesStatus($userId, $githubService, $julesService, $this->notificationService, $taskId);
 
-        // Notification SHOULD still be in the inbox
+        // Notification SHOULD NOT be in the inbox
         $stmt = $this->pdo->query("SELECT COUNT(*) FROM notifications WHERE type = 'task_status'");
-        $this->assertEquals(1, $stmt->fetchColumn());
+        $this->assertEquals(0, $stmt->fetchColumn());
     }
 
     public function testNotificationNormalizationForHyphenatedStatus()


### PR DESCRIPTION
Simplified the notification system to allow granular control over task state transitions. Users can now enable or disable notifications for any task state, and these settings apply to both the in-app inbox and external broadcasts (Telegram/Browser). The hardcoded filters that previously restricted external broadcasts to only a few "actionable" states have been removed.

Fixes #593

---
*PR created automatically by Jules for task [13749848459464832271](https://jules.google.com/task/13749848459464832271) started by @chatelao*