### PR TITLE
Remove "Run Agent" and restrict Rerun/Restart to failed Jules sessions

### DIFF
--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -581,17 +581,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_issues'])) {
                                                     <div class="flex flex-col space-y-2">
                                                         <?php
                                                         $isClosed = $task['status'] === App\Task::STATUS_FINISHED;
-                                                        $isReady = $task['status'] === App\Task::STATUS_READY;
-                                                        $isImplemented = $task['status'] === App\Task::STATUS_IMPLEMENTED;
+                                                        $isFailedJules = $task['status'] === App\Task::STATUS_FAILED_JULES;
                                                         ?>
-                                                        <?php if (!$isClosed && !$isReady && !$isImplemented) : ?>
-                                                            <form method="POST" class="inline">
-                                                                <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
-                                                                <input type="hidden" name="task_id" value="<?= $task['task_id'] ?>">
-                                                                <button type="submit" name="trigger_agent" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-xs px-3 py-2 focus:outline-none w-full">Run Agent</button>
-                                                            </form>
-                                                        <?php endif; ?>
-                                                        <?php if ($isReady || $isImplemented) : ?>
+                                                        <?php if ($isFailedJules) : ?>
                                                             <form method="POST" class="inline">
                                                                 <input type="hidden" name="csrf_token" value="<?= $auth->getCsrfToken() ?>">
                                                                 <input type="hidden" name="task_id" value="<?= $task['task_id'] ?>">

--- a/web/src/app/tasks/[id]/TaskDetailView.tsx
+++ b/web/src/app/tasks/[id]/TaskDetailView.tsx
@@ -233,20 +233,24 @@ export default function TaskDetailView({ id }: { id: string }) {
                 </div>
               </div>
               <div className="flex flex-wrap gap-3">
-                <button
-                  onClick={() => performAction({ action: 'trigger_agent' })}
-                  disabled={isPerformingAction}
-                  className="px-4 py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
-                >
-                  Retry Task
-                </button>
-                <button
-                  onClick={() => performAction({ action: 'trigger_agent' })}
-                  disabled={isPerformingAction}
-                  className="px-4 py-2 border border-gray-300 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-50 disabled:opacity-50 transition-colors"
-                >
-                  Restart from Scratch
-                </button>
+                {task.status === 'failed_jules' && (
+                  <>
+                    <button
+                      onClick={() => performAction({ action: 'trigger_agent' })}
+                      disabled={isPerformingAction}
+                      className="px-4 py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                    >
+                      Retry Task
+                    </button>
+                    <button
+                      onClick={() => performAction({ action: 'trigger_agent' })}
+                      disabled={isPerformingAction}
+                      className="px-4 py-2 border border-gray-300 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-50 disabled:opacity-50 transition-colors"
+                    >
+                      Restart from Scratch
+                    </button>
+                  </>
+                )}
                 {(task.status === 'ready' || task.status === 'implemented') && task.github_state === 'open' && (
                   <>
                     <button

--- a/web/src/components/InteractionPanel.tsx
+++ b/web/src/components/InteractionPanel.tsx
@@ -19,16 +19,6 @@ export const InteractionPanel: React.FC<InteractionPanelProps> = ({ task, onActi
     <div className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
       <h3 className="text-lg font-bold text-gray-900 mb-4">Actions</h3>
       <div className="space-y-3">
-        {!isClosed && !isReady && !isImplemented && (
-          <button
-            onClick={() => onAction('trigger_agent')}
-            disabled={isLoading}
-            className="w-full text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 focus:outline-none disabled:opacity-50"
-          >
-            {isLoading ? 'Running...' : 'Run Agent'}
-          </button>
-        )}
-
         {hasPr && !isClosed && task.github_state === 'open' && (
           <>
             <button
@@ -48,7 +38,7 @@ export const InteractionPanel: React.FC<InteractionPanelProps> = ({ task, onActi
           </>
         )}
 
-        {(isReady || isImplemented) && (
+        {task.status === 'failed_jules' && (
           <button
              onClick={() => onAction('trigger_agent')}
              disabled={isLoading}


### PR DESCRIPTION
I have removed the "Run Agent" option from both the Legacy and Next-Gen UIs. I also updated the conditional logic so that the "Restart" and "Rerun" buttons are only visible when a task's status is `failed_jules`. These changes clean up the UI and ensure that manual intervention options are only presented when an agent failure has occurred. Verified with PHP unit tests and Next.js build.

Fixes #703

---
*PR created automatically by Jules for task [16140619226495809124](https://jules.google.com/task/16140619226495809124) started by @chatelao*