### PR TITLE
Ensure relative paths in /web (excluding API)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getRelativePath } from '@/utils/paths';
 
 const apiClient = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || '/api',
@@ -45,7 +46,8 @@ apiClient.interceptors.response.use(
           localStorage.removeItem('access_token');
           localStorage.removeItem('refresh_token');
           if (typeof window !== 'undefined') {
-            window.location.href = '/google/login.php';
+            const currentPathname = window.location.pathname.replace(/^\/web/, '') || '/';
+            window.location.href = getRelativePath('/google/login.php', currentPathname);
           }
         }
       }

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -103,8 +103,8 @@ export default function SettingsPage() {
     setIsTesting(true);
     setTestStatus(null);
     try {
-      // Use full URL or ensure it's routed correctly
-      const response = await apiClient.post('/../ajax-notifications.php?action=test_broadcast', {});
+      // API call should be absolute to domain root, as per user requirement "(not the ones to the API)"
+      const response = await apiClient.post('/ajax-notifications.php?action=test_broadcast', {});
       if (response.data.status === 'success') {
         const channels = Object.keys(response.data.channels).filter((c: any) => response.data.channels[c]);
         setTestStatus({ status: 'success', message: `Test broadcast sent to: ${channels.join(', ')}` });

--- a/web/src/hooks/useRelativePath.ts
+++ b/web/src/hooks/useRelativePath.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
+import { getRelativePath } from '@/utils/paths';
 
 /**
  * Hook to convert root-relative paths to relative paths based on current URL depth.
@@ -16,53 +17,7 @@ export const useRelativePath = () => {
    * @returns A relative path starting with './' or '../'
    */
   const rel = (targetPath: string): string => {
-    // 1. API paths should remain absolute root-relative as they are proxied or handled by the server root
-    if (targetPath.startsWith('/api/')) {
-      return targetPath;
-    }
-
-    // 2. External links or already relative links return as is
-    if (targetPath.startsWith('http') || targetPath.startsWith('./') || targetPath.startsWith('../')) {
-      return targetPath;
-    }
-
-    // 3. Identify if the path is intended to be outside the /web basePath (Legacy UI)
-    const isLegacy = targetPath.startsWith('/github/') ||
-                     targetPath.startsWith('/google/') ||
-                     targetPath.startsWith('/admin/') ||
-                     targetPath.startsWith('/logout.php') ||
-                     targetPath.startsWith('/index.php') ||
-                     targetPath.endsWith('.php');
-
-    // Calculate how many levels we are deep within the /web basePath
-    // e.g., if at /web/projects/1/, usePathname() returns /projects/1
-    const segments = pathname.split('/').filter(s => s.length > 0);
-    const depth = segments.length;
-
-    // To reach domain root from /web/..., we need to go up (depth + 1) levels
-    // (depth for the path inside /web, plus 1 for /web itself)
-    const upToDomainRoot = '../'.repeat(depth + 1);
-
-    if (isLegacy) {
-      return upToDomainRoot + targetPath.slice(1);
-    }
-
-    // Internal Next-Gen UI paths
-    // In Next.js with basePath: '/web', we usually link to '/' or '/logs'
-    // and it resolves to '/web/' or '/web/logs/'.
-    // Here we want to produce a truly relative link for portability.
-
-    const target = targetPath.startsWith('/') ? targetPath.slice(1) : targetPath;
-
-    // If target is root '/', it means the root of /web
-    if (target === '') {
-      // From /web/projects/1/ to /web/ -> ../../
-      return depth > 0 ? '../'.repeat(depth) : './';
-    }
-
-    // From /web/projects/1/ to /web/logs/ -> ../../logs/
-    const upToWebRoot = depth > 0 ? '../'.repeat(depth) : './';
-    return upToWebRoot + target + (target.includes('.') ? '' : '/');
+    return getRelativePath(targetPath, pathname);
   };
 
   return { rel };

--- a/web/src/utils/paths.ts
+++ b/web/src/utils/paths.ts
@@ -1,0 +1,53 @@
+/**
+ * Converts a root-relative path (relative to domain root or basePath root) to a relative path.
+ * This ensures the exported static site is portable and doesn't rely on being at the domain root.
+ *
+ * @param targetPath The path starting with '/'
+ * @param currentPathname The current pathname (excluding basePath), e.g. from usePathname()
+ * @returns A relative path starting with './' or '../'
+ */
+export const getRelativePath = (targetPath: string, currentPathname: string): string => {
+  const pathname = currentPathname || '/';
+
+  // 1. API paths should remain absolute root-relative as they are proxied or handled by the server root
+  if (targetPath.startsWith('/api/')) {
+    return targetPath;
+  }
+
+  // 2. External links or already relative links return as is
+  if (targetPath.startsWith('http') || targetPath.startsWith('./') || targetPath.startsWith('../')) {
+    return targetPath;
+  }
+
+  // 3. Identify if the path is intended to be outside the /web basePath (Legacy UI)
+  const isLegacy = targetPath.startsWith('/github/') ||
+                   targetPath.startsWith('/google/') ||
+                   targetPath.startsWith('/admin/') ||
+                   targetPath.startsWith('/logout.php') ||
+                   targetPath.startsWith('/index.php') ||
+                   targetPath.endsWith('.php');
+
+  // Calculate how many levels we are deep within the /web basePath
+  const segments = pathname.split('/').filter(s => s.length > 0);
+  const depth = segments.length;
+
+  // To reach domain root from /web/..., we need to go up (depth + 1) levels
+  // (depth for the path inside /web, plus 1 for /web itself)
+  const upToDomainRoot = '../'.repeat(depth + 1);
+
+  if (isLegacy) {
+    const target = targetPath.startsWith('/') ? targetPath.slice(1) : targetPath;
+    return upToDomainRoot + target;
+  }
+
+  // Internal Next-Gen UI paths
+  const target = targetPath.startsWith('/') ? targetPath.slice(1) : targetPath;
+
+  // If target is root '/', it means the root of /web
+  if (target === '') {
+    return depth > 0 ? '../'.repeat(depth) : './';
+  }
+
+  const upToWebRoot = depth > 0 ? '../'.repeat(depth) : './';
+  return upToWebRoot + target + (target.includes('.') ? '' : '/');
+};


### PR DESCRIPTION
I have ensured that all UI and navigation paths within the `/web` directory are relative to support portability across different hosting environments. I extracted the path resolution logic into a standalone utility to allow its use in the API client, enabling relative redirects for authentication failures. API-related paths remain absolute as requested.

Fixes #690

---
*PR created automatically by Jules for task [11028916104947137334](https://jules.google.com/task/11028916104947137334) started by @chatelao*