### PR TITLE
Domain-specific OAuth callback URIs

### DIFF
--- a/src/backend/Auth.php
+++ b/src/backend/Auth.php
@@ -20,7 +20,16 @@ class Auth
         $this->client = new GoogleClient();
         $this->client->setClientId(getenv('GOOGLE_CLIENT_ID'));
         $this->client->setClientSecret(getenv('GOOGLE_CLIENT_SECRET'));
-        $this->client->setRedirectUri(getenv('GOOGLE_REDIRECT_URI'));
+
+        $redirectUri = getenv('GOOGLE_REDIRECT_URI');
+        if (isset($_SERVER['HTTP_HOST']) && !empty($redirectUri)) {
+            $parsedUrl = parse_url($redirectUri);
+            if (isset($parsedUrl['scheme']) && isset($parsedUrl['path'])) {
+                $redirectUri = $parsedUrl['scheme'] . '://' . $_SERVER['HTTP_HOST'] . $parsedUrl['path'];
+            }
+        }
+        $this->client->setRedirectUri($redirectUri);
+
         $this->client->addScope("email");
         $this->client->addScope("profile");
 

--- a/src/backend/GitHubAuth.php
+++ b/src/backend/GitHubAuth.php
@@ -16,7 +16,16 @@ class GitHubAuth
     {
         $this->clientId = getenv('GITHUB_CLIENT_ID') ?: '';
         $this->clientSecret = getenv('GITHUB_CLIENT_SECRET') ?: '';
-        $this->redirectUri = getenv('GITHUB_REDIRECT_URI') ?: '';
+
+        $redirectUri = getenv('GITHUB_REDIRECT_URI') ?: '';
+        if (isset($_SERVER['HTTP_HOST']) && !empty($redirectUri)) {
+            $parsedUrl = parse_url($redirectUri);
+            if (isset($parsedUrl['scheme']) && isset($parsedUrl['path'])) {
+                $redirectUri = $parsedUrl['scheme'] . '://' . $_SERVER['HTTP_HOST'] . $parsedUrl['path'];
+            }
+        }
+        $this->redirectUri = $redirectUri;
+
         $this->httpClient = new Client();
     }
 


### PR DESCRIPTION
Ensured OAuth redirect URIs for Google and GitHub are domain-specific by using `$_SERVER['HTTP_HOST']` when available.

Fixes #645

---
*PR created automatically by Jules for task [14669242064330568493](https://jules.google.com/task/14669242064330568493) started by @chatelao*