### PR TITLE
Automate Redocly Documentation Deployment to GitHub Pages

### DIFF
--- a/.github/workflows/redoc-gh-pages.yml
+++ b/.github/workflows/redoc-gh-pages.yml
@@ -1,0 +1,39 @@
+name: Deploy Redocly to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli
+
+      - name: Build documentation
+        run: |
+          mkdir -p dist
+          redocly build-docs api/openapi.yaml --output=dist/index.html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This change introduces a GitHub Actions workflow that automatically generates Redocly API documentation from the OpenAPI specification and publishes it to GitHub Pages. The workflow triggers on every push to the `main` branch, ensuring the documentation stays up-to-date with the latest API changes.

Fixes #601

---
*PR created automatically by Jules for task [15812827363624908467](https://jules.google.com/task/15812827363624908467) started by @chatelao*