### PR TITLE
Update global notification settings with granular substates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -680,6 +680,22 @@ paths:
                       type: boolean
                     failed:
                       type: boolean
+                    analyzing:
+                      type: boolean
+                    planning:
+                      type: boolean
+                    executing:
+                      type: boolean
+                    verifying:
+                      type: boolean
+                    implemented:
+                      type: boolean
+                    checking:
+                      type: boolean
+                    failed_jules:
+                      type: boolean
+                    failed_pr:
+                      type: boolean
       responses:
         '200':
           description: User profile updated successfully
@@ -807,6 +823,22 @@ components:
             finished:
               type: boolean
             failed:
+              type: boolean
+            analyzing:
+              type: boolean
+            planning:
+              type: boolean
+            executing:
+              type: boolean
+            verifying:
+              type: boolean
+            implemented:
+              type: boolean
+            checking:
+              type: boolean
+            failed_jules:
+              type: boolean
+            failed_pr:
               type: boolean
 
     Project:

--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -37,10 +37,9 @@ class NotificationService
         // 2. Check for status-based filtering
         if (isset($data['status'])) {
             $status = $data['status'];
-            $unifiedState = Task::getUnifiedState($status);
 
-            // 2.1 Check global user unified state settings
-            if (!$this->isUserUnifiedStateEnabled($userId, $unifiedState)) {
+            // 2.1 Check global user status settings
+            if (!$this->isUserStatusEnabled($userId, $status)) {
                 return false;
             }
 
@@ -304,6 +303,21 @@ class NotificationService
         return $settings[$unifiedState] ?? true;
     }
 
+    private function isUserStatusEnabled(int $userId, string $status): bool
+    {
+        $normalizedStatus = str_replace('-', '_', $status);
+        $settings = $this->getUserEventSettings($userId);
+
+        // 1. If granular setting exists, it takes precedence
+        if (isset($settings[$normalizedStatus])) {
+            return $settings[$normalizedStatus];
+        }
+
+        // 2. Fallback to unified state setting
+        $unifiedState = Task::getUnifiedState($status);
+        return $settings[$unifiedState] ?? true;
+    }
+
     /**
      * @deprecated
      */
@@ -523,6 +537,30 @@ class NotificationService
         foreach ($unifiedStates as $state) {
             if (!isset($settings[$state])) {
                 $settings[$state] = true;
+            }
+        }
+
+        // Granular statuses
+        $granularStatuses = [
+            Task::STATUS_CREATED,
+            Task::STATUS_ANALYZING,
+            Task::STATUS_PLANNING,
+            Task::STATUS_EXECUTING,
+            Task::STATUS_VERIFYING,
+            Task::STATUS_IMPLEMENTED,
+            Task::STATUS_CHECKING,
+            Task::STATUS_READY,
+            Task::STATUS_FINISHED,
+            Task::STATUS_FAILED_JULES,
+            Task::STATUS_FAILED_PR
+        ];
+
+        foreach ($granularStatuses as $status) {
+            $normalizedStatus = str_replace('-', '_', $status);
+            if (!isset($settings[$normalizedStatus])) {
+                // If the unified state is set, use that as default
+                $unifiedState = Task::getUnifiedState($status);
+                $settings[$normalizedStatus] = $settings[$unifiedState] ?? true;
             }
         }
 

--- a/src/frontend/api/user.php
+++ b/src/frontend/api/user.php
@@ -127,6 +127,15 @@ $output = [
         'ready' => (bool)($eventSettings[\App\Task::UNIFIED_READY] ?? true),
         'finished' => (bool)($eventSettings[\App\Task::UNIFIED_FINISHED] ?? true),
         'failed' => (bool)($eventSettings[\App\Task::UNIFIED_FAILED] ?? true),
+        // Granular
+        'analyzing' => (bool)($eventSettings[\App\Task::STATUS_ANALYZING] ?? true),
+        'planning' => (bool)($eventSettings[\App\Task::STATUS_PLANNING] ?? true),
+        'executing' => (bool)($eventSettings[\App\Task::STATUS_EXECUTING] ?? true),
+        'verifying' => (bool)($eventSettings[\App\Task::STATUS_VERIFYING] ?? true),
+        'implemented' => (bool)($eventSettings[\App\Task::STATUS_IMPLEMENTED] ?? true),
+        'checking' => (bool)($eventSettings[\App\Task::STATUS_CHECKING] ?? true),
+        'failed_jules' => (bool)($eventSettings[\App\Task::STATUS_FAILED_JULES] ?? true),
+        'failed_pr' => (bool)($eventSettings[\App\Task::STATUS_FAILED_PR] ?? true),
     ],
 ];
 

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -63,14 +63,38 @@ export default function SettingsPage() {
     });
   };
 
-  const toggleEvent = (event: 'created' | 'processing' | 'ready' | 'finished' | 'failed') => {
+  const toggleEvent = (event: string) => {
     if (!user?.notification_event_settings) return;
     updateUser.mutate({
       notification_event_settings: {
         ...user.notification_event_settings,
-        [event]: !user.notification_event_settings[event],
+        [event]: !user.notification_event_settings[event as keyof typeof user.notification_event_settings],
       },
     });
+  };
+
+  const statusGrouping = {
+    'CREATED': {
+      'created': 'Waiting for Agent'
+    },
+    'PROCESSING': {
+      'analyzing': 'Analyzing',
+      'planning': 'Planning',
+      'executing': 'Executing',
+      'verifying': 'Verifying',
+      'implemented': 'Implemented',
+      'checking': 'Checking'
+    },
+    'READY': {
+      'ready': 'Ready'
+    },
+    'FINISHED': {
+      'finished': 'Finished'
+    },
+    'FAILED': {
+      'failed_jules': 'Jules Failed',
+      'failed_pr': 'PR Failed'
+    }
   };
 
   const sendTestBroadcast = async () => {
@@ -317,25 +341,32 @@ export default function SettingsPage() {
 
             <section className="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
               <h3 className="text-lg font-semibold text-gray-900 mb-2">Global State Subscriptions</h3>
-              <p className="text-sm text-gray-500 mb-6">Receive notifications when tasks reach these states across all projects.</p>
+              <p className="text-sm text-gray-500 mb-6">Choose which status changes trigger a notification across all projects.</p>
 
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {(['created', 'processing', 'ready', 'finished', 'failed'] as const).map((event) => (
-                  <div key={event} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-100">
-                    <span className="text-sm font-medium text-gray-700 capitalize">{event}</span>
-                    <button
-                      onClick={() => toggleEvent(event)}
-                      disabled={updateUser.isPending}
-                      className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
-                        user?.notification_event_settings?.[event] ? 'bg-blue-600' : 'bg-gray-200'
-                      }`}
-                    >
-                      <span
-                        className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                          user?.notification_event_settings?.[event] ? 'translate-x-4' : 'translate-x-0'
-                        }`}
-                      />
-                    </button>
+              <div className="space-y-8">
+                {(Object.entries(statusGrouping) as [string, Record<string, string>][]).map(([group, statuses]) => (
+                  <div key={group} className="border-t border-gray-100 pt-4 first:border-0 first:pt-0">
+                    <h4 className="text-xs font-bold text-gray-900 mb-3 uppercase tracking-wider">{group}</h4>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                      {Object.entries(statuses).map(([id, label]) => (
+                        <div key={id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-100">
+                          <span className="text-xs font-medium text-gray-600">{label}</span>
+                          <button
+                            onClick={() => toggleEvent(id)}
+                            disabled={updateUser.isPending}
+                            className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
+                              user?.notification_event_settings?.[id as keyof typeof user.notification_event_settings] ? 'bg-blue-600' : 'bg-gray-200'
+                            }`}
+                          >
+                            <span
+                              className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                                user?.notification_event_settings?.[id as keyof typeof user.notification_event_settings] ? 'translate-x-4' : 'translate-x-0'
+                              }`}
+                            />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 ))}
               </div>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1221,6 +1221,14 @@ export interface paths {
                             ready?: boolean;
                             finished?: boolean;
                             failed?: boolean;
+                            analyzing?: boolean;
+                            planning?: boolean;
+                            executing?: boolean;
+                            verifying?: boolean;
+                            implemented?: boolean;
+                            checking?: boolean;
+                            failed_jules?: boolean;
+                            failed_pr?: boolean;
                         };
                     };
                 };
@@ -1372,6 +1380,14 @@ export interface components {
                 ready?: boolean;
                 finished?: boolean;
                 failed?: boolean;
+                analyzing?: boolean;
+                planning?: boolean;
+                executing?: boolean;
+                verifying?: boolean;
+                implemented?: boolean;
+                checking?: boolean;
+                failed_jules?: boolean;
+                failed_pr?: boolean;
             };
         };
         Project: {


### PR DESCRIPTION
I have updated the global notification settings to match the pattern used in project settings, including support for granular task substates. 

Key changes:
1.  **Backend Enhancement**: Updated `App\NotificationService` to support checking for granular status enablement in global user settings. It maintains backward compatibility by falling back to unified state settings if a granular setting is not found.
2.  **API Update**: Modified `src/frontend/api/user.php` to include all 11 granular statuses in the `notification_event_settings` JSON object.
3.  **OpenAPI & Types**: Updated `api/openapi.yaml` to document the new granular fields and regenerated `web/src/types/api.ts`.
4.  **Frontend Redesign**: Completely overhauled the "Global State Subscriptions" section in `web/src/app/settings/page.tsx`. It now displays toggles for individual task statuses (Analyzing, Planning, etc.) grouped under their respective Unified States (Created, Processing, Ready, Finished, Failed), mirroring the project settings UI for a consistent user experience.

All backend unit tests for notifications passed, and the Next-Gen UI build and TypeScript checks were successful.

Fixes #667

---
*PR created automatically by Jules for task [15524128914623529544](https://jules.google.com/task/15524128914623529544) started by @chatelao*