### PR TITLE
Convert /web paths to be relative

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -6,17 +6,19 @@ import { useAdminUsers } from '@/hooks/useAdminUsers';
 import { useUser } from '@/hooks/useUser';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+import { useRelativePath } from '@/hooks/useRelativePath';
 
 export default function AdminDashboard() {
+  const { rel } = useRelativePath();
   const { data: currentUser, isLoading: isUserLoading } = useUser();
   const { data: users, isLoading: isUsersLoading, error } = useAdminUsers();
   const router = useRouter();
 
   useEffect(() => {
     if (!isUserLoading && currentUser && currentUser.role !== 'admin') {
-      router.push('/');
+      router.push(rel('/'));
     }
-  }, [currentUser, isUserLoading, router]);
+  }, [currentUser, isUserLoading, router, rel]);
 
   if (isUserLoading || isUsersLoading) {
     return (
@@ -55,13 +57,13 @@ export default function AdminDashboard() {
           </div>
           <div className="flex space-x-3">
             <a
-              href="/admin/db-check.php"
+              href={rel('/admin/db-check.php')}
               className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
             >
               DB Check
             </a>
             <a
-              href="/admin/upgrade.php"
+              href={rel('/admin/upgrade.php')}
               className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
             >
               System Upgrade

--- a/web/src/app/projects/[id]/ProjectDetailView.tsx
+++ b/web/src/app/projects/[id]/ProjectDetailView.tsx
@@ -3,6 +3,7 @@
 import React, { use, useState, useMemo } from 'react';
 import Link from 'next/link';
 import { useProject } from '@/hooks/useProject';
+import { useRelativePath } from '@/hooks/useRelativePath';
 import { useTasks } from '@/hooks/useTasks';
 import { useTemplates } from '@/hooks/useTemplates';
 import StatusBadge from '@/components/StatusBadge';
@@ -13,6 +14,7 @@ import { components } from '@/types/api';
 type TaskStatus = components['schemas']['Task']['status'];
 
 export default function ProjectDetailView({ id }: { id: string }) {
+  const { rel } = useRelativePath();
   const projectId = parseInt(id);
   const { data: project, isLoading: projectLoading, error: projectError, syncIssues, isSyncing, createFromTemplate, isCreatingFromTemplate, createFromRoadmap, isCreatingFromRoadmap } = useProject(projectId);
   const { data: tasks, isLoading: tasksLoading } = useTasks(projectId);
@@ -46,7 +48,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
           <p className="font-bold">Error loading project</p>
           <p className="text-sm">Please try again later or check your connection.</p>
         </div>
-        <Link href="/" className="mt-4 text-blue-600 hover:underline">
+        <Link href={rel('/')} className="mt-4 text-blue-600 hover:underline">
           Back to Dashboard
         </Link>
       </div>
@@ -62,7 +64,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
           <div>
             <nav className="flex mb-2" aria-label="Breadcrumb">
               <ol className="flex items-center space-x-2 text-sm text-gray-500">
-                <li><Link href="/" className="hover:text-gray-700">Dashboard</Link></li>
+                <li><Link href={rel('/')} className="hover:text-gray-700">Dashboard</Link></li>
                 <li><svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd"></path></svg></li>
                 <li className="font-medium text-gray-900 truncate max-w-[200px]">{project.github_repo}</li>
               </ol>
@@ -84,7 +86,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
               {isSyncing ? 'Syncing...' : 'Sync Issues'}
             </button>
             <Link
-              href={`/projects/${id}/settings`}
+              href={rel(`/projects/${id}/settings`)}
               className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-all"
             >
               Settings
@@ -128,7 +130,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
                       <tr key={task.id} className="hover:bg-gray-50 transition-colors">
                         <td className="px-6 py-4">
                           <div className="flex flex-col">
-                            <Link href={`/tasks/${task.id}`} className="text-sm font-bold text-blue-600 hover:underline">
+                            <Link href={rel(`/tasks/${task.id}`)} className="text-sm font-bold text-blue-600 hover:underline">
                               #{task.issue_number} - {task.title}
                             </Link>
                             <span className="text-xs text-gray-500 mt-1 line-clamp-1">
@@ -141,7 +143,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
                           <StatusBadge status={task.status} />
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                          <Link href={`/tasks/${task.id}`} className="text-blue-600 hover:text-blue-900">
+                          <Link href={rel(`/tasks/${task.id}`)} className="text-blue-600 hover:text-blue-900">
                             Details
                           </Link>
                         </td>
@@ -214,7 +216,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
               ) : (
                 <p className="text-sm text-gray-500 italic">
                   No templates found.{' '}
-                  <Link href="/templates" className="text-blue-600 hover:underline">
+                  <Link href={rel('/templates')} className="text-blue-600 hover:underline">
                     Create one here.
                   </Link>
                 </p>

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -4,8 +4,10 @@ import React, { useState, useEffect } from 'react';
 import Navbar from '@/components/Navbar';
 import { useUser, useUpdateUser } from '@/hooks/useUser';
 import apiClient from '@/api/client';
+import { useRelativePath } from '@/hooks/useRelativePath';
 
 export default function SettingsPage() {
+  const { rel } = useRelativePath();
   const { data: user, isLoading } = useUser();
   const updateUser = useUpdateUser();
   const [activeTab, setActiveTab] = useState<'general' | 'notifications'>('general');
@@ -272,7 +274,7 @@ export default function SettingsPage() {
                 )}
                 <div className="pt-2">
                   <a
-                    href="/github/login.php"
+                    href={rel('/github/login.php')}
                     className="inline-flex items-center text-sm font-medium text-blue-600 hover:underline"
                   >
                     Link another GitHub account →

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -3,32 +3,34 @@
 import React from 'react';
 import Link from 'next/link';
 import { useUser } from '@/hooks/useUser';
+import { useRelativePath } from '@/hooks/useRelativePath';
 
 const Navbar = () => {
   const { data: user } = useUser();
+  const { rel } = useRelativePath();
 
   return (
     <nav className="bg-white border-b border-gray-200 px-4 py-3 sticky top-0 z-10">
       <div className="max-w-7xl mx-auto flex justify-between items-center">
         <div className="flex items-center space-x-8">
-          <Link href="/" className="text-xl font-bold text-gray-900 hover:text-blue-600 transition-colors">
+          <Link href={rel('/')} className="text-xl font-bold text-gray-900 hover:text-blue-600 transition-colors">
             Agent Control
           </Link>
           <div className="hidden md:flex items-center space-x-4">
-            <Link href="/" className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
+            <Link href={rel('/')} className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
               Dashboard
             </Link>
-            <Link href="/logs" className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
+            <Link href={rel('/logs')} className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
               Logs
             </Link>
-            <Link href="/settings" className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
+            <Link href={rel('/settings')} className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
               Settings
             </Link>
-            <Link href="/templates" className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
+            <Link href={rel('/templates')} className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
               Templates
             </Link>
             {user?.role === 'admin' && (
-              <Link href="/admin" className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
+              <Link href={rel('/admin')} className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
                 Admin
               </Link>
             )}

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { components } from '@/types/api';
 import TaskStatusGrid from './TaskStatusGrid';
+import { useRelativePath } from '@/hooks/useRelativePath';
 
 type Project = components['schemas']['Project'];
 type Task = components['schemas']['Task'];
@@ -12,19 +13,21 @@ interface ProjectCardProps {
 }
 
 export const ProjectCard: React.FC<ProjectCardProps> = ({ project, tasks = [] }) => {
+  const { rel } = useRelativePath();
+
   return (
     <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-5 flex flex-col h-full">
       <div className="flex justify-between items-start mb-2">
         <h3 className="text-lg font-bold text-gray-900 truncate pr-4">
           <Link
-            href={`/projects/${project.id}`}
+            href={rel(`/projects/${project.id}`)}
             className="hover:text-blue-600 transition-colors"
           >
             {project.github_repo}
           </Link>
         </h3>
         <Link
-          href={`/projects/${project.id}/settings`}
+          href={rel(`/projects/${project.id}/settings`)}
           className="text-gray-400 hover:text-gray-600 focus:outline-none p-1 rounded-md hover:bg-gray-100 transition-colors"
           title="Project Settings"
         >
@@ -49,7 +52,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({ project, tasks = [] })
 
       <div className="mt-4 pt-4 border-t border-gray-100">
         <Link
-          href={`/projects/${project.id}`}
+          href={rel(`/projects/${project.id}`)}
           className="text-blue-600 hover:text-blue-800 text-sm font-semibold inline-flex items-center group"
         >
           View Details

--- a/web/src/components/TaskSidebar.tsx
+++ b/web/src/components/TaskSidebar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { components } from '@/types/api';
+import { useRelativePath } from '@/hooks/useRelativePath';
 
 type Task = components['schemas']['Task'];
 
@@ -8,6 +9,7 @@ interface TaskSidebarProps {
 }
 
 export const TaskSidebar: React.FC<TaskSidebarProps> = ({ task }) => {
+  const { rel } = useRelativePath();
   return (
     <div className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
       <h3 className="text-lg font-bold text-gray-900 mb-4">Links & Info</h3>

--- a/web/src/components/TaskStatusSquare.tsx
+++ b/web/src/components/TaskStatusSquare.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { components } from '@/types/api';
+import { useRelativePath } from '@/hooks/useRelativePath';
 
 type Task = components['schemas']['Task'];
 type TaskStatus = Task['status'];
@@ -42,6 +43,7 @@ const getStatusLabel = (status: TaskStatus): string => {
 };
 
 export const TaskStatusSquare: React.FC<TaskStatusSquareProps> = ({ task }) => {
+  const { rel } = useRelativePath();
   const status = task.status || 'created';
   const colorClass = statusColors[status] || 'bg-gray-400';
   const emoji = getStatusEmoji(status);
@@ -56,7 +58,7 @@ export const TaskStatusSquare: React.FC<TaskStatusSquareProps> = ({ task }) => {
   return (
     <div className="relative group">
       <Link
-        href={`/tasks/${task.id}`}
+        href={rel(`/tasks/${task.id}`)}
         className={`block w-6 h-6 rounded shadow-sm transition-transform duration-200 hover:scale-125 hover:z-10 ${colorClass}`}
         aria-label={`Task #${task.issue_number}: ${label}`}
       />

--- a/web/src/hooks/useRelativePath.ts
+++ b/web/src/hooks/useRelativePath.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+/**
+ * Hook to convert root-relative paths to relative paths based on current URL depth.
+ * This ensures the exported static site is portable and doesn't rely on being at the domain root.
+ */
+export const useRelativePath = () => {
+  const pathname = usePathname() || '/';
+
+  /**
+   * Converts a root-relative path (relative to domain root or basePath root) to a relative path.
+   *
+   * @param targetPath The path starting with '/'
+   * @returns A relative path starting with './' or '../'
+   */
+  const rel = (targetPath: string): string => {
+    // 1. API paths should remain absolute root-relative as they are proxied or handled by the server root
+    if (targetPath.startsWith('/api/')) {
+      return targetPath;
+    }
+
+    // 2. External links or already relative links return as is
+    if (targetPath.startsWith('http') || targetPath.startsWith('./') || targetPath.startsWith('../')) {
+      return targetPath;
+    }
+
+    // 3. Identify if the path is intended to be outside the /web basePath (Legacy UI)
+    const isLegacy = targetPath.startsWith('/github/') ||
+                     targetPath.startsWith('/google/') ||
+                     targetPath.startsWith('/admin/') ||
+                     targetPath.startsWith('/logout.php') ||
+                     targetPath.startsWith('/index.php') ||
+                     targetPath.endsWith('.php');
+
+    // Calculate how many levels we are deep within the /web basePath
+    // e.g., if at /web/projects/1/, usePathname() returns /projects/1
+    const segments = pathname.split('/').filter(s => s.length > 0);
+    const depth = segments.length;
+
+    // To reach domain root from /web/..., we need to go up (depth + 1) levels
+    // (depth for the path inside /web, plus 1 for /web itself)
+    const upToDomainRoot = '../'.repeat(depth + 1);
+
+    if (isLegacy) {
+      return upToDomainRoot + targetPath.slice(1);
+    }
+
+    // Internal Next-Gen UI paths
+    // In Next.js with basePath: '/web', we usually link to '/' or '/logs'
+    // and it resolves to '/web/' or '/web/logs/'.
+    // Here we want to produce a truly relative link for portability.
+
+    const target = targetPath.startsWith('/') ? targetPath.slice(1) : targetPath;
+
+    // If target is root '/', it means the root of /web
+    if (target === '') {
+      // From /web/projects/1/ to /web/ -> ../../
+      return depth > 0 ? '../'.repeat(depth) : './';
+    }
+
+    // From /web/projects/1/ to /web/logs/ -> ../../logs/
+    const upToWebRoot = depth > 0 ? '../'.repeat(depth) : './';
+    return upToWebRoot + target + (target.includes('.') ? '' : '/');
+  };
+
+  return { rel };
+};


### PR DESCRIPTION
This change ensures that the Next-Gen UI in the `/web` directory uses relative paths (e.g., `../`, `./`) for internal navigation instead of root-relative paths. This improves the portability of the exported static site. 

Key changes:
- Introduced `web/src/hooks/useRelativePath.ts` which provides a `rel()` helper.
- The `rel()` helper calculates the correct number of `../` segments based on the current `usePathname()` depth.
- API paths (starting with `/api/`) are explicitly ignored by the helper and remain root-relative.
- Updated `Navbar`, `ProjectCard`, `TaskStatusSquare`, and several page views to utilize this hook.
- Legacy UI links (e.g., to `/github/` or `/admin/*.php`) are also converted to be relative to the domain root from the current `/web` nested path.

Verification:
- Successfully ran `npm run build` in the `web/` directory.
- Ran PHP unit tests via `php vendor/bin/phpunit test/Unit` with 100% success.
- Verified that API hooks still target `/api/` correctly.

Fixes #685

---
*PR created automatically by Jules for task [11765505508513090272](https://jules.google.com/task/11765505508513090272) started by @chatelao*