### PR TITLE
Reject non-existent repositories during project linking

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -22,6 +22,25 @@ class GitHubService
     /**
      * @throws Exception
      */
+    public function getRepository(string $repo): array
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+
+        return $this->apiCall(
+            'GitHub API',
+            "GET repo $repo",
+            fn() => $this->client->api('repo')->show($username, $repository)
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
     public function getIssue(string $repo, int $issueNumber): array
     {
         $parts = explode('/', $repo);

--- a/src/backend/Project.php
+++ b/src/backend/Project.php
@@ -11,7 +11,7 @@ class Project
     {
     }
 
-    public function create(int $userId, int $githubAccountId, string $githubRepo): array
+    public function create(int $userId, int $githubAccountId, string $githubRepo, ?GitHubService $githubService = null): array
     {
         // Verify that the github account belongs to the user
         $stmt = $this->db->getConnection()->prepare(
@@ -20,6 +20,10 @@ class Project
         $stmt->execute([$githubAccountId, $userId]);
         if (!$stmt->fetch()) {
             throw new Exception("Invalid GitHub account selected.");
+        }
+
+        if ($githubService) {
+            $githubService->getRepository($githubRepo);
         }
 
         $webhookSecret = bin2hex(random_bytes(16));
@@ -74,7 +78,7 @@ class Project
         return $project ?: null;
     }
 
-    public function update(int $projectId, int $userId, int $githubAccountId, string $githubRepo): bool
+    public function update(int $projectId, int $userId, int $githubAccountId, string $githubRepo, ?GitHubService $githubService = null): bool
     {
         // Verify that the github account belongs to the user
         $stmt = $this->db->getConnection()->prepare(
@@ -83,6 +87,10 @@ class Project
         $stmt->execute([$githubAccountId, $userId]);
         if (!$stmt->fetch()) {
             throw new Exception("Invalid GitHub account selected.");
+        }
+
+        if ($githubService) {
+            $githubService->getRepository($githubRepo);
         }
 
         $stmt = $this->db->getConnection()->prepare(

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -14,6 +14,7 @@ $userModel = new User($db);
 $projectModel = new Project($db);
 
 $user = $auth->isLoggedIn() ? $userModel->findById($auth->getUserId()) : null;
+$githubAccounts = $user ? $userModel->getGitHubAccounts($user['user_id']) : [];
 
 // Handle Project Creation
 if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['github_repo']) && isset($_POST['github_account_id'])) {
@@ -24,9 +25,7 @@ if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['github_repo'
     $accountId = (int)$_POST['github_account_id'];
     if (!empty($repo) && $accountId > 0) {
         try {
-            $result = $projectModel->create($user['user_id'], $accountId, $repo);
-
-            // Register Webhook with GitHub
+            // Find GitHub account to get the token for validation
             $githubAccount = null;
             foreach ($githubAccounts as $account) {
                 if ((int)$account['github_account_id'] === $accountId) {
@@ -35,8 +34,15 @@ if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['github_repo'
                 }
             }
 
+            $ghService = null;
             if ($githubAccount && !empty($githubAccount['github_token'])) {
                 $ghService = new App\GitHubService(null, $githubAccount['github_token']);
+            }
+
+            $result = $projectModel->create($user['user_id'], $accountId, $repo, $ghService);
+
+            // Register Webhook with GitHub
+            if ($ghService) {
                 $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https" : "http";
                 $host = $_SERVER['HTTP_HOST'];
                 $webhookUrl = "$protocol://$host/github/webhook.php?project_id=" . $result['project_id'];
@@ -58,7 +64,6 @@ if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['github_repo'
 }
 
 $projects = $user ? $projectModel->findByUserId($user['user_id']) : [];
-$githubAccounts = $user ? $userModel->getGitHubAccounts($user['user_id']) : [];
 $taskModel = new Task($db);
 
 

--- a/src/frontend/project-settings.php
+++ b/src/frontend/project-settings.php
@@ -23,6 +23,7 @@ if (!$auth->isLoggedIn()) {
 }
 
 $user = $userModel->findById($auth->getUserId());
+$githubAccounts = $userModel->getGitHubAccounts($user['user_id']);
 $projectId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $project = $projectModel->findById($projectId);
 
@@ -30,7 +31,6 @@ if (!$project || $project['user_id'] !== $user['user_id']) {
     die("Project not found or access denied.");
 }
 
-$githubAccounts = $userModel->getGitHubAccounts($user['user_id']);
 $errorMessage = null;
 $successMessage = null;
 
@@ -45,7 +45,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_project'])) {
 
     if (!empty($repo) && $accountId > 0) {
         try {
-            $projectModel->update($projectId, $user['user_id'], $accountId, $repo);
+            // Find GitHub account to get the token for validation
+            $githubAccount = null;
+            foreach ($githubAccounts as $account) {
+                if ((int)$account['github_account_id'] === $accountId) {
+                    $githubAccount = $account;
+                    break;
+                }
+            }
+
+            $ghService = null;
+            if ($githubAccount && !empty($githubAccount['github_token'])) {
+                $ghService = new App\GitHubService(null, $githubAccount['github_token']);
+            }
+
+            $projectModel->update($projectId, $user['user_id'], $accountId, $repo, $ghService);
             header("Location: project-settings.php?id=$projectId&success=project_updated");
             exit;
         } catch (Exception $e) {

--- a/test/Integration/ProjectRepositoryValidationTest.php
+++ b/test/Integration/ProjectRepositoryValidationTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\Project;
+use App\User;
+use App\GitHubService;
+use PDO;
+use Exception;
+use Tests\TestDatabaseTrait;
+
+class ProjectRepositoryValidationTest extends TestCase
+{
+    use TestDatabaseTrait;
+
+    private $db;
+    private $pdo;
+    private $projectModel;
+    private $userModel;
+
+    protected function setUp(): void
+    {
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $this->pdo->exec("DROP TABLE IF EXISTS projects");
+        $this->pdo->exec("DROP TABLE IF EXISTS user_github_accounts");
+        $this->pdo->exec("DROP TABLE IF EXISTS users");
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
+
+        $this->pdo->exec("CREATE TABLE users (
+            user_id $pk,
+            google_id VARCHAR(255) UNIQUE NOT NULL,
+            name VARCHAR(255) NOT NULL,
+            email VARCHAR(255) UNIQUE NOT NULL,
+            avatar VARCHAR(255), role VARCHAR(20) DEFAULT 'user',
+            created_at $timestamp
+        )");
+
+        $this->pdo->exec("CREATE TABLE user_github_accounts (
+            github_account_id $pk,
+            user_id INT NOT NULL,
+            github_username VARCHAR(255) NOT NULL,
+            github_token VARCHAR(255) NOT NULL,
+            created_at $timestamp,
+            FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+            UNIQUE(user_id, github_username)
+        )");
+
+        $this->pdo->exec("CREATE TABLE projects (
+            project_id $pk,
+            user_id INT NOT NULL,
+            github_account_id INT NOT NULL,
+            github_repo VARCHAR(255) NOT NULL,
+            webhook_secret VARCHAR(255),
+            created_at $timestamp,
+            FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+            FOREIGN KEY (github_account_id) REFERENCES user_github_accounts(github_account_id) ON DELETE CASCADE
+        )");
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        $this->projectModel = new Project($this->db);
+        $this->userModel = new User($this->db);
+
+        $this->userModel->createOrUpdate([
+            'google_id' => 'google-123',
+            'name' => 'Test User',
+            'email' => 'test@example.com'
+        ]);
+        $this->userModel->addGitHubAccount(1, 'token-123', 'github-user');
+    }
+
+    public function testCreateProjectWithValidRepo()
+    {
+        $githubService = $this->createMock(GitHubService::class);
+        $githubService->expects($this->once())
+            ->method('getRepository')
+            ->with('owner/repo')
+            ->willReturn(['id' => 123]);
+
+        $result = $this->projectModel->create(1, 1, 'owner/repo', $githubService);
+        $this->assertIsArray($result);
+        $this->assertGreaterThan(0, $result['project_id']);
+    }
+
+    public function testCreateProjectWithInvalidRepo()
+    {
+        $githubService = $this->createMock(GitHubService::class);
+        $githubService->expects($this->once())
+            ->method('getRepository')
+            ->with('owner/invalid')
+            ->willThrowException(new Exception("Not Found", 404));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Not Found");
+
+        $this->projectModel->create(1, 1, 'owner/invalid', $githubService);
+    }
+
+    public function testUpdateProjectWithValidRepo()
+    {
+        $githubService = $this->createMock(GitHubService::class);
+        $githubService->method('getRepository')
+            ->willReturn(['id' => 123]);
+
+        $res = $this->projectModel->create(1, 1, 'owner/old', $githubService);
+        $projectId = $res['project_id'];
+
+        $githubService = $this->createMock(GitHubService::class);
+        $githubService->expects($this->once())
+            ->method('getRepository')
+            ->with('owner/new')
+            ->willReturn(['id' => 456]);
+
+        $result = $this->projectModel->update($projectId, 1, 1, 'owner/new', $githubService);
+        $this->assertTrue($result);
+
+        $project = $this->projectModel->findById($projectId);
+        $this->assertEquals('owner/new', $project['github_repo']);
+    }
+
+    public function testUpdateProjectWithInvalidRepo()
+    {
+        $githubService = $this->createMock(GitHubService::class);
+        $githubService->method('getRepository')
+            ->willReturn(['id' => 123]);
+
+        $res = $this->projectModel->create(1, 1, 'owner/old', $githubService);
+        $projectId = $res['project_id'];
+
+        $githubService = $this->createMock(GitHubService::class);
+        $githubService->expects($this->once())
+            ->method('getRepository')
+            ->with('owner/invalid')
+            ->willThrowException(new Exception("Not Found", 404));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Not Found");
+
+        $this->projectModel->update($projectId, 1, 1, 'owner/invalid', $githubService);
+    }
+}


### PR DESCRIPTION
This change implements repository existence validation when linking or updating projects. It utilizes the GitHub API via `GitHubService` to verify that a repository exists before it is saved to the database. If the repository does not exist, an exception is thrown and an error message is displayed to the user. Integration tests have been added to ensure the validation works as expected for both creation and updates.

Fixes #635

---
*PR created automatically by Jules for task [15053406051122281695](https://jules.google.com/task/15053406051122281695) started by @chatelao*