### PR TITLE
Resolve stuck 'pending' task status during synchronization

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -432,7 +432,12 @@ class Task
                         title = excluded.title,
                         body = excluded.body,
                         github_data = excluded.github_data,
-                        github_state = excluded.github_state";
+                        github_state = excluded.github_state,
+                        status = CASE
+                            WHEN excluded.github_state = 'closed' THEN 'finished'
+                            WHEN status = 'pending' THEN 'created'
+                            ELSE status
+                        END";
         } else {
             $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
@@ -440,7 +445,12 @@ class Task
                         title = VALUES(title),
                         body = VALUES(body),
                         github_data = VALUES(github_data),
-                        github_state = VALUES(github_state)";
+                        github_state = VALUES(github_state),
+                        status = CASE
+                            WHEN VALUES(github_state) = 'closed' THEN 'finished'
+                            WHEN status = 'pending' THEN 'created'
+                            ELSE status
+                        END";
         }
 
         $stmt = $connection->prepare($sql);
@@ -673,7 +683,7 @@ class Task
     public function getTargetUrl(array $task, ?string $repo = null): string
     {
         $issueUrl = "https://github.com/" . ($repo ?? $task['github_repo']) . "/issues/" . $task['issue_number'];
-        $status = $task['status'] ?? 'pending';
+        $status = $task['status'] ?? self::STATUS_CREATED;
 
         if ($status === self::STATUS_FINISHED || $status === 'completed' || $status === 'failed_pr') {
             return $task['pr_url'] ?: $issueUrl;
@@ -709,12 +719,12 @@ class Task
             $sql .= " AND t.project_id = ?";
             $params[] = $projectId;
             $fiveMinutesAgo = date('Y-m-d H:i:s', strtotime('-5 minutes'));
-            $sql .= " AND (t.last_synced_at IS NULL OR t.last_synced_at < ?)
+            $sql .= " AND (t.last_synced_at IS NULL OR t.last_synced_at < ? OR t.status = 'pending')
                       AND (t.status NOT IN ('" . self::STATUS_FINISHED . "', 'completed', 'failed', 'failed_jules', 'failed_pr') OR t.jules_status NOT IN ('completed', 'failed'))";
             $params[] = $fiveMinutesAgo;
         } else {
             $fiveMinutesAgo = date('Y-m-d H:i:s', strtotime('-5 minutes'));
-            $sql .= " AND (t.last_synced_at IS NULL OR t.last_synced_at < ?)
+            $sql .= " AND (t.last_synced_at IS NULL OR t.last_synced_at < ? OR t.status = 'pending')
                       AND (t.status NOT IN ('" . self::STATUS_FINISHED . "', 'completed', 'failed', 'failed_jules', 'failed_pr') OR t.jules_status NOT IN ('completed', 'failed'))";
             $params[] = $fiveMinutesAgo;
         }

--- a/test/Integration/TaskDBIntegrationTest.php
+++ b/test/Integration/TaskDBIntegrationTest.php
@@ -33,7 +33,7 @@ class TaskDBIntegrationTest extends TestCase
             issue_number INT NOT NULL,
             title VARCHAR(255) NOT NULL,
             body TEXT,
-            status TEXT DEFAULT 'pending',
+            status TEXT DEFAULT 'created',
             github_state VARCHAR(20) DEFAULT 'open',
             github_data TEXT,
             created_at $timestamp,
@@ -55,7 +55,7 @@ class TaskDBIntegrationTest extends TestCase
             'issue_number' => 101,
             'title' => 'Test Issue',
             'body' => 'Test Body',
-            'status' => 'pending'
+            'status' => 'created'
         ];
 
         $this->assertTrue($this->taskModel->create($data));


### PR DESCRIPTION
This change addresses an issue where tasks would remain in a 'pending' status even after their associated GitHub steps were completed. The fix involves ensuring that the background synchronization and the initial upsert logic correctly map the 'pending' database default to the unified 'created' or 'finished' states.

Key changes:
- In `src/backend/Task.php`, `upsert` now updates the `status` column on conflict.
- In `src/backend/Task.php`, `refreshJulesStatus` query now includes `OR t.status = 'pending'`.
- In `src/backend/Task.php`, `getTargetUrl` uses `self::STATUS_CREATED` as fallback.
- In `test/Integration/TaskDBIntegrationTest.php`, updated table definition and test data to use 'created' status.

Fixes #626

---
*PR created automatically by Jules for task [10566810437435888408](https://jules.google.com/task/10566810437435888408) started by @chatelao*