### PR TITLE
Unify Third-party API URLs and Naming

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,14 +23,14 @@ This guide explains how to install the AI Brain application on a web server.
 5.  Go to **APIs & Services > Credentials**.
 6.  Click **Create Credentials > OAuth client ID**.
 7.  Select **Web application** as the application type.
-8.  Add your `GOOGLE_REDIRECT_URI` (e.g., `https://your-domain.com/callback.php`) to the **Authorized redirect URIs**.
+8.  Add your `GOOGLE_REDIRECT_URI` (e.g., `https://your-domain.com/google/callback.php`) to the **Authorized redirect URIs**.
 9.  Copy the **Client ID** and **Client Secret**.
 
 ### 2. GitHub OAuth App
 1.  Go to your GitHub **Settings > Developer settings > OAuth Apps**.
 2.  Click **New OAuth App**.
 3.  Set the **Homepage URL** to your domain.
-4.  Set the **Authorization callback URL** to your `GITHUB_REDIRECT_URI` (e.g., `https://your-domain.com/github-callback.php`).
+4.  Set the **Authorization callback URL** to your `GITHUB_REDIRECT_URI` (e.g., `https://your-domain.com/github/callback.php`).
 5.  Click **Register application**.
 6.  Copy the **Client ID** and click **Generate a new client secret** to get your secret.
 
@@ -159,14 +159,14 @@ Use this method if you want to deploy from your local machine via SSH.
    #
    SetEnv GOOGLE_CLIENT_ID        your_google_client_id
    SetEnv GOOGLE_CLIENT_SECRET    your_google_client_secret
-   SetEnv GOOGLE_REDIRECT_URI     https://your-domain.com/callback.php
+   SetEnv GOOGLE_REDIRECT_URI     https://your-domain.com/google/callback.php
 
    #
    # GitHub OAuth: https://github.com/settings/developers
    #
    SetEnv GITHUB_CLIENT_ID        your_github_client_id
    SetEnv GITHUB_CLIENT_SECRET    your_github_client_secret
-   SetEnv GITHUB_REDIRECT_URI     https://your-domain.com/github-callback.php
+   SetEnv GITHUB_REDIRECT_URI     https://your-domain.com/github/callback.php
 
    #
    # Telegram Bot: https://t.me/botfather
@@ -223,10 +223,10 @@ The application requires several environment variables to be set in your web ser
 | `DB_PASS` | Database password |
 | `GOOGLE_CLIENT_ID` | Google OAuth 2.0 Client ID |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth 2.0 Client Secret |
-| `GOOGLE_REDIRECT_URI` | `https://your-domain.com/callback.php` |
+| `GOOGLE_REDIRECT_URI` | `https://your-domain.com/google/callback.php` |
 | `GITHUB_CLIENT_ID` | GitHub OAuth App Client ID |
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth App Client Secret |
-| `GITHUB_REDIRECT_URI` | `https://your-domain.com/github-callback.php` |
+| `GITHUB_REDIRECT_URI` | `https://your-domain.com/github/callback.php` |
 | `UPGRADE_ALLOWED_EMAIL` | (Required for upgrades) Email address of the admin user authorized to trigger database migrations on the Admin Dashboard. |
 | `ENABLE_UPGRADE_PAGE` | (Optional) Set to `true` to enable the interactive database upgrade page at `/upgrade.php`. Useful for initial setup or maintenance. **Disable after use for security.** |
 | `DB_UPGRADE_SECRET` | (Optional) A secret token that allows automated database upgrades via the "Apply DB Patch" workflow. Should be set in `.htaccess` or server configuration. |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ php -S localhost:8080 -t src/frontend
 ```
 
 ## Project Structure
-- `src/frontend/`: Web entry points (index.php, login.php, etc.) and frontend assets.
+- `src/frontend/`: Web entry points (index.php, google/login.php, etc.) and frontend assets.
 - `src/backend/`: Core PHP logic and classes.
 - `src/sql/`: Database schema and migrations.
 - `test/`: PHPUnit tests and testing tools.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -9,7 +9,7 @@ servers:
     description: Local development server
 
 paths:
-  /login.php:
+  /google/login.php:
     get:
       summary: Initiate Google SSO login
       description: Redirects the user to Google for authentication.
@@ -17,7 +17,7 @@ paths:
         '302':
           description: Redirect to Google OAuth URL
 
-  /callback.php:
+  /google/callback.php:
     get:
       summary: Google SSO callback
       description: Handles the response from Google and logs the user in.
@@ -49,9 +49,9 @@ paths:
       description: Destroys the user session.
       responses:
         '302':
-          description: Redirect to login.php
+          description: Redirect to google/login.php
 
-  /github-login.php:
+  /github/login.php:
     get:
       summary: Initiate GitHub OAuth
       description: Redirects the user to GitHub for account linking.
@@ -59,7 +59,7 @@ paths:
         '302':
           description: Redirect to GitHub OAuth URL
 
-  /github-callback.php:
+  /github/callback.php:
     get:
       summary: GitHub OAuth callback
       description: Handles the response from GitHub and links the account.
@@ -202,7 +202,7 @@ paths:
                 TriggerAgent:
                   value: "<html>...Agent response...</html>"
 
-  /webhook.php:
+  /github/webhook.php:
     post:
       summary: GitHub Webhook
       description: Receives 'issues' events from GitHub.
@@ -256,7 +256,7 @@ paths:
         '500':
           description: Failed to process event
 
-  /telegram-webhook.php:
+  /telegram/webhook.php:
     post:
       summary: Telegram Webhook
       description: Receives updates from the Telegram Bot API.
@@ -312,7 +312,7 @@ paths:
                 AdminView:
                   value: "<html>...User Management...</html>"
         '302':
-          description: Redirect to login if not logged in
+          description: Redirect to google/login if not logged in
         '403':
           description: Access denied if not admin
 
@@ -694,7 +694,7 @@ components:
           example: "john@example.com"
         endpoint:
           type: string
-          example: "webhook.php"
+          example: "github/webhook.php"
         payload:
           type: string
           nullable: true

--- a/src/frontend/admin/db-check.php
+++ b/src/frontend/admin/db-check.php
@@ -12,7 +12,7 @@ $db = new Database();
 $userModel = new User($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: ../login.php');
+    header('Location: ../google/login.php');
     exit;
 }
 

--- a/src/frontend/admin/index.php
+++ b/src/frontend/admin/index.php
@@ -12,7 +12,7 @@ $db = new Database();
 $userModel = new User($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: ../login.php');
+    header('Location: ../google/login.php');
     exit;
 }
 

--- a/src/frontend/admin/upgrade.php
+++ b/src/frontend/admin/upgrade.php
@@ -19,7 +19,7 @@ $isSecretValid = !empty($configuredSecret) && $providedSecret === $configuredSec
 
 if (!$isSecretValid) {
     if (!$auth->isLoggedIn()) {
-        header('Location: ../login.php');
+        header('Location: ../google/login.php');
         exit;
     }
 

--- a/src/frontend/debug_jules.php
+++ b/src/frontend/debug_jules.php
@@ -15,7 +15,7 @@ $db = new Database();
 $userModel = new User($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: login.php');
+    header('Location: google/login.php');
     exit;
 }
 

--- a/src/frontend/github/callback.php
+++ b/src/frontend/github/callback.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../../vendor/autoload.php';
 use App\Auth;
 use App\GitHubAuth;
 use App\Database;
@@ -21,7 +21,7 @@ if (!$rateLimiter->check("github_callback_$ip", 20, 60)) {
 
 $auth = new Auth();
 if (!$auth->isLoggedIn()) {
-    header('Location: index.php');
+    header('Location: ../index.php');
     exit;
 }
 
@@ -50,13 +50,13 @@ if (isset($_GET['code']) && isset($_GET['state'])) {
             }
         }
 
-        header('Location: settings.php?github=success');
+        header('Location: ../settings.php?github=success');
         exit;
     } catch (Exception $e) {
-        header('Location: settings.php?github=error&message=' . urlencode($e->getMessage()));
+        header('Location: ../settings.php?github=error&message=' . urlencode($e->getMessage()));
         exit;
     }
 } else {
-    header('Location: index.php');
+    header('Location: ../index.php');
     exit;
 }

--- a/src/frontend/github/login.php
+++ b/src/frontend/github/login.php
@@ -1,12 +1,12 @@
 <?php
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../../vendor/autoload.php';
 use App\Auth;
 use App\GitHubAuth;
 
 $auth = new Auth();
 if (!$auth->isLoggedIn()) {
-    header('Location: index.php');
+    header('Location: ../index.php');
     exit;
 }
 

--- a/src/frontend/github/webhook.php
+++ b/src/frontend/github/webhook.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../../vendor/autoload.php';
 
 use App\Database;
 use App\Project;
@@ -26,7 +26,7 @@ $githubEvent = $headers['X-GitHub-Event'] ?? $_SERVER['HTTP_X_GITHUB_EVENT'] ?? 
 $githubSignature = $headers['X-Hub-Signature-256'] ?? $_SERVER['HTTP_X_HUB_SIGNATURE_256'] ?? '';
 
 if (!$rateLimiter->check("webhook_$ip", 100, 60)) {
-    $logger->log(0, 'github', $payload, $headersStr, 429, 'Rate limit exceeded');
+    $logger->log(0, 'github/webhook.php', $payload, $headersStr, 429, 'Rate limit exceeded');
     http_response_code(429);
     exit('Too many webhook requests. Please try again later.');
 }
@@ -36,19 +36,19 @@ $handler = new WebhookHandler($db);
 $notificationService = new NotificationService($db);
 
 if (empty($payload)) {
-    $logger->log(0, 'github', $payload, $headersStr, 400, 'Empty payload');
+    $logger->log(0, 'github/webhook.php', $payload, $headersStr, 400, 'Empty payload');
     http_response_code(400);
     exit('Empty payload');
 }
 
 if (empty($githubSignature)) {
-    $logger->log(0, 'github', $payload, $headersStr, 400, 'Missing signature');
+    $logger->log(0, 'github/webhook.php', $payload, $headersStr, 400, 'Missing signature');
     http_response_code(400);
     exit('Missing signature');
 }
 
 if (empty($githubEvent)) {
-    $logger->log(0, 'github', $payload, $headersStr, 400, 'Missing event header');
+    $logger->log(0, 'github/webhook.php', $payload, $headersStr, 400, 'Missing event header');
     http_response_code(400);
     exit('Missing event header');
 }
@@ -64,7 +64,7 @@ try {
     $repoFullName = $data['repository']['full_name'] ?? '';
 
     if (empty($repoFullName)) {
-        $logger->log(0, 'github', $payload, $headersStr, 400, 'Repository information missing');
+        $logger->log(0, 'github/webhook.php', $payload, $headersStr, 400, 'Repository information missing');
         http_response_code(400);
         exit('Repository information missing');
     }
@@ -74,7 +74,7 @@ try {
     if ($projectId > 0) {
         $project = $projectModel->findById($projectId);
         if (!$project || $project['github_repo'] !== $repoFullName) {
-            $logger->log(0, 'github', $payload, $headersStr, 404, 'Project not found or repository mismatch');
+            $logger->log(0, 'github/webhook.php', $payload, $headersStr, 404, 'Project not found or repository mismatch');
             http_response_code(404);
             exit('Project not found or repository mismatch');
         }
@@ -84,7 +84,7 @@ try {
     }
 
     if (empty($projects)) {
-        $logger->log(0, 'github', $payload, $headersStr, 404, 'Project not found');
+        $logger->log(0, 'github/webhook.php', $payload, $headersStr, 404, 'Project not found');
         http_response_code(404);
         exit('Project not found');
     }
@@ -103,7 +103,7 @@ try {
     if (!$verified) {
         // Log failure for the first project found as a fallback if we can't verify any
         if (!empty($projects)) {
-            $logger->log($projects[0]['user_id'], 'github', $payload, $headersStr, 401, 'Invalid signature');
+            $logger->log($projects[0]['user_id'], 'github/webhook.php', $payload, $headersStr, 401, 'Invalid signature');
         }
         http_response_code(401);
         exit('Invalid signature');
@@ -111,7 +111,7 @@ try {
 
     if ($githubEvent === 'ping') {
         if (!empty($projects)) {
-            $logger->log($projects[0]['user_id'], 'github', $payload, $headersStr, 200, 'PONG');
+            $logger->log($projects[0]['user_id'], 'github/webhook.php', $payload, $headersStr, 200, 'PONG');
         }
         http_response_code(200);
         exit('PONG');
@@ -138,11 +138,11 @@ try {
     $julesService = new JulesService(null, $user['jules_api_key'] ?? null);
 
     if ($handler->handle($matchingProject, $data, $githubService, $notificationService, $julesService)) {
-        $logger->log($matchingProject['user_id'], 'github', $payload, $headersStr, 200);
+        $logger->log($matchingProject['user_id'], 'github/webhook.php', $payload, $headersStr, 200);
         http_response_code(200);
         echo 'OK';
     } else {
-        $logger->log($matchingProject['user_id'], 'github', $payload, $headersStr, 500, 'Failed to process event');
+        $logger->log($matchingProject['user_id'], 'github/webhook.php', $payload, $headersStr, 500, 'Failed to process event');
         http_response_code(500);
         echo 'Failed to process event';
     }

--- a/src/frontend/google/callback.php
+++ b/src/frontend/google/callback.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../../vendor/autoload.php';
 use App\Auth;
 use App\Database;
 use App\User;
@@ -14,12 +14,12 @@ if (isset($_GET['code'])) {
         $googleUser = $auth->authenticate($_GET['code']);
         $user = $userModel->createOrUpdate($googleUser);
         $auth->login($user);
-        header('Location: index.php');
+        header('Location: ../index.php');
         exit;
     } catch (Exception $e) {
         echo "Error: " . htmlspecialchars($e->getMessage());
     }
 } else {
-    header('Location: index.php');
+    header('Location: ../index.php');
     exit;
 }

--- a/src/frontend/google/login.php
+++ b/src/frontend/google/login.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../../vendor/autoload.php';
 use App\Auth;
 use App\Database;
 use App\RateLimiter;

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -39,7 +39,7 @@ if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['github_repo'
                 $ghService = new App\GitHubService(null, $githubAccount['github_token']);
                 $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https" : "http";
                 $host = $_SERVER['HTTP_HOST'];
-                $webhookUrl = "$protocol://$host/webhook.php?project_id=" . $result['project_id'];
+                $webhookUrl = "$protocol://$host/github/webhook.php?project_id=" . $result['project_id'];
 
                 try {
                     $ghService->createWebhook($repo, $webhookUrl, $result['webhook_secret']);
@@ -144,7 +144,7 @@ $errorMessage = $errorMessage ?? null;
                             <a href="logout.php" class="ml-4 text-sm font-medium text-red-600 hover:underline">Logout</a>
                         </div>
                     <?php else : ?>
-                        <a href="login.php" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 focus:outline-none">Login with Google</a>
+                        <a href="google/login.php" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 focus:outline-none">Login with Google</a>
                     <?php endif; ?>
                 </div>
             </div>

--- a/src/frontend/logs.php
+++ b/src/frontend/logs.php
@@ -16,7 +16,7 @@ $logger = new Logger($db);
 $webhookLogger = new WebhookLogger($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: login.php');
+    header('Location: google/login.php');
     exit;
 }
 

--- a/src/frontend/notifications.php
+++ b/src/frontend/notifications.php
@@ -15,7 +15,7 @@ $taskModel = new Task($db);
 $notificationService = new NotificationService($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: login.php');
+    header('Location: google/login.php');
     exit;
 }
 

--- a/src/frontend/project-settings.php
+++ b/src/frontend/project-settings.php
@@ -18,7 +18,7 @@ $taskModel = new Task($db);
 $notificationService = new NotificationService($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: login.php');
+    header('Location: google/login.php');
     exit;
 }
 
@@ -95,7 +95,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_notifications'
 }
 
 // Handle Setup Webhook (copied from project.php)
-$webhookUrl = ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/webhook.php?project_id=' . $projectId;
+$webhookUrl = ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/github/webhook.php?project_id=' . $projectId;
 $githubToken = $project['github_token'] ?? null;
 $webhookStatus = 'unknown';
 
@@ -105,8 +105,8 @@ if ($githubToken) {
         $webhooks = $githubService->listWebhooks($project['github_repo']);
         $webhookStatus = 'missing';
         foreach ($webhooks as $wh) {
-            if (isset($wh['config']['url']) && str_starts_with($wh['config']['url'], ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/webhook.php')) {
-                if ($wh['config']['url'] === $webhookUrl || $wh['config']['url'] === ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/webhook.php') {
+            if (isset($wh['config']['url']) && str_starts_with($wh['config']['url'], ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/github/webhook.php')) {
+                if ($wh['config']['url'] === $webhookUrl || $wh['config']['url'] === ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? 'https') . '://' . $_SERVER['HTTP_HOST'] . '/github/webhook.php') {
                     $webhookStatus = $wh['active'] ? 'active' : 'inactive';
                     break;
                 }

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -24,7 +24,7 @@ $notificationService = new NotificationService($db);
 $logger = new Logger($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: login.php');
+    header('Location: google/login.php');
     exit;
 }
 

--- a/src/frontend/settings.php
+++ b/src/frontend/settings.php
@@ -18,7 +18,7 @@ $webhookLogger = new WebhookLogger($db);
 $notificationService = new NotificationService($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: login.php');
+    header('Location: google/login.php');
     exit;
 }
 
@@ -74,7 +74,7 @@ if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_teleg
                 }
 
                 $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
-                $webhookUrl = $protocol . $host . "/telegram-webhook.php?user_id=" . $user['user_id'];
+                $webhookUrl = $protocol . $host . "/telegram/webhook.php?user_id=" . $user['user_id'];
 
                 $telegramService->setWebhook($webhookUrl, $newWebhookSecret);
             } catch (\Exception $e) {
@@ -248,7 +248,7 @@ if ($user && !$telegramChatId && !empty($telegramBotName) && empty($telegramLink
                                 <div class="p-4 bg-purple-50 border border-purple-200 rounded-lg">
                                     <h4 class="text-lg font-semibold text-purple-900 mb-2">Telegram Custom Bot</h4>
                                     <p class="text-sm text-purple-700 mb-4">Optional: Use your own Telegram Bot. Configure the webhook to:<br>
-                                        <code class="bg-white px-1 rounded text-xs font-mono">https://<?= $_SERVER['HTTP_HOST'] ?? 'your-domain.com' ?>/telegram-webhook.php?user_id=<?= $user['user_id'] ?></code>
+                                        <code class="bg-white px-1 rounded text-xs font-mono">https://<?= $_SERVER['HTTP_HOST'] ?? 'your-domain.com' ?>/telegram/webhook.php?user_id=<?= $user['user_id'] ?></code>
                                     </p>
                                     <form method="POST" class="space-y-2">
                                         <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
@@ -296,7 +296,7 @@ if ($user && !$telegramChatId && !empty($telegramBotName) && empty($telegramLink
                                             </div>
                                         <?php endforeach; ?>
                                     <?php endif; ?>
-                                    <a href="github-login.php" class="mt-2 inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-gray-800 rounded-lg hover:bg-gray-900 focus:ring-4 focus:outline-none focus:ring-gray-300">
+                                    <a href="github/login.php" class="mt-2 inline-flex items-center px-3 py-2 text-sm font-medium text-center text-white bg-gray-800 rounded-lg hover:bg-gray-900 focus:ring-4 focus:outline-none focus:ring-gray-300">
                                         <svg class="w-4 h-4 mr-2 text-white" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
                                         Link <?= empty($githubAccounts) ? 'GitHub Account' : 'Another GitHub Account' ?>
                                     </a>

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -18,7 +18,7 @@ $taskModel = new Task($db);
 $notificationService = new NotificationService($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: login.php');
+    header('Location: google/login.php');
     exit;
 }
 

--- a/src/frontend/tasks.php
+++ b/src/frontend/tasks.php
@@ -14,7 +14,7 @@ $userModel = new User($db);
 $taskModel = new Task($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: login.php');
+    header('Location: google/login.php');
     exit;
 }
 

--- a/src/frontend/telegram/webhook.php
+++ b/src/frontend/telegram/webhook.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../../vendor/autoload.php';
 
 use App\Database;
 use App\User;
@@ -41,7 +41,7 @@ $providedSecret = $_SERVER['HTTP_X_TELEGRAM_BOT_API_SECRET_TOKEN'] ?? '';
 
 if (!$handler->verifySecret($providedSecret)) {
     if ($userId) {
-        $logger->log($userId, 'telegram', $input, $headersStr, 401, "Unauthorized");
+        $logger->log($userId, 'telegram/webhook.php', $input, $headersStr, 401, "Unauthorized");
     }
     http_response_code(401);
     echo "Unauthorized";
@@ -52,7 +52,7 @@ $update = json_decode($input, true);
 
 if (!$update) {
     if ($userId) {
-        $logger->log($userId, 'telegram', $input, $headersStr, 400, "Invalid Request");
+        $logger->log($userId, 'telegram/webhook.php', $input, $headersStr, 400, "Invalid Request");
     }
     http_response_code(400);
     echo "Invalid Request";
@@ -60,7 +60,7 @@ if (!$update) {
 }
 
 if ($userId) {
-    $logger->log($userId, 'telegram', $input, $headersStr, 200);
+    $logger->log($userId, 'telegram/webhook.php', $input, $headersStr, 200);
 }
 
 // Acknowledge Telegram immediately

--- a/src/frontend/templates.php
+++ b/src/frontend/templates.php
@@ -14,7 +14,7 @@ $userModel = new User($db);
 $templateModel = new IssueTemplate($db);
 
 if (!$auth->isLoggedIn()) {
-    header('Location: login.php');
+    header('Location: google/login.php');
     exit;
 }
 

--- a/test/Unit/UI/DashboardTest.php
+++ b/test/Unit/UI/DashboardTest.php
@@ -77,7 +77,7 @@ class DashboardTest extends TestCase
                 <span><?= htmlspecialchars($user['name']) ?></span>
                 <a href="logout.php">Logout</a>
             <?php else: ?>
-                <a href="login.php">Login with Google</a>
+                <a href="google/login.php">Login with Google</a>
             <?php endif; ?>
         </nav>
         <main>

--- a/wiki/Telegram-Bot.md
+++ b/wiki/Telegram-Bot.md
@@ -11,7 +11,7 @@ By default, the system can be configured to use a shared bot, but you can also u
 3. Enter your **Telegram Bot Token** and a **Webhook Secret** (any random string).
 4. Click **"Save"**.
 5. Set your bot's webhook URL to:
-   `https://your-domain.com/telegram-webhook.php?user_id=YOUR_USER_ID`
+   `https://your-domain.com/telegram/webhook.php?user_id=YOUR_USER_ID`
    (The exact URL is provided in your Settings page).
 
 ## Linking Your Account


### PR DESCRIPTION
This change unifies the naming and directory structure for third-party integrations (Google, GitHub, Telegram) in the frontend. 

Key modifications:
- Reworked URLs to follow a provider-based hierarchy (e.g., `/google/`, `/github/`, `/telegram/`).
- Moved and renamed entry points:
    - `src/frontend/login.php` -> `src/frontend/google/login.php`
    - `src/frontend/callback.php` -> `src/frontend/google/callback.php`
    - `src/frontend/github-login.php` -> `src/frontend/github/login.php`
    - `src/frontend/github-callback.php` -> `src/frontend/github/callback.php`
    - `src/frontend/webhook.php` -> `src/frontend/github/webhook.php`
    - `src/frontend/telegram-webhook.php` -> `src/frontend/telegram/webhook.php`
- Updated all internal links, `header('Location: ...')` redirects, and automated webhook registration logic.
- Adjusted `require_once` paths for the Composer autoloader in moved files.
- Unified endpoint identification in `WebhookLogger` calls.
- Updated `api/openapi.yaml`, `README.md`, `INSTALL.md`, and `wiki/Telegram-Bot.md`.
- Verified changes with unit tests.

Fixes #610

---
*PR created automatically by Jules for task [8570732988915366954](https://jules.google.com/task/8570732988915366954) started by @chatelao*