### PR TITLE
Fix task hang in 'checking' status for completed GitHub checks

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -63,10 +63,14 @@ class Task
                     if ($status !== 'completed') {
                         $running = true;
                         $success = false;
-                    } elseif (in_array($conclusion, ['failure', 'timed_out', 'cancelled', 'action_required'])) {
+                    } elseif (in_array($conclusion, ['failure', 'timed_out', 'cancelled', 'action_required', 'startup_failure'])) {
                         $failed = true;
                         $success = false;
-                    } elseif ($conclusion !== 'success' && $conclusion !== 'neutral' && $conclusion !== 'skipped' && $conclusion !== 'stale') {
+                    } elseif ($conclusion === 'success' || $conclusion === 'neutral' || $conclusion === 'skipped' || $conclusion === 'stale') {
+                        // Keep success = true (or whatever it is)
+                    } else {
+                        // Any other completed conclusion (including unknown ones) is considered a failure for safety
+                        $failed = true;
                         $success = false;
                     }
                 }

--- a/test/Unit/TaskCheckSuiteTest.php
+++ b/test/Unit/TaskCheckSuiteTest.php
@@ -68,4 +68,50 @@ class TaskCheckSuiteTest extends TestCase
         $status = $this->taskModel->resolveStatus($task, null, $checkSuitesData);
         $this->assertEquals(Task::STATUS_READY, $status);
     }
+
+    public function testResolveStatusWithStartupFailure()
+    {
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1',
+            'status' => Task::STATUS_CHECKING
+        ];
+
+        $checkSuitesData = [
+            'check_suites' => [
+                [
+                    'status' => 'completed',
+                    'conclusion' => 'startup_failure'
+                ]
+            ]
+        ];
+
+        $status = $this->taskModel->resolveStatus($task, null, $checkSuitesData);
+        $this->assertEquals(Task::STATUS_FAILED_PR, $status, "startup_failure should result in STATUS_FAILED_PR");
+    }
+
+    public function testResolveStatusWithUnknownCompletedConclusion()
+    {
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1',
+            'status' => Task::STATUS_CHECKING
+        ];
+
+        $checkSuitesData = [
+            'check_suites' => [
+                [
+                    'status' => 'completed',
+                    'conclusion' => 'unknown_new_conclusion'
+                ]
+            ]
+        ];
+
+        $status = $this->taskModel->resolveStatus($task, null, $checkSuitesData);
+        // It shouldn't be STATUS_CHECKING anymore if it is completed
+        $this->assertNotEquals(Task::STATUS_CHECKING, $status, "Unknown completed conclusion should not stay in CHECKING");
+        $this->assertEquals(Task::STATUS_FAILED_PR, $status, "Unknown completed conclusion should default to FAILED_PR for safety");
+    }
 }


### PR DESCRIPTION
This change fixes a bug where tasks would remain stuck in the "checking" status because their GitHub check suites were completed with conclusions not explicitly handled by the application (specifically 'startup_failure' or potential new conclusions).

The `App\Task::resolveStatus` method has been updated to:
1. Include `startup_failure` in the list of failing conclusions.
2. Default any unknown but `completed` conclusion to a failure state, ensuring the task transitions out of the "checking" status once GitHub processing is done.

New unit tests have been added to `test/Unit/TaskCheckSuiteTest.php` to reproduce and verify the fix.

Fixes #613

---
*PR created automatically by Jules for task [2738038428064568873](https://jules.google.com/task/2738038428064568873) started by @chatelao*