### PR TITLE
Add Redocly API documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A PHP application to control agents from Google Jules, coordinated by GitHub rep
 | API / Interface | Description |
 | :--- | :--- |
 | [**PlantUML**](https://plantuml.com/) | Architecture diagram generation from text. |
+| [**Agent Control API**](https://chatelao.github.io/ai-brain/) | OpenAPI 3.0 specification rendered with Redocly. |
 
 ## Features
 
@@ -101,3 +102,4 @@ php -S localhost:8080 -t src/frontend
 - [Roadmap](ROADMAP.md)
 - [Notification Roadmap](NOTIF_ROADMAP.md)
 - [Telegram Chat Roadmap](CHAT_ROADMAP.md)
+- [**API Reference (Redocly)**](https://chatelao.github.io/ai-brain/) - Interactive API documentation.


### PR DESCRIPTION
The `README.md` file has been updated to include links to the Redocly-rendered API documentation on GitHub Pages (`https://chatelao.github.io/ai-brain/`).

Specifically:
- Added a row for "Agent Control API" in the "Used APIs and Interfaces" -> "#### Test/Documentation" table.
- Added a new bullet point "[**API Reference (Redocly)**](https://chatelao.github.io/ai-brain/) - Interactive API documentation." at the end of the "## Documentation" section.

All tests passed (172 tests, 576 assertions).

Fixes #617

---
*PR created automatically by Jules for task [7655263524747642415](https://jules.google.com/task/7655263524747642415) started by @chatelao*