### PR TITLE
Fix "Clear all" notifications functionality

### DIFF
--- a/src/backend/NotificationService.php
+++ b/src/backend/NotificationService.php
@@ -448,6 +448,14 @@ class NotificationService
         return $stmt->execute([$userId]);
     }
 
+    public function deleteAllNotifications(int $userId): bool
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "DELETE FROM notifications WHERE user_id = ?"
+        );
+        return $stmt->execute([$userId]);
+    }
+
     public function getTotalCount(int $userId): int
     {
         $stmt = $this->db->getConnection()->prepare(

--- a/src/frontend/ajax-notifications.php
+++ b/src/frontend/ajax-notifications.php
@@ -105,6 +105,15 @@ try {
 
         $notificationService->markAllAsRead($userId);
         echo json_encode(['status' => 'success']);
+    } elseif ($action === 'clear_all') {
+        if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
+            http_response_code(403);
+            echo json_encode(['error' => 'CSRF token validation failed']);
+            exit;
+        }
+
+        $notificationService->deleteAllNotifications($userId);
+        echo json_encode(['status' => 'success']);
     } elseif ($action === 'test_broadcast') {
         if (!$auth->validateCsrfToken($_POST['csrf_token'] ?? null)) {
             http_response_code(403);

--- a/src/frontend/navbar-icons.php
+++ b/src/frontend/navbar-icons.php
@@ -206,12 +206,12 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
         })
         .catch(err => console.error('Failed to mark notification as read:', err));
     },
-    markAllRead() {
+    clearAll() {
         const basePath = window.location.pathname.includes('/admin/') ? '../' : '';
         const formData = new FormData();
         formData.append('csrf_token', this.csrfToken);
 
-        fetch(basePath + 'ajax-notifications.php?action=mark_all_read', {
+        fetch(basePath + 'ajax-notifications.php?action=clear_all', {
             method: 'POST',
             body: formData
         })
@@ -219,10 +219,10 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
         .then(data => {
             if (data.status === 'success') {
                 this.unreadNotifications = 0;
-                this.notifications = this.notifications.map(n => ({ ...n, is_read: 1 }));
+                this.notifications = [];
             }
         })
-        .catch(err => console.error('Failed to mark all notifications as read:', err));
+        .catch(err => console.error('Failed to clear notifications:', err));
     }
 }">
     <div class="flex items-center" x-show="syncing || syncStatus">
@@ -305,7 +305,7 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
                 </template>
             </div>
             <div class="p-2 border-t border-gray-100 flex justify-center space-x-6 bg-gray-50">
-                <button @click="markAllRead()" class="text-xs text-blue-600 hover:underline">Clear all</button>
+                <button @click="clearAll()" class="text-xs text-blue-600 hover:underline">Clear all</button>
                 <a href="notifications.php" class="text-xs text-blue-600 hover:underline">View all</a>
             </div>
         </div>

--- a/test/Unit/Services/NotificationServiceTest.php
+++ b/test/Unit/Services/NotificationServiceTest.php
@@ -195,6 +195,19 @@ class NotificationServiceTest extends TestCase
         $this->assertEquals(1, $updatedNotification['is_read']);
     }
 
+    public function testDeleteAllNotifications()
+    {
+        $userId = 1;
+        $this->notificationService->notify($userId, 'type1', 'title1', 'message1');
+        $this->notificationService->notify($userId, 'type2', 'title2', 'message2');
+
+        $this->assertEquals(2, $this->notificationService->getTotalCount($userId));
+
+        $this->notificationService->deleteAllNotifications($userId);
+
+        $this->assertEquals(0, $this->notificationService->getTotalCount($userId));
+    }
+
     public function testGetUnreadCount()
     {
         $userId = 1;


### PR DESCRIPTION
This PR fixes the issue where clicking "Clear all" in the notification dropdown tray did not actually remove the notifications. The implementation was changed from merely marking them as read (which left them visible in the list) to actually deleting them for the user, which better matches the "Clear" terminology and user expectation.

Key changes:
- `App\NotificationService`: Added `deleteAllNotifications(int $userId)` to handle database deletion.
- `ajax-notifications.php`: Added `clear_all` API endpoint.
- `navbar-icons.php`: Updated Alpine.js logic to call the new endpoint and immediately clear the frontend notifications array.
- `NotificationServiceTest.php`: Added unit test coverage for the new deletion method.

Fixes #683

---
*PR created automatically by Jules for task [12884992041204575731](https://jules.google.com/task/12884992041204575731) started by @chatelao*