### PR TITLE
Treat skipped GitHub checks as successful

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -60,7 +60,7 @@ class Task
                     $status = $suite['status'] ?? '';
                     $conclusion = $suite['conclusion'] ?? '';
 
-                    if ($status !== 'completed') {
+                    if ($status !== 'completed' && $status !== 'skipped') {
                         $running = true;
                         $success = false;
                     } elseif (in_array($conclusion, ['failure', 'timed_out', 'cancelled', 'action_required', 'startup_failure'])) {

--- a/test/Unit/TaskSkippedTest.php
+++ b/test/Unit/TaskSkippedTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\Task;
+use App\Database;
+
+class TaskSkippedTest extends TestCase
+{
+    private $taskModel;
+
+    protected function setUp(): void
+    {
+        $db = $this->createMock(Database::class);
+        $this->taskModel = new Task($db);
+    }
+
+    public function testResolveStatusWithSkippedCheckSuite()
+    {
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1',
+            'status' => Task::STATUS_CHECKING
+        ];
+
+        $checkSuitesData = [
+            'check_suites' => [
+                [
+                    'status' => 'completed',
+                    'conclusion' => 'skipped'
+                ]
+            ]
+        ];
+
+        $status = $this->taskModel->resolveStatus($task, null, $checkSuitesData);
+        $this->assertEquals(Task::STATUS_READY, $status, "A single skipped check suite should result in STATUS_READY");
+    }
+
+    public function testResolveStatusWithMixedSuccessAndSkipped()
+    {
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1',
+            'status' => Task::STATUS_CHECKING
+        ];
+
+        $checkSuitesData = [
+            'check_suites' => [
+                [
+                    'status' => 'completed',
+                    'conclusion' => 'success'
+                ],
+                [
+                    'status' => 'completed',
+                    'conclusion' => 'skipped'
+                ]
+            ]
+        ];
+
+        $status = $this->taskModel->resolveStatus($task, null, $checkSuitesData);
+        $this->assertEquals(Task::STATUS_READY, $status, "Mixed success and skipped should result in STATUS_READY");
+    }
+
+    public function testResolveStatusWithStatusSkipped()
+    {
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1',
+            'status' => Task::STATUS_CHECKING
+        ];
+
+        $checkSuitesData = [
+            'check_suites' => [
+                [
+                    'status' => 'skipped',
+                    'conclusion' => 'neutral'
+                ]
+            ]
+        ];
+
+        $status = $this->taskModel->resolveStatus($task, null, $checkSuitesData);
+        $this->assertEquals(Task::STATUS_READY, $status, "Status 'skipped' should also be considered okay and result in STATUS_READY");
+    }
+
+    public function testResolveStatusWithNoSuitesAndFinishedJules()
+    {
+        // This is the case where jules finished but no check suites were reported yet
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1',
+            'status' => Task::STATUS_CHECKING
+        ];
+
+        $checkSuitesData = null; // Or empty
+
+        $status = $this->taskModel->resolveStatus($task, null, $checkSuitesData);
+        // Current implementation returns STATUS_CHECKING if $checkSuitesData is null
+        $this->assertEquals(Task::STATUS_CHECKING, $status);
+    }
+}


### PR DESCRIPTION
Modified the status resolution logic for tasks to ensure that GitHub check suites with a 'skipped' status or conclusion are treated as non-blocking. This allows tasks to correctly transition from 'checking' to 'ready' when tests are skipped, preventing them from being stuck in a pending state. Added unit tests to verify these scenarios.

Fixes #644

---
*PR created automatically by Jules for task [12263567754300178021](https://jules.google.com/task/12263567754300178021) started by @chatelao*