### PR TITLE
Fix Next-Gen UI deep links and pre-rendering

### DIFF
--- a/src/frontend/navbar-icons.php
+++ b/src/frontend/navbar-icons.php
@@ -48,6 +48,22 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
     $syncStatus = 'error';
     $syncMessage = $_GET['error'];
 }
+
+$nextGenUrl = '/web/';
+$currentScript = basename($_SERVER['SCRIPT_NAME']);
+if ($currentScript === 'project.php' && isset($_GET['id'])) {
+    $nextGenUrl = '/web/projects/' . (int)$_GET['id'] . '/';
+} elseif ($currentScript === 'task.php' && isset($_GET['id'])) {
+    $nextGenUrl = '/web/tasks/' . (int)$_GET['id'] . '/';
+} elseif ($currentScript === 'settings.php') {
+    $nextGenUrl = '/web/settings/';
+} elseif ($currentScript === 'templates.php') {
+    $nextGenUrl = '/web/templates/';
+} elseif ($currentScript === 'logs.php') {
+    $nextGenUrl = '/web/logs/';
+} elseif (strpos($_SERVER['SCRIPT_NAME'], '/admin/') !== false) {
+    $nextGenUrl = '/web/admin/';
+}
 ?>
 
 <div class="flex items-center space-x-4 mr-4" x-data="{
@@ -263,7 +279,7 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
     </div>
 
     <!-- Next-Gen UI Link -->
-    <a href="/web/" class="text-xs font-bold text-blue-600 hover:underline border border-blue-200 px-2 py-1 rounded bg-blue-50 transition-colors" title="Switch to Next-Generation React UI">
+    <a href="<?= htmlspecialchars($nextGenUrl) ?>" class="text-xs font-bold text-blue-600 hover:underline border border-blue-200 px-2 py-1 rounded bg-blue-50 transition-colors" title="Switch to Next-Generation React UI">
         Next-Gen UI
     </a>
 

--- a/web/src/app/projects/[id]/page.tsx
+++ b/web/src/app/projects/[id]/page.tsx
@@ -2,7 +2,7 @@ import React, { use } from 'react';
 import ProjectDetailView from './ProjectDetailView';
 
 export async function generateStaticParams() {
-  return [{ id: '1' }];
+  return Array.from({ length: 100 }, (_, i) => ({ id: (i + 1).toString() }));
 }
 
 export default function Page({ params }: { params: Promise<{ id: string }> }) {

--- a/web/src/app/tasks/[id]/page.tsx
+++ b/web/src/app/tasks/[id]/page.tsx
@@ -2,7 +2,7 @@ import React, { use } from 'react';
 import TaskDetailView from './TaskDetailView';
 
 export async function generateStaticParams() {
-  return [{ id: '1' }];
+  return Array.from({ length: 100 }, (_, i) => ({ id: (i + 1).toString() }));
 }
 
 export default function Page({ params }: { params: Promise<{ id: string }> }) {


### PR DESCRIPTION
This PR fixes the "broken" Next-Gen UI by ensuring that common project and task pages are pre-rendered during the static build process and by providing context-aware navigation from the Legacy UI.

Key changes:
1.  **Legacy UI Navigation**: The "Next-Gen UI" button in the navbar now detects if the user is on a project or task page and links directly to the equivalent page in the React UI (e.g., `project.php?id=15` -> `/web/projects/15/`).
2.  **Pre-rendering**: Updated `generateStaticParams` in `web/src/app/projects/[id]/page.tsx` and `web/src/app/tasks/[id]/page.tsx` to include IDs from 1 to 100. This fixes 404 errors for projects like ID 15 that were previously missing from the static export.
3.  **Verification**: Verified that the Next.js build succeeds and PHP unit tests pass.

Fixes #705

---
*PR created automatically by Jules for task [1775526251616913633](https://jules.google.com/task/1775526251616913633) started by @chatelao*