### PR TITLE
Add "Merge, Close & Duplicate" Button

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -538,7 +538,7 @@ paths:
               properties:
                 action:
                   type: string
-                  enum: [trigger_agent, merge_close]
+                  enum: [trigger_agent, merge_close, merge_close_duplicate]
               required:
                 - action
       responses:
@@ -985,6 +985,15 @@ components:
         body:
           type: string
           example: "Steps to reproduce..."
+        labels:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              color:
+                type: string
         status:
           type: string
           enum: [created, analyzing, planning, executing, verifying, checking, ready, finished, implemented, failed_jules, failed_pr]

--- a/src/frontend/api/task.php
+++ b/src/frontend/api/task.php
@@ -103,6 +103,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             break;
 
         case 'merge_close':
+        case 'merge_close_duplicate':
             try {
                 $githubToken = $project['github_token'] ?? null;
                 if (!$githubToken) {
@@ -110,6 +111,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
 
                 $githubService = new App\GitHubService(null, $githubToken);
+
+                if ($action === 'merge_close_duplicate') {
+                    $githubService->addLabel($project['github_repo'], $task['issue_number'], 'autorepeat');
+                }
+
                 $prNumber = $githubService->extractPrNumber($task['pr_url'] ?? '');
 
                 if (!$prNumber) {
@@ -120,10 +126,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $githubService->closeIssue($project['github_repo'], $task['issue_number'], 'completed');
                 $taskModel->markAsMerged($taskId);
 
-                echo json_encode(['status' => 'success', 'message' => 'PR merged and issue closed']);
+                echo json_encode(['status' => 'success', 'message' => $action === 'merge_close_duplicate' ? 'PR merged, issue closed and duplicated' : 'PR merged and issue closed']);
             } catch (Exception $e) {
                 http_response_code(500);
-                echo json_encode(['error' => 'Failed to merge/close: ' . $e->getMessage()]);
+                echo json_encode(['error' => 'Failed to ' . ($action === 'merge_close_duplicate' ? 'merge/close/duplicate' : 'merge/close') . ': ' . $e->getMessage()]);
             }
             break;
 
@@ -156,6 +162,9 @@ if (!$project || (int)$project['user_id'] !== $userId) {
     exit;
 }
 
+$githubData = json_decode($task['github_data'] ?? '{}', true);
+$labels = $githubData['labels'] ?? [];
+
 // Map internal database fields to OpenAPI schema
 echo json_encode([
     'id' => (int)$task['task_id'],
@@ -163,6 +172,7 @@ echo json_encode([
     'issue_number' => (int)$task['issue_number'],
     'title' => $task['title'],
     'body' => $task['body'],
+    'labels' => $labels,
     'status' => $task['status'],
     'agent_response' => $task['agent_response'],
     'pr_url' => $task['pr_url'],

--- a/src/frontend/api/tasks.php
+++ b/src/frontend/api/tasks.php
@@ -52,12 +52,16 @@ $tasks = $taskModel->findByProjectId($projectId);
 
 // Map internal database fields to OpenAPI schema
 $output = array_map(function($task) {
+    $githubData = json_decode($task['github_data'] ?? '{}', true);
+    $labels = $githubData['labels'] ?? [];
+
     return [
         'id' => (int)$task['task_id'],
         'project_id' => (int)$task['project_id'],
         'issue_number' => (int)$task['issue_number'],
         'title' => $task['title'],
         'body' => $task['body'],
+        'labels' => $labels,
         'status' => $task['status'],
         'agent_response' => $task['agent_response'],
         'pr_url' => $task['pr_url'],

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -227,7 +227,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_from_template'
 }
 
 // Handle Merge & Close
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['merge_close']) || isset($_POST['merge_close_duplicate']))) {
     if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
         die("CSRF token validation failed.");
     }
@@ -243,6 +243,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
             }
 
             $githubService = new \App\GitHubService(null, $githubToken);
+
+            if (isset($_POST['merge_close_duplicate'])) {
+                $githubService->addLabel($project['github_repo'], $task['issue_number'], 'autorepeat');
+            }
+
             $prNumber = $githubService->extractPrNumber($task['pr_url'] ?? '');
 
             if (!$prNumber) {
@@ -258,7 +263,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
             // 3. Mark as merged in database
             $taskModel->markAsMerged($taskId);
 
-            header("Location: project.php?id=$projectId&success=merged_closed");
+            $successAction = isset($_POST['merge_close_duplicate']) ? 'merged_closed_duplicated' : 'merged_closed';
+            header("Location: project.php?id=$projectId&success=$successAction");
             exit;
         } catch (Exception $e) {
             $errorMessage = "Error merging/closing: " . $e->getMessage();
@@ -414,6 +420,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                     <?php if (isset($_GET['success']) && $_GET['success'] === 'merged_closed') : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Pull Request merged and Issue closed.
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'merged_closed_duplicated') : ?>
+                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+                            <span class="font-medium">Success!</span> Pull Request merged, Issue closed and duplicated.
                         </div>
                     <?php endif; ?>
 
@@ -592,7 +604,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                             <form method="POST" class="inline">
                                                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                                                 <input type="hidden" name="task_id" value="<?= $task['task_id'] ?>">
-                                                                <button type="submit" name="merge_close" class="text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none w-full" onclick="return confirm('Are you sure you want to merge this PR and close the issue?')">Merge & Close</button>
+                                                                <button type="submit" name="merge_close" class="text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none w-full mb-2" onclick="return confirm('Are you sure you want to merge this PR and close the issue?')">Merge & Close</button>
+                                                            </form>
+                                                            <form method="POST" class="inline">
+                                                                <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                                                <input type="hidden" name="task_id" value="<?= $task['task_id'] ?>">
+                                                                <button type="submit" name="merge_close_duplicate" class="text-white bg-indigo-600 hover:bg-indigo-700 focus:ring-4 focus:ring-indigo-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none w-full" onclick="return confirm('Are you sure you want to merge this PR, close the issue and create a duplicate?')">Merge, Close & Duplicate</button>
                                                             </form>
                                                         <?php endif; ?>
                                                     </div>

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -58,7 +58,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_task_notificat
 }
 
 // Handle Merge & Close
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['merge_close']) || isset($_POST['merge_close_duplicate']))) {
     if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
         die("CSRF token validation failed.");
     }
@@ -70,6 +70,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
         }
 
         $githubService = new \App\GitHubService(null, $githubToken);
+
+        if (isset($_POST['merge_close_duplicate'])) {
+            $githubService->addLabel($project['github_repo'], $task['issue_number'], 'autorepeat');
+        }
+
         $prNumber = $githubService->extractPrNumber($task['pr_url'] ?? '');
 
         if (!$prNumber) {
@@ -85,7 +90,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
         // 3. Mark as merged in database
         $taskModel->markAsMerged($taskId);
 
-        header("Location: task.php?id=$taskId&success=merged_closed");
+        $successAction = isset($_POST['merge_close_duplicate']) ? 'merged_closed_duplicated' : 'merged_closed';
+        header("Location: task.php?id=$taskId&success=$successAction");
         exit;
     } catch (Exception $e) {
         $errorMessage = "Error merging/closing: " . $e->getMessage();
@@ -257,6 +263,12 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                     <?php if (isset($_GET['success']) && $_GET['success'] === 'merged_closed') : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Pull Request merged and Issue closed.
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'merged_closed_duplicated') : ?>
+                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+                            <span class="font-medium">Success!</span> Pull Request merged, Issue closed and duplicated.
                         </div>
                     <?php endif; ?>
 
@@ -467,11 +479,17 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                                     <?php
                                     $isMergeable = ($prDetails && ($prDetails['state'] ?? '') === 'open' && ($prDetails['mergeable_state'] ?? '') === 'clean' && !($prDetails['draft'] ?? false));
                                     if ($isMergeable) : ?>
-                                        <div class="mt-4 pt-4 border-t border-gray-100">
+                                        <div class="mt-4 pt-4 border-t border-gray-100 space-y-3">
                                             <form method="POST">
                                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                                 <button type="submit" name="merge_close" class="w-full text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none" onclick="return confirm('Are you sure you want to merge this PR and close the issue?')">
                                                     Merge & Close
+                                                </button>
+                                            </form>
+                                            <form method="POST">
+                                                <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                                <button type="submit" name="merge_close_duplicate" class="w-full text-white bg-indigo-600 hover:bg-indigo-700 focus:ring-4 focus:ring-indigo-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none" onclick="return confirm('Are you sure you want to merge this PR, close the issue and create a duplicate?')">
+                                                    Merge, Close & Duplicate
                                                 </button>
                                             </form>
                                         </div>

--- a/web/src/app/tasks/[id]/page.tsx
+++ b/web/src/app/tasks/[id]/page.tsx
@@ -76,27 +76,36 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
               <h3 className="text-lg font-bold text-gray-900 mb-4">Actions</h3>
               <div className="flex flex-wrap gap-3">
                 <button
-                  onClick={() => performAction('retry')}
+                  onClick={() => performAction({ action: 'trigger_agent' })}
                   disabled={isPerformingAction}
                   className="px-4 py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
                 >
                   Retry Task
                 </button>
                 <button
-                  onClick={() => performAction('restart')}
+                  onClick={() => performAction({ action: 'trigger_agent' })}
                   disabled={isPerformingAction}
                   className="px-4 py-2 border border-gray-300 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-50 disabled:opacity-50 transition-colors"
                 >
                   Restart from Scratch
                 </button>
-                {task.github_status === 'passed' && (
-                  <button
-                    onClick={() => performAction('merge')}
-                    disabled={isPerformingAction}
-                    className="px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 disabled:opacity-50 transition-colors"
-                  >
-                    Merge PR
-                  </button>
+                {task.status === 'ready' && (
+                  <>
+                    <button
+                      onClick={() => performAction({ action: 'merge_close' })}
+                      disabled={isPerformingAction}
+                      className="px-4 py-2 bg-purple-600 text-white rounded-md text-sm font-medium hover:bg-purple-700 disabled:opacity-50 transition-colors"
+                    >
+                      Merge & Close
+                    </button>
+                    <button
+                      onClick={() => performAction({ action: 'merge_close_duplicate' })}
+                      disabled={isPerformingAction}
+                      className="px-4 py-2 bg-indigo-600 text-white rounded-md text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                    >
+                      Merge, Close & Duplicate
+                    </button>
+                  </>
                 )}
               </div>
             </div>
@@ -114,7 +123,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
                   <div className="space-y-2">
                     {logs.map((log, index) => (
                       <div key={index} className="flex space-x-4">
-                        <span className="text-gray-500 shrink-0">[{new Date(log.created_at).toLocaleTimeString()}]</span>
+                        <span className="text-gray-500 shrink-0">[{log.created_at ? new Date(log.created_at).toLocaleTimeString() : 'Unknown'}]</span>
                         <span className={log.level === 'error' ? 'text-red-400' : 'text-gray-300'}>
                           {log.message}
                         </span>

--- a/web/src/components/InteractionPanel.tsx
+++ b/web/src/components/InteractionPanel.tsx
@@ -5,7 +5,7 @@ type Task = components['schemas']['Task'];
 
 interface InteractionPanelProps {
   task: Task;
-  onAction: (action: 'trigger_agent' | 'merge_close') => void;
+  onAction: (action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate') => void;
   isLoading?: boolean;
 }
 
@@ -30,13 +30,22 @@ export const InteractionPanel: React.FC<InteractionPanelProps> = ({ task, onActi
         )}
 
         {hasPr && !isClosed && (
-          <button
-            onClick={() => onAction('merge_close')}
-            disabled={isLoading}
-            className="w-full text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none disabled:opacity-50"
-          >
-            {isLoading ? 'Merging...' : 'Merge & Close'}
-          </button>
+          <>
+            <button
+              onClick={() => onAction('merge_close')}
+              disabled={isLoading}
+              className="w-full text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none disabled:opacity-50"
+            >
+              {isLoading ? 'Merging...' : 'Merge & Close'}
+            </button>
+            <button
+              onClick={() => onAction('merge_close_duplicate')}
+              disabled={isLoading}
+              className="w-full text-white bg-indigo-600 hover:bg-indigo-700 focus:ring-4 focus:ring-indigo-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none disabled:opacity-50"
+            >
+              {isLoading ? 'Processing...' : 'Merge, Close & Duplicate'}
+            </button>
+          </>
         )}
 
         {(isReady || isImplemented) && (

--- a/web/src/hooks/useTask.ts
+++ b/web/src/hooks/useTask.ts
@@ -17,7 +17,7 @@ export const useTask = (id: number | string | undefined) => {
   });
 
   const taskActionMutation = useMutation({
-    mutationFn: async ({ action }: { action: 'trigger_agent' | 'merge_close' }) => {
+    mutationFn: async ({ action }: { action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate' }) => {
       const response = await apiClient.post(`/task.php?id=${id}`, { action });
       return response.data;
     },

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -945,7 +945,7 @@ export interface paths {
                 content: {
                     "application/json": {
                         /** @enum {string} */
-                        action: "trigger_agent" | "merge_close";
+                        action: "trigger_agent" | "merge_close" | "merge_close_duplicate";
                     };
                 };
             };
@@ -1570,6 +1570,10 @@ export interface components {
             title?: string;
             /** @example Steps to reproduce... */
             body?: string;
+            labels?: {
+                name?: string;
+                color?: string;
+            }[];
             /**
              * @example created
              * @enum {string}


### PR DESCRIPTION
This PR implements a new "Merge, Close & Duplicate" button in both the Legacy (PHP) and Next-Gen (React) user interfaces. 

Key changes:
1. **API & Backend**:
   - Updated `api/openapi.yaml` with the new `merge_close_duplicate` action.
   - Modified `src/frontend/api/task.php` to handle this action by adding an `autorepeat` label to the GitHub issue, merging the associated Pull Request, and closing the issue as 'completed'.
   - Ensured `labels` are included in task API responses.

2. **Legacy UI**:
   - Added the "Merge, Close & Duplicate" button to `src/frontend/task.php` and `src/frontend/project.php`.
   - Handled the new POST action and added success notifications.

3. **Next-Gen UI**:
   - Updated `useTask` hook and `InteractionPanel` component to support the new action.
   - Refactored `performAction` calls in the task detail page to use the correct object-based signature.
   - Regenerated TypeScript types using `openapi-typescript`.

4. **Maintenance**:
   - Fixed latent TypeScript errors in the Next-Gen UI related to missing properties and potential undefined values.
   - Verified the implementation with PHP unit tests and Next.js build/type-checks.

Fixes #679

---
*PR created automatically by Jules for task [10308974663956473552](https://jules.google.com/task/10308974663956473552) started by @chatelao*