### PR TITLE
Auto-Repeat Feature with Countdown Support

### DIFF
--- a/HOWTO-AUTOREPEAT.md
+++ b/HOWTO-AUTOREPEAT.md
@@ -1,0 +1,28 @@
+# Auto-Repeat Tasks
+
+Auto-Repeat allows a task to be automatically merged, closed, and duplicated a specified number of times. This is useful for recurring tasks or tasks that require multiple iterations.
+
+## How it Works
+
+1.  **Set Auto-Repeat Count**: On the Task Detail page, you can specify the number of repetitions in the "Auto-Repeat" input field within the Actions panel.
+2.  **Automatic Processing**:
+    *   When a task reaches the **READY** status (i.e., Jules has finished, and all GitHub PR checks have passed), the system checks if `autorepeat_remaining` is greater than 0.
+    *   If active, the system automatically:
+        1.  Adds the `autorepeat` label to the GitHub issue (to trigger duplication logic).
+        2.  Merges the Pull Request.
+        3.  Closes the GitHub Issue as "completed".
+3.  **Duplication**:
+    *   Upon closing the issue, the `WebhookHandler` detects the `autorepeat` label.
+    *   It creates a new issue with the same title and body.
+    *   The `autorepeat_remaining` count is decremented by 1 and assigned to the new task.
+    *   The `Jules` label is added to the new issue to start the agent processing automatically.
+
+## Manual Trigger
+
+You can still manually trigger a "Merge, Close & Duplicate" action. If you do this, the `autorepeat` label is added, and the issue is duplicated once. If you had a count set in "Auto-Repeat", it will be carried over (decremented) to the new task.
+
+## UI Indicators
+
+*   Tasks with the `autorepeat` or `auto-repeat` label are highlighted with a pink border in the task grid.
+*   The "Running Autorepeat Tasks" section on the dashboard shows all active tasks with this label.
+*   The Task Detail page displays the remaining repetition count.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1017,6 +1017,9 @@ components:
           format: date-time
           nullable: true
           example: "2023-10-27T10:15:00Z"
+        autorepeat_remaining:
+          type: integer
+          example: 5
         labels:
           type: array
           items:

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -395,7 +395,7 @@ class Task
         }
 
         $stmt = $this->db->getConnection()->prepare(
-            "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+            "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state, autorepeat_remaining) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
         );
         return $stmt->execute([
             $data['user_id'],
@@ -405,7 +405,8 @@ class Task
             $data['body'] ?? '',
             $data['github_data'] ?? null,
             $status,
-            $data['github_state'] ?? 'open'
+            $data['github_state'] ?? 'open',
+            $data['autorepeat_remaining'] ?? 0
         ]);
     }
 
@@ -426,32 +427,34 @@ class Task
         $this->deleteByIssueNumbersNotIn($projectId, $issueNumbers);
     }
 
-    public function upsert(int $userId, int $projectId, array $issue): bool
+    public function upsert(int $userId, int $projectId, array $issue, int $autorepeatRemaining = 0): bool
     {
         $connection = $this->db->getConnection();
         $driver = $connection->getAttribute(PDO::ATTR_DRIVER_NAME);
 
         if ($driver === 'sqlite') {
-            $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state, autorepeat_remaining)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(project_id, issue_number) DO UPDATE SET
                         title = excluded.title,
                         body = excluded.body,
                         github_data = excluded.github_data,
                         github_state = excluded.github_state,
+                        autorepeat_remaining = excluded.autorepeat_remaining,
                         status = CASE
                             WHEN excluded.github_state = 'closed' THEN 'finished'
                             WHEN status = 'pending' THEN 'created'
                             ELSE status
                         END";
         } else {
-            $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state, autorepeat_remaining)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON DUPLICATE KEY UPDATE
                         title = VALUES(title),
                         body = VALUES(body),
                         github_data = VALUES(github_data),
                         github_state = VALUES(github_state),
+                        autorepeat_remaining = VALUES(autorepeat_remaining),
                         status = CASE
                             WHEN VALUES(github_state) = 'closed' THEN 'finished'
                             WHEN status = 'pending' THEN 'created'
@@ -471,7 +474,8 @@ class Task
             $issue['body'],
             json_encode($issue),
             $status,
-            $issue['state'] ?? 'open'
+            $issue['state'] ?? 'open',
+            $autorepeatRemaining
         ]);
     }
 
@@ -763,6 +767,14 @@ class Task
         return $issueUrl;
     }
 
+    public function updateAutorepeatRemaining(int $id, int $count): bool
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "UPDATE tasks SET autorepeat_remaining = ? WHERE task_id = ?"
+        );
+        return $stmt->execute([$count, $id]);
+    }
+
     public function refreshJulesStatus(int $userId, GitHubService $githubService, JulesService $julesService, ?NotificationService $notificationService = null, ?int $taskId = null, ?int $projectId = null): void
     {
         $sql = "SELECT t.*, p.github_repo
@@ -942,6 +954,17 @@ class Task
                     } elseif ($mappedStatus === self::STATUS_READY) {
                         $title = "🚀 Task Ready: #" . $task['issue_number'];
                         $message = "Task \"" . $task['title'] . "\" is ready to merge.";
+
+                        // Automatic merge if autorepeat is active
+                        if (($task['autorepeat_remaining'] ?? 0) > 0) {
+                            $webhookHandler = new WebhookHandler($this->db);
+                            $projectModel = new Project($this->db);
+                            $project = $projectModel->findById($task['project_id']);
+                            if ($project) {
+                                $webhookHandler->autoMergeAndDuplicate($project, array_merge($task, ['status' => $mappedStatus]), $githubService, $notificationService);
+                                $message .= " (Auto-merging...)";
+                            }
+                        }
                     } elseif ($mappedStatus === self::STATUS_FAILED_JULES) {
                         $title = "❌ Jules Failed: #" . $task['issue_number'];
                         $message = "Jules session for \"" . $task['title'] . "\" failed.";

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -112,6 +112,32 @@ class WebhookHandler
         return $result;
     }
 
+    public function autoMergeAndDuplicate(array $project, array $task, GitHubService $githubService, ?NotificationService $notificationService = null): void
+    {
+        $prNumber = $githubService->extractPrNumber($task['pr_url'] ?? '');
+        if (!$prNumber) {
+            return;
+        }
+
+        try {
+            // 1. Add autorepeat label if requested
+            $githubService->addLabel($project['github_repo'], $task['issue_number'], 'autorepeat');
+
+            // 2. Merge PR
+            $githubService->mergePullRequest($project['github_repo'], $prNumber, "Merged automatically via Auto-Repeat: " . $task['title']);
+
+            // 3. Close Issue
+            $githubService->closeIssue($project['github_repo'], $task['issue_number'], 'completed');
+
+            // 4. Mark as merged in DB
+            $taskModel = new Task($this->db);
+            $taskModel->markAsMerged($task['task_id']);
+
+        } catch (\Exception $e) {
+            Logger::getInstance($this->db)->log($project['user_id'], $task['task_id'], "Auto-merge failed: " . $e->getMessage(), 'error');
+        }
+    }
+
     private function maybeDuplicateTask(array $project, array $event, GitHubService $githubService, ?NotificationService $notificationService = null): void
     {
         $issue = $event['issue'] ?? null;
@@ -186,7 +212,15 @@ class WebhookHandler
                 );
             }
 
-            $githubService->createIssue($repo, $issue['title'], $issue['body'] ?? null, array_values($labelNames));
+            $newIssue = $githubService->createIssue($repo, $issue['title'], $issue['body'] ?? null, array_values($labelNames));
+
+            if (!empty($newIssue['number'])) {
+                $newAutorepeatRemaining = max(0, ($task['autorepeat_remaining'] ?? 0) - 1);
+                if ($newAutorepeatRemaining > 0) {
+                    $taskModel->upsert($project['user_id'], $project['project_id'], $newIssue, $newAutorepeatRemaining);
+                }
+            }
+
             $githubService->removeLabel($repo, $issue['number'], $autorepeatLabelName);
 
             if ($notificationService) {
@@ -329,6 +363,11 @@ class WebhookHandler
                 if ($notificationService) {
                     $title = $newStatus === Task::STATUS_FAILED_PR ? "❌ PR Failed: #" . $task['issue_number'] : "✅ PR Fixed: #" . $task['issue_number'];
                     $message = $newStatus === Task::STATUS_FAILED_PR ? "PR checks for \"" . $task['title'] . "\" failed." : "PR checks for \"" . $task['title'] . "\" are now passing.";
+
+                    if ($newStatus === Task::STATUS_READY && ($task['autorepeat_remaining'] ?? 0) > 0 && $githubService) {
+                        $this->autoMergeAndDuplicate($project, array_merge($task, ['status' => $newStatus]), $githubService, $notificationService);
+                        $message .= " (Auto-merging...)";
+                    }
 
                     $actions = [];
                     if ($newStatus === Task::STATUS_READY) {

--- a/src/frontend/api/task.php
+++ b/src/frontend/api/task.php
@@ -57,6 +57,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $user = $userModel->findById($userId);
 
     switch ($action) {
+        case 'update_autorepeat':
+            try {
+                $count = isset($input['autorepeat_remaining']) ? (int)$input['autorepeat_remaining'] : 0;
+                $taskModel->updateAutorepeatRemaining($taskId, $count);
+                echo json_encode(['status' => 'success', 'message' => 'Auto-repeat updated']);
+            } catch (Exception $e) {
+                http_response_code(500);
+                echo json_encode(['error' => 'Failed to update auto-repeat: ' . $e->getMessage()]);
+            }
+            break;
+
         case 'trigger_agent':
             try {
                 $julesService = new App\JulesService(null, $user['jules_api_key'] ?? null);
@@ -185,5 +196,6 @@ echo json_encode([
     'github_state' => $task['github_state'],
     'created_at' => $task['created_at'],
     'last_synced_at' => $task['last_synced_at'],
+    'autorepeat_remaining' => (int)($task['autorepeat_remaining'] ?? 0),
     'labels' => $labels
 ]);

--- a/src/sql/patches/018_add_autorepeat_remaining_to_tasks.sql
+++ b/src/sql/patches/018_add_autorepeat_remaining_to_tasks.sql
@@ -1,0 +1,2 @@
+-- Add autorepeat_remaining column to tasks table
+ALTER TABLE tasks ADD COLUMN autorepeat_remaining INT DEFAULT 0;

--- a/test/Integration/IssueSyncIntegrationTest.php
+++ b/test/Integration/IssueSyncIntegrationTest.php
@@ -27,7 +27,7 @@ class IssueSyncIntegrationTest extends TestCase
             body TEXT,
             status TEXT DEFAULT 'pending',
             github_state VARCHAR(20) DEFAULT 'open',
-            github_data TEXT,
+            github_data TEXT, autorepeat_remaining INT DEFAULT 0,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             UNIQUE(project_id, issue_number)

--- a/test/Integration/NotificationTriggerTest.php
+++ b/test/Integration/NotificationTriggerTest.php
@@ -87,7 +87,7 @@ class NotificationTriggerTest extends TestCase
             body TEXT,
             status VARCHAR(50) DEFAULT 'pending',
             github_state VARCHAR(20) DEFAULT 'open',
-            github_data TEXT,
+            github_data TEXT, autorepeat_remaining INT DEFAULT 0,
             jules_session_id VARCHAR(255),
             jules_status VARCHAR(50),
             jules_url VARCHAR(255),

--- a/test/Integration/TaskActionApiTest.php
+++ b/test/Integration/TaskActionApiTest.php
@@ -61,7 +61,7 @@ class TaskActionApiTest extends TestCase
             body TEXT,
             status VARCHAR(50) DEFAULT 'created',
             github_state VARCHAR(20) DEFAULT 'open',
-            github_data TEXT,
+            github_data TEXT, autorepeat_remaining INT DEFAULT 0,
             pr_url VARCHAR(255),
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             UNIQUE(project_id, issue_number)

--- a/test/Integration/TaskDBIntegrationTest.php
+++ b/test/Integration/TaskDBIntegrationTest.php
@@ -35,7 +35,7 @@ class TaskDBIntegrationTest extends TestCase
             body TEXT,
             status TEXT DEFAULT 'created',
             github_state VARCHAR(20) DEFAULT 'open',
-            github_data TEXT,
+            github_data TEXT, autorepeat_remaining INT DEFAULT 0,
             created_at $timestamp,
             updated_at $timestamp,
             UNIQUE(project_id, issue_number)

--- a/test/Integration/UserActionNotificationTest.php
+++ b/test/Integration/UserActionNotificationTest.php
@@ -70,7 +70,7 @@ class UserActionNotificationTest extends TestCase
             body TEXT,
             status VARCHAR(50) DEFAULT 'pending',
             github_state VARCHAR(20) DEFAULT 'open',
-            github_data TEXT,
+            github_data TEXT, autorepeat_remaining INT DEFAULT 0,
             UNIQUE(project_id, issue_number)
         )");
 

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -27,7 +27,7 @@ class WebhookHandlerTest extends TestCase
             body TEXT,
             status TEXT DEFAULT 'pending',
             github_state VARCHAR(20) DEFAULT 'open',
-            github_data TEXT,
+            github_data TEXT, autorepeat_remaining INT DEFAULT 0,
             agent_response TEXT,
             pr_url VARCHAR(255),
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/test/Integration/verify_index_ui.php
+++ b/test/Integration/verify_index_ui.php
@@ -58,7 +58,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     body TEXT,
     status TEXT DEFAULT 'pending',
     github_state VARCHAR(20) DEFAULT 'open',
-    github_data TEXT,
+    github_data TEXT, autorepeat_remaining INT DEFAULT 0,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 )");
 

--- a/test/Integration/verify_logs_ui.php
+++ b/test/Integration/verify_logs_ui.php
@@ -27,7 +27,7 @@ namespace {
     $pdo->exec("CREATE TABLE performance_logs (performance_log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, type TEXT, target TEXT, duration FLOAT, context TEXT, status_code INTEGER, error_message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
     $pdo->exec("CREATE TABLE webhook_logs (log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, endpoint TEXT, payload TEXT, headers TEXT, status_code INTEGER, error_message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
     $pdo->exec("CREATE TABLE task_logs (task_log_id INTEGER PRIMARY KEY, user_id INTEGER, task_id INTEGER, level TEXT, message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
-    $pdo->exec("CREATE TABLE tasks (task_id INTEGER PRIMARY KEY, user_id INTEGER, project_id INTEGER, issue_number INTEGER, title TEXT, status TEXT, github_state TEXT)");
+    $pdo->exec("CREATE TABLE tasks (task_id INTEGER PRIMARY KEY, user_id INTEGER, project_id INTEGER, issue_number INTEGER, title TEXT, status TEXT, autorepeat_remaining INT DEFAULT 0, github_state TEXT)");
 
     // Insert mock user
     $pdo->prepare("INSERT INTO users (user_id, name, email) VALUES (1, 'Admin User', 'admin@example.com')")->execute();

--- a/test/Integration/verify_logs_ui.php
+++ b/test/Integration/verify_logs_ui.php
@@ -27,7 +27,7 @@ namespace {
     $pdo->exec("CREATE TABLE performance_logs (performance_log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, type TEXT, target TEXT, duration FLOAT, context TEXT, status_code INTEGER, error_message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
     $pdo->exec("CREATE TABLE webhook_logs (log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, endpoint TEXT, payload TEXT, headers TEXT, status_code INTEGER, error_message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
     $pdo->exec("CREATE TABLE task_logs (task_log_id INTEGER PRIMARY KEY, user_id INTEGER, task_id INTEGER, level TEXT, message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
-    $pdo->exec("CREATE TABLE tasks (task_id INTEGER PRIMARY KEY, user_id INTEGER, project_id INTEGER, issue_number INTEGER, title TEXT, status TEXT, autorepeat_remaining INT DEFAULT 0, github_state TEXT)");
+    $pdo->exec("CREATE TABLE tasks (task_id INTEGER PRIMARY KEY, user_id INTEGER, project_id INTEGER, issue_number INTEGER, title TEXT, status TEXT, autorepeat_remaining INT DEFAULT 0, github_state TEXT, autorepeat_remaining INT DEFAULT 0)");
 
     // Insert mock user
     $pdo->prepare("INSERT INTO users (user_id, name, email) VALUES (1, 'Admin User', 'admin@example.com')")->execute();

--- a/test/Integration/verify_notifications_ui.php
+++ b/test/Integration/verify_notifications_ui.php
@@ -62,7 +62,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     body TEXT,
     status TEXT DEFAULT 'pending',
     github_state VARCHAR(20) DEFAULT 'open',
-    github_data TEXT,
+    github_data TEXT, autorepeat_remaining INT DEFAULT 0,
     agent_response TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/test/Integration/verify_project_settings_ui.php
+++ b/test/Integration/verify_project_settings_ui.php
@@ -100,7 +100,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     status TEXT DEFAULT 'pending',
     jules_status VARCHAR(50) DEFAULT 'pending',
     github_state VARCHAR(20) DEFAULT 'open',
-    github_data TEXT,
+    github_data TEXT, autorepeat_remaining INT DEFAULT 0,
     agent_response TEXT,
     pr_url VARCHAR(255),
     jules_url VARCHAR(255),

--- a/test/Integration/verify_project_ui.php
+++ b/test/Integration/verify_project_ui.php
@@ -63,7 +63,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     body TEXT,
     status TEXT DEFAULT 'pending',
     github_state VARCHAR(20) DEFAULT 'open',
-    github_data TEXT,
+    github_data TEXT, autorepeat_remaining INT DEFAULT 0,
     agent_response TEXT,
     jules_session_id VARCHAR(255),
     jules_status VARCHAR(255),

--- a/test/Integration/verify_settings_ui.php
+++ b/test/Integration/verify_settings_ui.php
@@ -93,7 +93,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     body TEXT,
     status TEXT DEFAULT 'pending',
     github_state VARCHAR(20) DEFAULT 'open',
-    github_data TEXT,
+    github_data TEXT, autorepeat_remaining INT DEFAULT 0,
     agent_response TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/test/Integration/verify_task_ui.php
+++ b/test/Integration/verify_task_ui.php
@@ -83,7 +83,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     status TEXT DEFAULT 'pending',
     jules_status VARCHAR(50) DEFAULT 'pending',
     github_state VARCHAR(20) DEFAULT 'open',
-    github_data TEXT,
+    github_data TEXT, autorepeat_remaining INT DEFAULT 0,
     agent_response TEXT,
     pr_url VARCHAR(255),
     jules_url VARCHAR(255),

--- a/test/Integration/verify_task_ui_fixed.php
+++ b/test/Integration/verify_task_ui_fixed.php
@@ -87,7 +87,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     status TEXT DEFAULT 'pending',
     jules_status VARCHAR(50) DEFAULT 'pending',
     github_state VARCHAR(20) DEFAULT 'open',
-    github_data TEXT,
+    github_data TEXT, autorepeat_remaining INT DEFAULT 0,
     github_pr_data TEXT,
     github_comments_data TEXT,
     github_data_updated_at DATETIME,

--- a/test/Integration/verify_tasks_list_ui.php
+++ b/test/Integration/verify_tasks_list_ui.php
@@ -55,7 +55,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS tasks (
     status TEXT DEFAULT 'pending',
     jules_status VARCHAR(50) DEFAULT 'pending',
     github_state VARCHAR(20) DEFAULT 'open',
-    github_data TEXT,
+    github_data TEXT, autorepeat_remaining INT DEFAULT 0,
     agent_response TEXT,
     pr_url VARCHAR(255),
     jules_url VARCHAR(255),

--- a/test/Unit/Services/LoggerTest.php
+++ b/test/Unit/Services/LoggerTest.php
@@ -23,7 +23,7 @@ class LoggerTest extends TestCase
     private function createSchema(): void
     {
         $pdo = $this->db->getConnection();
-        $pdo->exec("CREATE TABLE tasks (task_id INTEGER PRIMARY KEY, user_id INTEGER, project_id INTEGER, issue_number INTEGER, title TEXT, status TEXT, github_state TEXT)");
+        $pdo->exec("CREATE TABLE tasks (task_id INTEGER PRIMARY KEY, user_id INTEGER, project_id INTEGER, issue_number INTEGER, title TEXT, status TEXT, autorepeat_remaining INT DEFAULT 0, github_state TEXT)");
         $pdo->exec("CREATE TABLE task_logs (task_log_id INTEGER PRIMARY KEY, user_id INTEGER, task_id INTEGER, level TEXT, message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
         $pdo->exec("CREATE TABLE performance_logs (performance_log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, type TEXT, target TEXT, duration FLOAT, context TEXT, status_code INTEGER, error_message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
         $pdo->exec("CREATE TABLE users (user_id INTEGER PRIMARY KEY, email TEXT)");

--- a/web/src/app/tasks/[id]/TaskDetailView.tsx
+++ b/web/src/app/tasks/[id]/TaskDetailView.tsx
@@ -11,6 +11,13 @@ import Navbar from '@/components/Navbar';
 export default function TaskDetailView({ id }: { id: string }) {
   const { data: task, isLoading, error, performAction, isPerformingAction } = useTask(id);
   const { data: logs } = useTaskLogs(id);
+  const [autorepeatCount, setAutorepeatCount] = React.useState<number>(0);
+
+  React.useEffect(() => {
+    if (task?.autorepeat_remaining !== undefined) {
+      setAutorepeatCount(task.autorepeat_remaining);
+    }
+  }, [task?.autorepeat_remaining]);
 
   if (isLoading) {
     return (
@@ -72,7 +79,26 @@ export default function TaskDetailView({ id }: { id: string }) {
 
             {/* Interaction Panel */}
             <div className="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
-              <h3 className="text-lg font-bold text-gray-900 mb-4">Actions</h3>
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-bold text-gray-900">Actions</h3>
+                <div className="flex items-center space-x-4">
+                  <div className="flex items-center space-x-2 bg-gray-50 px-3 py-1.5 rounded-lg border border-gray-200">
+                    <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">Auto-Repeat</span>
+                    <input
+                      type="number"
+                      min="0"
+                      max="100"
+                      value={autorepeatCount}
+                      onChange={(e) => {
+                        const val = parseInt(e.target.value) || 0;
+                        setAutorepeatCount(val);
+                        performAction({ action: 'update_autorepeat', autorepeat_remaining: val });
+                      }}
+                      className="w-16 px-2 py-1 text-sm border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+                    />
+                  </div>
+                </div>
+              </div>
               <div className="flex flex-wrap gap-3">
                 <button
                   onClick={() => performAction({ action: 'trigger_agent' })}

--- a/web/src/hooks/useTask.ts
+++ b/web/src/hooks/useTask.ts
@@ -17,8 +17,8 @@ export const useTask = (id: number | string | undefined) => {
   });
 
   const taskActionMutation = useMutation({
-    mutationFn: async ({ action }: { action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate' }) => {
-      const response = await apiClient.post(`/task.php?id=${id}`, { action });
+    mutationFn: async ({ action, autorepeat_remaining }: { action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate' | 'update_autorepeat', autorepeat_remaining?: number }) => {
+      const response = await apiClient.post(`/task.php?id=${id}`, { action, autorepeat_remaining });
       return response.data;
     },
     onSuccess: () => {

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1595,6 +1595,8 @@ export interface components {
              * @example 2023-10-27T10:15:00Z
              */
             last_synced_at?: string | null;
+            /** @example 5 */
+            autorepeat_remaining?: number;
             labels?: {
                 name?: string;
                 color?: string;


### PR DESCRIPTION
Implemented a feature that allows tasks to automatically repeat (merge, close, and duplicate) a user-specified number of times. Added backend support for tracking remaining repetitions, automatic triggers in the process engine, and UI controls for the repetition count.

Fixes #695

---
*PR created automatically by Jules for task [15630833788600554514](https://jules.google.com/task/15630833788600554514) started by @chatelao*