### PR TITLE
Transition notifications to unified task states

### DIFF
--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -34,19 +34,25 @@ class NotificationService
             return false;
         }
 
-        // 2. Check global user event settings
-        if (!$this->isUserTypeEnabled($userId, $type)) {
-            return false;
-        }
+        // 2. Check for status-based filtering
+        if (isset($data['status'])) {
+            $status = $data['status'];
+            $unifiedState = Task::getUnifiedState($status);
 
-        // 3. Check project-level settings (if project_id is provided)
-        if (isset($data['project_id']) && !$this->isProjectTypeEnabled($data['project_id'], $type)) {
-            return false;
-        }
+            // 2.1 Check global user unified state settings
+            if (!$this->isUserUnifiedStateEnabled($userId, $unifiedState)) {
+                return false;
+            }
 
-        // 3.1 Check if notification is enabled for this status (if it's a task_status event)
-        if ($type === 'task_status' && isset($data['project_id']) && isset($data['status'])) {
-            if (!$this->isStatusNotificationEnabled((int)$data['project_id'], $data['status'])) {
+            // 2.2 Check project-level status settings
+            if (isset($data['project_id'])) {
+                if (!$this->isStatusNotificationEnabled((int)$data['project_id'], $status)) {
+                    return false;
+                }
+            }
+        } else {
+            // Fallback for legacy types or system notifications without status
+            if (!$this->isUserTypeEnabled($userId, $type)) {
                 return false;
             }
         }
@@ -188,59 +194,20 @@ class NotificationService
         return $stmt->execute([$taskId, (int)$isMuted]);
     }
 
+    /**
+     * @deprecated Use getStatusSettings instead
+     */
     public function getProjectSettings(int $projectId): array
     {
-        $stmt = $this->db->getConnection()->prepare(
-            "SELECT notification_type, is_enabled FROM project_notification_settings WHERE project_id = ?"
-        );
-        $stmt->execute([$projectId]);
-        $rows = $stmt->fetchAll();
-
-        $settings = [];
-        foreach ($rows as $row) {
-            $settings[$row['notification_type']] = (bool)$row['is_enabled'];
-        }
-
-        // Default settings if not present
-        $types = ['github_issue', 'github_pr', 'task_status', 'agent_event'];
-        foreach ($types as $type) {
-            if (!isset($settings[$type])) {
-                $settings[$type] = true;
-            }
-        }
-
-        return $settings;
+        return [];
     }
 
+    /**
+     * @deprecated Use updateStatusSettings instead
+     */
     public function updateProjectSettings(int $projectId, array $settings): bool
     {
-        $db = $this->db->getConnection();
-        $db->beginTransaction();
-
-        try {
-            foreach ($settings as $type => $enabled) {
-                $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
-                if ($driver === 'sqlite') {
-                    $stmt = $db->prepare(
-                        "INSERT INTO project_notification_settings (project_id, notification_type, is_enabled)
-                         VALUES (?, ?, ?)
-                         ON CONFLICT(project_id, notification_type) DO UPDATE SET is_enabled = excluded.is_enabled"
-                    );
-                } else {
-                    $stmt = $db->prepare(
-                        "INSERT INTO project_notification_settings (project_id, notification_type, is_enabled)
-                         VALUES (?, ?, ?)
-                         ON DUPLICATE KEY UPDATE is_enabled = VALUES(is_enabled)"
-                    );
-                }
-                $stmt->execute([$projectId, $type, (int)$enabled]);
-            }
-            $db->commit();
-            return true;
-        } catch (\Exception $e) {
-            $db->rollBack();
-            return false;
-        }
+        return true;
     }
 
     public function getStatusSettings(int $projectId): array
@@ -331,10 +298,18 @@ class NotificationService
         return $settings[$type] ?? true;
     }
 
+    private function isUserUnifiedStateEnabled(int $userId, string $unifiedState): bool
+    {
+        $settings = $this->getUserEventSettings($userId);
+        return $settings[$unifiedState] ?? true;
+    }
+
+    /**
+     * @deprecated
+     */
     private function isProjectTypeEnabled(int $projectId, string $type): bool
     {
-        $settings = $this->getProjectSettings($projectId);
-        return $settings[$type] ?? true;
+        return true;
     }
 
     private function isStatusNotificationEnabled(int $projectId, string $status): bool
@@ -536,11 +511,18 @@ class NotificationService
             $settings[$row['notification_type']] = (bool)$row['is_enabled'];
         }
 
-        // Default settings if not present
-        $types = ['github_issue', 'github_pr', 'task_status', 'agent_event'];
-        foreach ($types as $type) {
-            if (!isset($settings[$type])) {
-                $settings[$type] = true;
+        // Unified states
+        $unifiedStates = [
+            Task::UNIFIED_CREATED,
+            Task::UNIFIED_PROCESSING,
+            Task::UNIFIED_READY,
+            Task::UNIFIED_FINISHED,
+            Task::UNIFIED_FAILED
+        ];
+
+        foreach ($unifiedStates as $state) {
+            if (!isset($settings[$state])) {
+                $settings[$state] = true;
             }
         }
 

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -18,6 +18,12 @@ class Task
     public const STATUS_FAILED_JULES = 'failed_jules';
     public const STATUS_FAILED_PR = 'failed_pr';
 
+    public const UNIFIED_CREATED = 'CREATED';
+    public const UNIFIED_PROCESSING = 'PROCESSING';
+    public const UNIFIED_READY = 'READY';
+    public const UNIFIED_FINISHED = 'FINISHED';
+    public const UNIFIED_FAILED = 'FAILED';
+
     public function __construct(private Database $db)
     {
     }
@@ -543,6 +549,60 @@ class Task
         }
 
         return ucwords(str_replace('_', ' ', $status));
+    }
+
+    public static function getUnifiedState(string $status): string
+    {
+        switch ($status) {
+            case self::STATUS_CREATED:
+                return self::UNIFIED_CREATED;
+            case self::STATUS_ANALYZING:
+            case self::STATUS_PLANNING:
+            case self::STATUS_EXECUTING:
+            case self::STATUS_VERIFYING:
+            case self::STATUS_IMPLEMENTED:
+            case self::STATUS_CHECKING:
+            case 'in_progress': // Legacy
+                return self::UNIFIED_PROCESSING;
+            case self::STATUS_READY:
+                return self::UNIFIED_READY;
+            case self::STATUS_FINISHED:
+            case 'completed': // Legacy
+                return self::UNIFIED_FINISHED;
+            case self::STATUS_FAILED_JULES:
+            case self::STATUS_FAILED_PR:
+            case 'failed': // Legacy
+                return self::UNIFIED_FAILED;
+            default:
+                return self::UNIFIED_CREATED;
+        }
+    }
+
+    public static function getStatusGrouping(): array
+    {
+        return [
+            self::UNIFIED_CREATED => [
+                self::STATUS_CREATED => 'Waiting for Agent'
+            ],
+            self::UNIFIED_PROCESSING => [
+                self::STATUS_ANALYZING => 'Analyzing',
+                self::STATUS_PLANNING => 'Planning',
+                self::STATUS_EXECUTING => 'Executing',
+                self::STATUS_VERIFYING => 'Verifying',
+                self::STATUS_IMPLEMENTED => 'Implemented',
+                self::STATUS_CHECKING => 'Checking'
+            ],
+            self::UNIFIED_READY => [
+                self::STATUS_READY => 'Ready'
+            ],
+            self::UNIFIED_FINISHED => [
+                self::STATUS_FINISHED => 'Finished'
+            ],
+            self::UNIFIED_FAILED => [
+                self::STATUS_FAILED_JULES => 'Jules Failed',
+                self::STATUS_FAILED_PR => 'PR Failed'
+            ]
+        ];
     }
 
     public function hasAutorepeatLabel(array $task): bool

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -65,6 +65,7 @@ class WebhookHandler
                 $effectiveNotifService->notify($project['user_id'], 'github_issue', "🗑️ Issue Deleted: #" . $issue['number'], "Issue \"" . ($issue['title'] ?? 'Unknown') . "\" was deleted in " . $project['github_repo'], [
                     'project_id' => $project['project_id'],
                     'issue_number' => $issue['number'],
+                    'status' => Task::STATUS_FINISHED,
                     'source_url' => $issue['html_url'] ?? '',
                     'is_system' => !$this->isUserTriggered($event)
                 ]);
@@ -93,10 +94,13 @@ class WebhookHandler
             ];
 
             if ($action === 'opened') {
+                $notificationData['status'] = Task::STATUS_CREATED;
                 $effectiveNotifService->notify($project['user_id'], 'github_issue', "🆕 Issue Opened: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was opened in " . $project['github_repo'], $notificationData, ['acknowledge']);
             } elseif ($action === 'closed') {
+                $notificationData['status'] = Task::STATUS_FINISHED;
                 $effectiveNotifService->notify($project['user_id'], 'github_issue', "🔒 Issue Closed: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was closed in " . $project['github_repo'], $notificationData);
             } elseif ($action === 'reopened') {
+                $notificationData['status'] = Task::STATUS_CREATED;
                 $effectiveNotifService->notify($project['user_id'], 'github_issue', "🔓 Issue Reopened: #" . $issue['number'], "Issue \"" . $issue['title'] . "\" was reopened in " . $project['github_repo'], $notificationData, ['acknowledge']);
             }
         }
@@ -189,6 +193,7 @@ class WebhookHandler
                 $notificationService->notify($project['user_id'], 'github_issue', "🔁 Auto-Repeat: #" . $issue['number'], "Task \"" . $issue['title'] . "\" was merged/closed with Auto-Repeat. A new issue has been created.", [
                     'project_id' => $project['project_id'],
                     'issue_number' => $issue['number'],
+                    'status' => Task::STATUS_CREATED,
                     'source_url' => $issue['html_url'] ?? '',
                     'is_system' => true
                 ]);
@@ -226,6 +231,7 @@ class WebhookHandler
             $notificationService->notify($project['user_id'], 'github_pr', "$emoji PR $actionText: #" . $pr['number'], "Pull Request \"" . $pr['title'] . "\" was $actionText in " . $project['github_repo'], [
                 'project_id' => $project['project_id'],
                 'pr_number' => $pr['number'],
+                'status' => ($action === 'closed' && ($pr['merged'] ?? false)) ? Task::STATUS_FINISHED : Task::STATUS_CHECKING,
                 'source_url' => $pr['html_url'],
                 'is_system' => !$this->isUserTriggered($event)
             ]);

--- a/src/frontend/project-settings.php
+++ b/src/frontend/project-settings.php
@@ -75,12 +75,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_notifications'
     if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
         die("CSRF token validation failed.");
     }
-    $settings = [
-        'github_issue' => isset($_POST['notify_github_issue']),
-        'github_pr' => isset($_POST['notify_github_pr']),
-        'task_status' => isset($_POST['notify_task_status']),
-        'agent_event' => isset($_POST['notify_agent_event'])
-    ];
 
     $statusSettings = [
         str_replace('-', '_', Task::STATUS_CREATED) => isset($_POST['broadcast_' . Task::STATUS_CREATED]),
@@ -97,7 +91,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_notifications'
     ];
 
     if (
-        $notificationService->updateProjectSettings($projectId, $settings) &&
         $notificationService->updateStatusSettings($projectId, $statusSettings)
     ) {
         $redirectUrl = basename($_SERVER['PHP_SELF']) . "?id=$projectId&success=notifications_updated";
@@ -302,73 +295,32 @@ if (isset($_GET['success'])) {
                         <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
                             <h3 class="text-lg font-bold text-gray-900 mb-4">Notification Preferences</h3>
                             <?php
-                            $projectNotifSettings = $notificationService->getProjectSettings($projectId);
                             $statusNotifSettings = $notificationService->getStatusSettings($projectId);
+                            $grouping = Task::getStatusGrouping();
                             ?>
                             <form method="POST" class="space-y-6">
                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
-                                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-                                    <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                                        <span class="text-sm font-medium text-gray-700">GitHub Issues</span>
-                                        <label class="relative inline-flex items-center cursor-pointer">
-                                            <input type="checkbox" name="notify_github_issue" class="sr-only peer" <?= ($projectNotifSettings['github_issue'] ?? true) ? 'checked' : '' ?>>
-                                            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
-                                        </label>
-                                    </div>
-                                    <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                                        <span class="text-sm font-medium text-gray-700">GitHub PRs</span>
-                                        <label class="relative inline-flex items-center cursor-pointer">
-                                            <input type="checkbox" name="notify_github_pr" class="sr-only peer" <?= ($projectNotifSettings['github_pr'] ?? true) ? 'checked' : '' ?>>
-                                            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
-                                        </label>
-                                    </div>
-                                    <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                                        <span class="text-sm font-medium text-gray-700">Task Status</span>
-                                        <label class="relative inline-flex items-center cursor-pointer">
-                                            <input type="checkbox" name="notify_task_status" class="sr-only peer" <?= ($projectNotifSettings['task_status'] ?? true) ? 'checked' : '' ?>>
-                                            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
-                                        </label>
-                                    </div>
-                                    <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                                        <span class="text-sm font-medium text-gray-700">Agent Events</span>
-                                        <label class="relative inline-flex items-center cursor-pointer">
-                                            <input type="checkbox" name="notify_agent_event" class="sr-only peer" <?= ($projectNotifSettings['agent_event'] ?? true) ? 'checked' : '' ?>>
-                                            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
-                                        </label>
-                                    </div>
-                                </div>
 
-                                <div class="border-t border-gray-100 pt-4">
-                                    <h4 class="text-sm font-bold text-gray-900 mb-2 uppercase tracking-wider">Status Notification Preferences</h4>
-                                    <p class="text-xs text-gray-500 mb-4">Choose which status changes trigger a notification. Disabling a status here will suppress both in-app inbox alerts and external broadcasts (Telegram/Browser).</p>
-                                    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-                                        <?php
-                                        $statuses = [
-                                            Task::STATUS_CREATED => 'Waiting for Agent',
-                                            Task::STATUS_ANALYZING => 'Analyzing',
-                                            Task::STATUS_PLANNING => 'Planning',
-                                            Task::STATUS_EXECUTING => 'Executing',
-                                            Task::STATUS_VERIFYING => 'Verifying',
-                                            Task::STATUS_IMPLEMENTED => 'Implemented',
-                                            Task::STATUS_CHECKING => 'Checking',
-                                            Task::STATUS_READY => 'Ready',
-                                            Task::STATUS_FINISHED => 'Finished',
-                                            Task::STATUS_FAILED_JULES => 'Jules Failed',
-                                            Task::STATUS_FAILED_PR => 'PR Failed'
-                                        ];
-                                        foreach ($statuses as $id => $label) :
-                                            $normalizedId = str_replace('-', '_', $id);
+                                <p class="text-xs text-gray-500 mb-4">Choose which status changes trigger a notification. Disabling a status here will suppress both in-app inbox alerts and external broadcasts (Telegram/Browser).</p>
+
+                                <?php foreach ($grouping as $unifiedState => $statuses) : ?>
+                                    <div class="border-t border-gray-100 pt-4">
+                                        <h4 class="text-sm font-bold text-gray-900 mb-2 uppercase tracking-wider"><?= ucfirst(strtolower($unifiedState)) ?></h4>
+                                        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                                            <?php foreach ($statuses as $id => $label) :
+                                                $normalizedId = str_replace('-', '_', $id);
                                             ?>
-                                        <div class="flex items-center justify-between p-2 bg-gray-50 rounded-lg border border-gray-100 shadow-sm">
-                                            <span class="text-xs font-medium text-gray-600"><?= $label ?></span>
-                                            <label class="relative inline-flex items-center cursor-pointer scale-75">
-                                                <input type="checkbox" name="broadcast_<?= $id ?>" class="sr-only peer" <?= ($statusNotifSettings[$normalizedId] ?? false) ? 'checked' : '' ?>>
-                                                <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
-                                            </label>
+                                            <div class="flex items-center justify-between p-2 bg-gray-50 rounded-lg border border-gray-100 shadow-sm">
+                                                <span class="text-xs font-medium text-gray-600"><?= $label ?></span>
+                                                <label class="relative inline-flex items-center cursor-pointer scale-75">
+                                                    <input type="checkbox" name="broadcast_<?= $id ?>" class="sr-only peer" <?= ($statusNotifSettings[$normalizedId] ?? false) ? 'checked' : '' ?>>
+                                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                                                </label>
+                                            </div>
+                                            <?php endforeach; ?>
                                         </div>
-                                        <?php endforeach; ?>
                                     </div>
-                                </div>
+                                <?php endforeach; ?>
 
                                 <button type="submit" name="update_notifications" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none">Save Notification Settings</button>
                             </form>

--- a/src/frontend/settings.php
+++ b/src/frontend/settings.php
@@ -102,10 +102,11 @@ if ($user && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_notif
         'browser' => isset($_POST['notify_browser'])
     ];
     $eventSettings = [
-        'github_issue' => isset($_POST['notify_github_issue']),
-        'github_pr' => isset($_POST['notify_github_pr']),
-        'task_status' => isset($_POST['notify_task_status']),
-        'agent_event' => isset($_POST['notify_agent_event'])
+        App\Task::UNIFIED_CREATED => isset($_POST['notify_' . App\Task::UNIFIED_CREATED]),
+        App\Task::UNIFIED_PROCESSING => isset($_POST['notify_' . App\Task::UNIFIED_PROCESSING]),
+        App\Task::UNIFIED_READY => isset($_POST['notify_' . App\Task::UNIFIED_READY]),
+        App\Task::UNIFIED_FINISHED => isset($_POST['notify_' . App\Task::UNIFIED_FINISHED]),
+        App\Task::UNIFIED_FAILED => isset($_POST['notify_' . App\Task::UNIFIED_FAILED])
     ];
     if (
         $notificationService->updateUserSettings($user['user_id'], $settings) &&
@@ -432,18 +433,19 @@ if ($user && !$telegramChatId && !empty($telegramBotName) && empty($telegramLink
                                 </div>
 
                                 <div class="border-t border-gray-100 pt-4">
-                                    <h4 class="text-sm font-bold text-gray-900 mb-2 uppercase tracking-wider">Global Event Subscriptions</h4>
-                                    <p class="text-xs text-gray-500 mb-4">Choose which types of events you want to be notified about across all projects.</p>
-                                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+                                    <h4 class="text-sm font-bold text-gray-900 mb-2 uppercase tracking-wider">Global Task State Subscriptions</h4>
+                                    <p class="text-xs text-gray-500 mb-4">Choose which task states you want to be notified about across all projects.</p>
+                                    <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
                                         <?php
                                         $userEventSettings = $notificationService->getUserEventSettings($user['user_id']);
-                                        $eventTypes = [
-                                            'github_issue' => 'GitHub Issues',
-                                            'github_pr' => 'GitHub PRs',
-                                            'task_status' => 'Task Status',
-                                            'agent_event' => 'Agent Events'
+                                        $unifiedStates = [
+                                            Task::UNIFIED_CREATED => 'Created',
+                                            Task::UNIFIED_PROCESSING => 'Processing',
+                                            Task::UNIFIED_READY => 'Ready',
+                                            Task::UNIFIED_FINISHED => 'Finished',
+                                            Task::UNIFIED_FAILED => 'Failed'
                                         ];
-                                        foreach ($eventTypes as $id => $label) :
+                                        foreach ($unifiedStates as $id => $label) :
                                         ?>
                                         <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                                             <span class="text-sm font-medium text-gray-700"><?= $label ?></span>

--- a/test/Integration/NotificationTriggerTest.php
+++ b/test/Integration/NotificationTriggerTest.php
@@ -143,6 +143,18 @@ class NotificationTriggerTest extends TestCase
 
         $this->pdo->exec("INSERT INTO users (user_id, google_id, name, email, jules_api_key) VALUES (1, 'google-1', 'User 1', 'user1@example.com', 'key-123')");
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+
+        // Enable all unified states for user 1
+        $this->pdo->exec("INSERT INTO user_event_notification_settings (user_id, notification_type, is_enabled) VALUES (1, 'CREATED', 1)");
+        $this->pdo->exec("INSERT INTO user_event_notification_settings (user_id, notification_type, is_enabled) VALUES (1, 'PROCESSING', 1)");
+        $this->pdo->exec("INSERT INTO user_event_notification_settings (user_id, notification_type, is_enabled) VALUES (1, 'READY', 1)");
+        $this->pdo->exec("INSERT INTO user_event_notification_settings (user_id, notification_type, is_enabled) VALUES (1, 'FINISHED', 1)");
+        $this->pdo->exec("INSERT INTO user_event_notification_settings (user_id, notification_type, is_enabled) VALUES (1, 'FAILED', 1)");
+
+        // Enable some common statuses at project level by default for tests
+        $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES (1, 'created', 1)");
+        $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES (1, 'checking', 1)");
+        $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES (1, 'finished', 1)");
     }
 
     public function testWebhookIssueOpenedTriggersNotification()

--- a/test/Integration/UserActionNotificationTest.php
+++ b/test/Integration/UserActionNotificationTest.php
@@ -135,6 +135,14 @@ class UserActionNotificationTest extends TestCase
 
         $this->pdo->exec("INSERT INTO users (user_id, google_id, name, email) VALUES (1, 'google-1', 'User 1', 'user1@example.com')");
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+        // Enable CREATED notifications for user 1
+        $this->pdo->exec("INSERT INTO user_event_notification_settings (user_id, notification_type, is_enabled) VALUES (1, 'CREATED', 1)");
+        $this->pdo->exec("INSERT INTO user_event_notification_settings (user_id, notification_type, is_enabled) VALUES (1, 'FINISHED', 1)");
+        $this->pdo->exec("INSERT INTO user_event_notification_settings (user_id, notification_type, is_enabled) VALUES (1, 'CHECKING', 1)");
+
+        $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES (1, 'created', 1)");
+        $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES (1, 'finished', 1)");
+        $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES (1, 'checking', 1)");
     }
 
     public function testHandleSendsNotificationForUserSender()

--- a/test/Unit/Services/NotificationServiceTest.php
+++ b/test/Unit/Services/NotificationServiceTest.php
@@ -36,6 +36,7 @@ class NotificationServiceTest extends TestCase
         $this->pdo->exec("DROP TABLE IF EXISTS user_notification_settings");
         $this->pdo->exec("DROP TABLE IF EXISTS project_notification_settings");
         $this->pdo->exec("DROP TABLE IF EXISTS user_event_notification_settings");
+        $this->pdo->exec("DROP TABLE IF EXISTS project_status_notification_settings");
         $this->pdo->exec("DROP TABLE IF EXISTS task_notification_settings");
         $this->pdo->exec("DROP TABLE IF EXISTS projects");
         $this->pdo->exec("DROP TABLE IF EXISTS users");
@@ -81,6 +82,13 @@ class NotificationServiceTest extends TestCase
             notification_type VARCHAR(50),
             is_enabled BOOLEAN DEFAULT TRUE,
             PRIMARY KEY (project_id, notification_type)
+        )");
+
+        $this->pdo->exec("CREATE TABLE project_status_notification_settings (
+            project_id INT,
+            status VARCHAR(50),
+            is_enabled BOOLEAN DEFAULT TRUE,
+            PRIMARY KEY (project_id, status)
         )");
 
         $this->pdo->exec("CREATE TABLE task_notification_settings (
@@ -129,11 +137,14 @@ class NotificationServiceTest extends TestCase
     {
         $userId = 1;
         $projectId = 200;
-        $type = 'disabled_type';
+        $status = 'some_status';
 
-        $this->pdo->exec("INSERT INTO project_notification_settings (project_id, notification_type, is_enabled) VALUES ($projectId, '$type', 0)");
+        $this->pdo->exec("INSERT INTO project_status_notification_settings (project_id, status, is_enabled) VALUES ($projectId, '$status', 0)");
 
-        $result = $this->notificationService->notify($userId, $type, 'title', 'message', ['project_id' => $projectId]);
+        $result = $this->notificationService->notify($userId, 'type', 'title', 'message', [
+            'project_id' => $projectId,
+            'status' => $status
+        ]);
 
         $this->assertFalse($result);
         $this->assertEquals(0, $this->notificationService->getUnreadCount($userId));


### PR DESCRIPTION
Transitioned the notification subscription system from legacy event types to the unified task state and substate model. Users now subscribe to high-level states (Created, Processing, Ready, Finished, Failed) globally, while maintaining granular control over specific status updates at the project level. Updated backend filtering logic and frontend settings UI to reflect this unified mapping.

Fixes #656

---
*PR created automatically by Jules for task [296123251416137723](https://jules.google.com/task/296123251416137723) started by @chatelao*