### PR TITLE
Add "Merge, Close & Duplicate" button

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -538,7 +538,7 @@ paths:
               properties:
                 action:
                   type: string
-                  enum: [trigger_agent, merge_close]
+                  enum: [trigger_agent, merge_close, merge_close_duplicate]
               required:
                 - action
       responses:

--- a/src/frontend/api/task.php
+++ b/src/frontend/api/task.php
@@ -103,6 +103,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             break;
 
         case 'merge_close':
+        case 'merge_close_duplicate':
             try {
                 $githubToken = $project['github_token'] ?? null;
                 if (!$githubToken) {
@@ -116,14 +117,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     throw new Exception("No pull request associated with this task.");
                 }
 
+                if ($action === 'merge_close_duplicate') {
+                    $githubService->addLabel($project['github_repo'], $task['issue_number'], 'autorepeat');
+                }
+
                 $githubService->mergePullRequest($project['github_repo'], $prNumber, "Merged via Agent Control API: " . $task['title']);
                 $githubService->closeIssue($project['github_repo'], $task['issue_number'], 'completed');
                 $taskModel->markAsMerged($taskId);
 
-                echo json_encode(['status' => 'success', 'message' => 'PR merged and issue closed']);
+                $msg = $action === 'merge_close_duplicate' ? 'PR merged, issue closed and duplicated' : 'PR merged and issue closed';
+                echo json_encode(['status' => 'success', 'message' => $msg]);
             } catch (Exception $e) {
                 http_response_code(500);
-                echo json_encode(['error' => 'Failed to merge/close: ' . $e->getMessage()]);
+                echo json_encode(['error' => 'Failed to perform ' . $action . ': ' . $e->getMessage()]);
             }
             break;
 

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -227,13 +227,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_from_template'
 }
 
 // Handle Merge & Close
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['merge_close']) || isset($_POST['merge_close_duplicate']))) {
     if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
         die("CSRF token validation failed.");
     }
 
     $taskId = (int)$_POST['task_id'];
     $task = $taskModel->findById($taskId);
+    $isDuplicate = isset($_POST['merge_close_duplicate']);
 
     if ($task && $task['project_id'] === $project['project_id']) {
         try {
@@ -249,6 +250,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
                 throw new Exception("No pull request associated with this task.");
             }
 
+            // 0. Add autorepeat label if requested
+            if ($isDuplicate) {
+                $githubService->addLabel($project['github_repo'], $task['issue_number'], 'autorepeat');
+            }
+
             // 1. Merge the PR
             $githubService->mergePullRequest($project['github_repo'], $prNumber, "Merged via Agent Control: " . $task['title']);
 
@@ -258,7 +264,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
             // 3. Mark as merged in database
             $taskModel->markAsMerged($taskId);
 
-            header("Location: project.php?id=$projectId&success=merged_closed");
+            $successParam = $isDuplicate ? 'merged_closed_duplicated' : 'merged_closed';
+            header("Location: project.php?id=$projectId&success=$successParam");
             exit;
         } catch (Exception $e) {
             $errorMessage = "Error merging/closing: " . $e->getMessage();
@@ -414,6 +421,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                     <?php if (isset($_GET['success']) && $_GET['success'] === 'merged_closed') : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Pull Request merged and Issue closed.
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'merged_closed_duplicated') : ?>
+                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+                            <span class="font-medium">Success!</span> Pull Request merged, Issue closed and duplicated.
                         </div>
                     <?php endif; ?>
 
@@ -592,7 +605,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                             <form method="POST" class="inline">
                                                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                                                 <input type="hidden" name="task_id" value="<?= $task['task_id'] ?>">
-                                                                <button type="submit" name="merge_close" class="text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none w-full" onclick="return confirm('Are you sure you want to merge this PR and close the issue?')">Merge & Close</button>
+                                                                <button type="submit" name="merge_close" class="text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none w-full mb-2" onclick="return confirm('Are you sure you want to merge this PR and close the issue?')">Merge & Close</button>
+                                                            </form>
+                                                            <form method="POST" class="inline">
+                                                                <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                                                <input type="hidden" name="task_id" value="<?= $task['task_id'] ?>">
+                                                                <button type="submit" name="merge_close_duplicate" class="text-white bg-indigo-600 hover:bg-indigo-700 focus:ring-4 focus:ring-indigo-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none w-full" onclick="return confirm('Are you sure you want to merge this PR, close the issue and duplicate it?')">Merge, Close & Duplicate</button>
                                                             </form>
                                                         <?php endif; ?>
                                                     </div>

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -58,10 +58,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_task_notificat
 }
 
 // Handle Merge & Close
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['merge_close']) || isset($_POST['merge_close_duplicate']))) {
     if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
         die("CSRF token validation failed.");
     }
+
+    $isDuplicate = isset($_POST['merge_close_duplicate']);
 
     try {
         $githubToken = $project['github_token'] ?? null;
@@ -76,6 +78,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
             throw new Exception("No pull request associated with this task.");
         }
 
+        // 0. Add autorepeat label if requested
+        if ($isDuplicate) {
+            $githubService->addLabel($project['github_repo'], $task['issue_number'], 'autorepeat');
+        }
+
         // 1. Merge the PR
         $githubService->mergePullRequest($project['github_repo'], $prNumber, "Merged via Agent Control: " . $task['title']);
 
@@ -85,7 +92,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['merge_close'])) {
         // 3. Mark as merged in database
         $taskModel->markAsMerged($taskId);
 
-        header("Location: task.php?id=$taskId&success=merged_closed");
+        $successParam = $isDuplicate ? 'merged_closed_duplicated' : 'merged_closed';
+        header("Location: task.php?id=$taskId&success=$successParam");
         exit;
     } catch (Exception $e) {
         $errorMessage = "Error merging/closing: " . $e->getMessage();
@@ -257,6 +265,12 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                     <?php if (isset($_GET['success']) && $_GET['success'] === 'merged_closed') : ?>
                         <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
                             <span class="font-medium">Success!</span> Pull Request merged and Issue closed.
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if (isset($_GET['success']) && $_GET['success'] === 'merged_closed_duplicated') : ?>
+                        <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+                            <span class="font-medium">Success!</span> Pull Request merged, Issue closed and duplicated.
                         </div>
                     <?php endif; ?>
 
@@ -467,11 +481,17 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                                     <?php
                                     $isMergeable = ($prDetails && ($prDetails['state'] ?? '') === 'open' && ($prDetails['mergeable_state'] ?? '') === 'clean' && !($prDetails['draft'] ?? false));
                                     if ($isMergeable) : ?>
-                                        <div class="mt-4 pt-4 border-t border-gray-100">
+                                        <div class="mt-4 pt-4 border-t border-gray-100 space-y-2">
                                             <form method="POST">
                                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                                 <button type="submit" name="merge_close" class="w-full text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none" onclick="return confirm('Are you sure you want to merge this PR and close the issue?')">
                                                     Merge & Close
+                                                </button>
+                                            </form>
+                                            <form method="POST">
+                                                <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
+                                                <button type="submit" name="merge_close_duplicate" class="w-full text-white bg-indigo-600 hover:bg-indigo-700 focus:ring-4 focus:ring-indigo-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none" onclick="return confirm('Are you sure you want to merge this PR, close the issue and duplicate it?')">
+                                                    Merge, Close & Duplicate
                                                 </button>
                                             </form>
                                         </div>

--- a/web/src/app/tasks/[id]/TaskDetailView.tsx
+++ b/web/src/app/tasks/[id]/TaskDetailView.tsx
@@ -89,13 +89,22 @@ export default function TaskDetailView({ id }: { id: string }) {
                   Restart from Scratch
                 </button>
                 {(task.status === 'ready' || task.status === 'implemented') && (
-                  <button
-                    onClick={() => performAction({ action: 'merge_close' })}
-                    disabled={isPerformingAction}
-                    className="px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 disabled:opacity-50 transition-colors"
-                  >
-                    Merge PR
-                  </button>
+                  <>
+                    <button
+                      onClick={() => performAction({ action: 'merge_close' })}
+                      disabled={isPerformingAction}
+                      className="px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 disabled:opacity-50 transition-colors"
+                    >
+                      Merge PR
+                    </button>
+                    <button
+                      onClick={() => performAction({ action: 'merge_close_duplicate' })}
+                      disabled={isPerformingAction}
+                      className="px-4 py-2 bg-indigo-600 text-white rounded-md text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                    >
+                      Merge, Close & Duplicate
+                    </button>
+                  </>
                 )}
               </div>
             </div>

--- a/web/src/components/InteractionPanel.tsx
+++ b/web/src/components/InteractionPanel.tsx
@@ -5,7 +5,7 @@ type Task = components['schemas']['Task'];
 
 interface InteractionPanelProps {
   task: Task;
-  onAction: (action: 'trigger_agent' | 'merge_close') => void;
+  onAction: (action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate') => void;
   isLoading?: boolean;
 }
 
@@ -30,13 +30,22 @@ export const InteractionPanel: React.FC<InteractionPanelProps> = ({ task, onActi
         )}
 
         {hasPr && !isClosed && (
-          <button
-            onClick={() => onAction('merge_close')}
-            disabled={isLoading}
-            className="w-full text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none disabled:opacity-50"
-          >
-            {isLoading ? 'Merging...' : 'Merge & Close'}
-          </button>
+          <>
+            <button
+              onClick={() => onAction('merge_close')}
+              disabled={isLoading}
+              className="w-full text-white bg-purple-600 hover:bg-purple-700 focus:ring-4 focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none disabled:opacity-50"
+            >
+              {isLoading ? 'Merging...' : 'Merge & Close'}
+            </button>
+            <button
+              onClick={() => onAction('merge_close_duplicate')}
+              disabled={isLoading}
+              className="w-full text-white bg-indigo-600 hover:bg-indigo-700 focus:ring-4 focus:ring-indigo-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none disabled:opacity-50"
+            >
+              {isLoading ? 'Processing...' : 'Merge, Close & Duplicate'}
+            </button>
+          </>
         )}
 
         {(isReady || isImplemented) && (

--- a/web/src/hooks/useTask.ts
+++ b/web/src/hooks/useTask.ts
@@ -17,7 +17,7 @@ export const useTask = (id: number | string | undefined) => {
   });
 
   const taskActionMutation = useMutation({
-    mutationFn: async ({ action }: { action: 'trigger_agent' | 'merge_close' }) => {
+    mutationFn: async ({ action }: { action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate' }) => {
       const response = await apiClient.post(`/task.php?id=${id}`, { action });
       return response.data;
     },

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -945,7 +945,7 @@ export interface paths {
                 content: {
                     "application/json": {
                         /** @enum {string} */
-                        action: "trigger_agent" | "merge_close";
+                        action: "trigger_agent" | "merge_close" | "merge_close_duplicate";
                     };
                 };
             };


### PR DESCRIPTION
I have implemented the "Merge, Close & Duplicate" feature across the entire application. 

Key changes:
- **API**: Added `merge_close_duplicate` to the Task action enum in `api/openapi.yaml`.
- **Backend API**: Updated `src/frontend/api/task.php` to handle the new action. It adds the `autorepeat` label to the GitHub issue before merging the PR and closing the issue, which triggers the existing auto-repeat logic.
- **Legacy UI**: Added the "Merge, Close & Duplicate" button to both the project task list (`src/frontend/project.php`) and the task detail view (`src/frontend/task.php`). These buttons are only displayed when a mergeable PR is present.
- **Next-Gen UI**: 
    - Regenerated TypeScript types from the updated OpenAPI spec.
    - Updated the `useTask` hook to support the new action.
    - Added the button to the `InteractionPanel` and the `TaskDetailView`.
- **Verification**: 
    - Successfully ran PHP unit tests.
    - Confirmed the Next-Gen UI builds and type-checks without errors.
    - Verified that the implementation correctly uses the `autorepeat` label to trigger duplication via the `WebhookHandler`.

Fixes #684

---
*PR created automatically by Jules for task [1190148392120578184](https://jules.google.com/task/1190148392120578184) started by @chatelao*