### PR TITLE
Display Full PR Description and Jules Messages

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1101,6 +1101,52 @@ components:
                 type: string
               color:
                 type: string
+        pr_details:
+          type: object
+          nullable: true
+          properties:
+            title:
+              type: string
+            body:
+              type: string
+              nullable: true
+            state:
+              type: string
+            merged:
+              type: boolean
+            base:
+              type: object
+              properties:
+                ref:
+                  type: string
+            head:
+              type: object
+              properties:
+                ref:
+                  type: string
+            mergeable_state:
+              type: string
+              nullable: true
+            draft:
+              type: boolean
+              nullable: true
+        jules_messages:
+          type: array
+          items:
+            type: object
+            properties:
+              user:
+                type: object
+                properties:
+                  login:
+                    type: string
+              body:
+                type: string
+              created_at:
+                type: string
+                format: date-time
+              html_url:
+                type: string
 
     TaskLog:
       type: object

--- a/src/frontend/api/task.php
+++ b/src/frontend/api/task.php
@@ -181,6 +181,57 @@ $labels = array_map(function($label) {
     ];
 }, $githubData['labels'] ?? []);
 
+$prDetails = null;
+$julesMessages = [];
+$githubToken = $project['github_token'] ?? null;
+
+if ($githubToken) {
+    $githubService = new App\GitHubService(null, $githubToken);
+
+    $cacheTimeout = 15 * 60; // 15 minutes
+    $cacheUpdatedAt = strtotime($task['github_data_updated_at'] ?? '2000-01-01');
+    $isCacheValid = (time() - $cacheUpdatedAt) < $cacheTimeout;
+
+    if ($isCacheValid && !empty($task['github_pr_data'])) {
+        $prDetails = json_decode($task['github_pr_data'], true);
+    } elseif (!empty($task['pr_url'])) {
+        $prNumber = $githubService->extractPrNumber($task['pr_url']);
+        if ($prNumber) {
+            try {
+                $prDetails = $githubService->getPullRequest($project['github_repo'], $prNumber);
+                $taskModel->updateGitHubCache($taskId, $prDetails, null);
+            } catch (Exception $e) {
+                // Ignore PR fetch errors
+            }
+        }
+    }
+
+    if ($isCacheValid && !empty($task['github_comments_data'])) {
+        $comments = json_decode($task['github_comments_data'], true);
+    } else {
+        try {
+            $comments = $githubService->getIssueComments($project['github_repo'], $task['issue_number']);
+            $taskModel->updateGitHubCache($taskId, null, $comments);
+        } catch (Exception $e) {
+            $comments = [];
+        }
+    }
+
+    $julesComments = array_filter($comments, function($comment) {
+        $login = strtolower($comment['user']['login'] ?? '');
+        return $login === 'jules' || $login === 'google-labs-jules[bot]';
+    });
+
+    foreach (array_slice(array_reverse($julesComments), 0, 3) as $msg) {
+        $julesMessages[] = [
+            'user' => ['login' => $msg['user']['login'] ?? 'Jules'],
+            'body' => $msg['body'] ?? '',
+            'created_at' => $msg['created_at'] ?? '',
+            'html_url' => $msg['html_url'] ?? ''
+        ];
+    }
+}
+
 // Map internal database fields to OpenAPI schema
 echo json_encode([
     'id' => (int)$task['task_id'],
@@ -197,5 +248,16 @@ echo json_encode([
     'created_at' => $task['created_at'],
     'last_synced_at' => $task['last_synced_at'],
     'autorepeat_remaining' => (int)($task['autorepeat_remaining'] ?? 0),
-    'labels' => $labels
+    'labels' => $labels,
+    'pr_details' => $prDetails ? [
+        'title' => $prDetails['title'] ?? '',
+        'body' => $prDetails['body'] ?? '',
+        'state' => $prDetails['state'] ?? '',
+        'merged' => $prDetails['merged'] ?? false,
+        'base' => ['ref' => $prDetails['base']['ref'] ?? ''],
+        'head' => ['ref' => $prDetails['head']['ref'] ?? ''],
+        'mergeable_state' => $prDetails['mergeable_state'] ?? null,
+        'draft' => $prDetails['draft'] ?? null
+    ] : null,
+    'jules_messages' => $julesMessages
 ]);

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -375,7 +375,7 @@ if ($prDetails && ($prDetails['state'] ?? '') === 'open') {
                                         </div>
                                         <?php if (!empty($prDetails['body'])) : ?>
                                             <div class="prose prose-sm max-w-none text-gray-600 bg-gray-50 p-4 rounded-lg border border-gray-100">
-                                                <?= $parsedown->text($taskModel->processGitHubImages(mb_substr($prDetails['body'], 0, 300) . (mb_strlen($prDetails['body']) > 300 ? '...' : ''))) ?>
+                                                <?= $parsedown->text($taskModel->processGitHubImages($prDetails['body'])) ?>
                                             </div>
                                         <?php endif; ?>
                                     </div>

--- a/web/src/app/tasks/[id]/TaskDetailView.tsx
+++ b/web/src/app/tasks/[id]/TaskDetailView.tsx
@@ -72,10 +72,110 @@ export default function TaskDetailView({ id }: { id: string }) {
                   </span>
                 ))}
               </div>
-              <div className="prose prose-sm max-w-none text-gray-600 border-t pt-4">
+              <div className="prose prose-sm max-w-none text-gray-600 border-t pt-4 whitespace-pre-wrap">
                 {task.body}
               </div>
             </div>
+
+            {/* Associated Pull Request */}
+            {task.pr_details && (
+              <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+                <div className="bg-green-50 px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+                  <div className="flex items-center space-x-2">
+                    <svg className="w-5 h-5 text-green-600" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M11 19.25c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM11 14.5c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM11 9.75c0 .414-.336.75-.75.75H8.5a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 19.25c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 14.5c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM16 9.75c0 .414-.336.75-.75.75h-1.75a.75.75 0 0 1-.75-.75v-1.5c0-.414.336-.75.75-.75h1.75c.414 0 .75.336.75.75v1.5zM20.5 2h-17C2.673 2 2 2.673 2 3.5v17c0 .827.673 1.5 1.5 1.5h17c.827 0 1.5-.673 1.5-1.5v-17C22 2.673 21.327 2 20.5 2zM20 18H4V4h16v14z" />
+                    </svg>
+                    <span className="text-sm font-bold text-green-900">Associated Pull Request</span>
+                  </div>
+                  {task.pr_url && (
+                    <a
+                      href={task.pr_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs font-medium text-green-700 hover:underline"
+                    >
+                      View on GitHub &rarr;
+                    </a>
+                  )}
+                </div>
+                <div className="p-6">
+                  <div className="flex items-start justify-between mb-2">
+                    <h4 className="text-lg font-bold text-gray-900 leading-tight">
+                      {task.pr_details.title}
+                    </h4>
+                    <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 border border-green-200 shadow-sm">
+                      {task.pr_details.state}
+                    </span>
+                  </div>
+                  <div className="text-sm text-gray-500 mb-4 flex items-center space-x-4">
+                    <span>Merged: {task.pr_details.merged ? 'Yes' : 'No'}</span>
+                    <span>
+                      Base: <code className="bg-gray-100 px-1 rounded">{task.pr_details.base?.ref}</code>
+                    </span>
+                    <span>
+                      Head: <code className="bg-gray-100 px-1 rounded">{task.pr_details.head?.ref}</code>
+                    </span>
+                  </div>
+                  {task.pr_details.body && (
+                    <div className="prose prose-sm max-w-none text-gray-600 bg-gray-50 p-4 rounded-lg border border-gray-100 whitespace-pre-wrap">
+                      {task.pr_details.body}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Last Jules Messages */}
+            {task.jules_messages && task.jules_messages.length > 0 && (
+              <div className="space-y-4">
+                <h3 className="text-lg font-bold text-gray-900 px-1 flex items-center">
+                  <svg
+                    className="w-5 h-5 mr-2 text-blue-600"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+                    />
+                  </svg>
+                  Last Jules Messages
+                </h3>
+                {task.jules_messages.map((msg, index) => (
+                  <div key={index} className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+                    <div className="bg-blue-50 px-4 py-2 border-b border-gray-200 flex items-center justify-between">
+                      <div className="flex items-center space-x-2">
+                        <div className="w-6 h-6 rounded-full bg-blue-600 flex items-center justify-center text-[10px] text-white font-bold">
+                          J
+                        </div>
+                        <span className="text-sm font-bold text-gray-700">{msg.user?.login}</span>
+                        <span className="text-sm text-gray-500">
+                          at {msg.created_at ? new Date(msg.created_at).toLocaleString() : ''}
+                        </span>
+                      </div>
+                      {msg.html_url && (
+                        <a
+                          href={msg.html_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-blue-600 hover:underline"
+                        >
+                          Link
+                        </a>
+                      )}
+                    </div>
+                    <div className="p-4">
+                      <div className="prose prose-sm max-w-none text-gray-700 whitespace-pre-wrap">
+                        {msg.body}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
 
             {/* Interaction Panel */}
             <div className="bg-white border border-gray-200 rounded-xl shadow-sm p-6">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1710,6 +1710,29 @@ export interface components {
                 name?: string;
                 color?: string;
             }[];
+            pr_details?: {
+                title?: string;
+                body?: string | null;
+                state?: string;
+                merged?: boolean;
+                base?: {
+                    ref?: string;
+                };
+                head?: {
+                    ref?: string;
+                };
+                mergeable_state?: string | null;
+                draft?: boolean | null;
+            } | null;
+            jules_messages?: {
+                user?: {
+                    login?: string;
+                };
+                body?: string;
+                /** Format: date-time */
+                created_at?: string;
+                html_url?: string;
+            }[];
         };
         TaskLog: {
             /** @example 500 */


### PR DESCRIPTION
This change ensures that users can see the full Pull Request description, which is critical for judging the agent's work. It also adds a "Last Jules Messages" section to both the Legacy and Next-Gen UIs to provide more context on the agent's actions.

Key changes:
- Backend: Updated `src/frontend/api/task.php` to fetch PR details and Jules comments from GitHub, with a 15-minute caching layer.
- API: Updated `api/openapi.yaml` and regenerated web types.
- Legacy UI: Removed the 300-character limit on PR descriptions in `src/frontend/task.php`.
- Next-Gen UI: Implemented "Associated Pull Request" and "Last Jules Messages" sections in `TaskDetailView.tsx`, ensuring no truncation and correct formatting.

Fixes #701

---
*PR created automatically by Jules for task [1572085112030397535](https://jules.google.com/task/1572085112030397535) started by @chatelao*