### PR TITLE
Fix notification settings case-sensitivity mismatch

### DIFF
--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -508,7 +508,7 @@ class NotificationService
 
         $settings = [];
         foreach ($rows as $row) {
-            $settings[$row['notification_type']] = (bool)$row['is_enabled'];
+            $settings[strtoupper($row['notification_type'])] = (bool)$row['is_enabled'];
         }
 
         // Unified states
@@ -536,6 +536,7 @@ class NotificationService
 
         try {
             foreach ($settings as $type => $enabled) {
+                $type = strtoupper($type);
                 $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
                 if ($driver === 'sqlite') {
                     $stmt = $db->prepare(


### PR DESCRIPTION
Normalizes user event notification setting keys to uppercase in the backend to ensure consistency between the Next-Gen UI (lowercase) and backend logic (uppercase constants). This fixes the issue where disabling notifications in the UI had no effect.

Fixes #664

---
*PR created automatically by Jules for task [11921252038372558171](https://jules.google.com/task/11921252038372558171) started by @chatelao*