### PR TITLE
Fix false PR failure status in dashboard

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -68,6 +68,10 @@ class Task
                         $success = false;
                     } elseif ($conclusion === 'success' || $conclusion === 'neutral' || $conclusion === 'skipped' || $conclusion === 'stale') {
                         // Keep success = true (or whatever it is)
+                    } elseif (empty($conclusion)) {
+                        // Completed but no conclusion yet? Treat as still running/checking to avoid false failure
+                        $running = true;
+                        $success = false;
                     } else {
                         // Any other completed conclusion (including unknown ones) is considered a failure for safety
                         $failed = true;


### PR DESCRIPTION
Modified the status resolution logic for GitHub check suites to prevent false failure reports when a suite is completed but lacks a definitive conclusion. These cases are now treated as 'running', maintaining the 'checking' status until a valid conclusion is received.

Fixes #619

---
*PR created automatically by Jules for task [1666841098132311153](https://jules.google.com/task/1666841098132311153) started by @chatelao*