### PR TITLE
Fix Mermaid rendering error in documentation diagrams

### DIFF
--- a/STATE_EVENTS_CONCEPT.md
+++ b/STATE_EVENTS_CONCEPT.md
@@ -202,7 +202,7 @@ This section describes the task lifecycle using the [XState](https://xstate.js.o
 The diagram visually groups the core **Jules Processing** activities to distinguish them from GitHub-managed states like `CHECKING`.
 
 ```mermaid
-stateDiagram
+stateDiagram-v1
     [*] --> CREATED
 
     CREATED --> PROCESSING : JULES_STARTED

--- a/docs/TASK_XSTATE.md
+++ b/docs/TASK_XSTATE.md
@@ -5,7 +5,7 @@ This document describes the task lifecycle defined in [STATE_EVENTS_CONCEPT.md](
 ## 1. Visual Representation (Mermaid)
 
 ```mermaid
-stateDiagram
+stateDiagram-v1
     [*] --> CREATED
 
     CREATED --> PROCESSING_ANALYZING : JULES_STARTED


### PR DESCRIPTION
This change resolves a rendering error in the project's documentation diagrams on GitHub. The error "No such shape: roundedWithTitle" is a known issue when using nested states with titles in the default Mermaid state diagram renderer. By explicitly using `stateDiagram-v1`, we switch to the older Dagre-based renderer which handles these structures correctly.

Files modified:
- `STATE_EVENTS_CONCEPT.md`: Updated the Task State-Event Diagram.
- `docs/TASK_XSTATE.md`: Updated the Visual Representation (Mermaid) diagram.

Verification:
- Manually inspected the syntax changes.
- Ran the full unit and integration test suite (`vendor/bin/phpunit -c test/phpunit.xml`) to ensure no regressions. All 160 tests passed.

Fixes #598

---
*PR created automatically by Jules for task [1090102796779643033](https://jules.google.com/task/1090102796779643033) started by @chatelao*