### PR TITLE
Implement Running Autorepeat Tasks View in Next-Gen UI

### DIFF
--- a/NEXT_GEN_UI_ROADMAP.md
+++ b/NEXT_GEN_UI_ROADMAP.md
@@ -90,6 +90,7 @@ The goal of Phase 3 is to launch the native mobile application and enhance the n
     - ⏳ Initialize the Expo project and implement shared API clients.
     - ⏳ Build the unified Login flow (Google/GitHub).
 - ⏳ **Milestone 3.2: Native Oversight**
+    - ✅ Implement the "Running Autorepeat Tasks" view for web.
     - ⏳ Implement the "Running Autorepeat Tasks" and "Project Grid" views for mobile.
 - ⏳ **Milestone 3.3: Push Notifications**
     - ⏳ Integrate with Firebase or Expo Notifications to deliver native alerts for `FAILED` and `READY` states.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -564,6 +564,24 @@ paths:
         '404':
           description: Project not found
 
+  /api/autorepeat-tasks.php:
+    get:
+      summary: List running autorepeat tasks (JSON)
+      description: Returns a list of all active autorepeat tasks for the authenticated user.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: A JSON list of tasks
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Task'
+        '401':
+          description: Unauthorized
+
   /api/task.php:
     get:
       summary: Get task details (JSON)
@@ -1080,6 +1098,9 @@ components:
         github_state:
           type: string
           example: "open"
+        github_repo:
+          type: string
+          example: "google/jules"
         created_at:
           type: string
           format: date-time

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -125,7 +125,9 @@ class Task
 
     public function findByProjectId(int $projectId, bool $showAll = true): array
     {
-        $sql = "SELECT t1.* FROM tasks t1 WHERE t1.project_id = ?
+        $sql = "SELECT t1.*, p.github_repo FROM tasks t1
+                JOIN projects p ON t1.project_id = p.project_id
+                WHERE t1.project_id = ?
                 AND t1.issue_number > 0 AND t1.title != ''";
         $params = [$projectId];
 

--- a/src/frontend/api/autorepeat-tasks.php
+++ b/src/frontend/api/autorepeat-tasks.php
@@ -4,7 +4,6 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 
 use App\Database;
 use App\Auth;
-use App\Project;
 use App\Task;
 
 header('Content-Type: application/json');
@@ -29,26 +28,10 @@ if (!$userId) {
     exit;
 }
 
-$projectId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-if (!$projectId) {
-    http_response_code(400);
-    echo json_encode(['error' => 'Missing project ID']);
-    exit;
-}
-
 $db = new Database();
-$projectModel = new Project($db);
 $taskModel = new Task($db);
 
-// Verify project ownership
-$project = $projectModel->findById($projectId);
-if (!$project || (int)$project['user_id'] !== $userId) {
-    http_response_code(404);
-    echo json_encode(['error' => 'Project not found']);
-    exit;
-}
-
-$tasks = $taskModel->findByProjectId($projectId);
+$tasks = $taskModel->getRunningAutorepeatTasks($userId);
 
 // Map internal database fields to OpenAPI schema
 $output = array_map(function($task) {
@@ -72,7 +55,7 @@ $output = array_map(function($task) {
         'jules_url' => $task['jules_url'],
         'jules_status' => $task['jules_status'],
         'github_state' => $task['github_state'],
-        'github_repo' => $task['github_repo'] ?? '',
+        'github_repo' => $task['github_repo'],
         'created_at' => $task['created_at'],
         'last_synced_at' => $task['last_synced_at'],
         'autorepeat_remaining' => (int)($task['autorepeat_remaining'] ?? 0),

--- a/src/frontend/api/task.php
+++ b/src/frontend/api/task.php
@@ -245,6 +245,7 @@ echo json_encode([
     'jules_url' => $task['jules_url'],
     'jules_status' => $task['jules_status'],
     'github_state' => $task['github_state'],
+    'github_repo' => $project['github_repo'] ?? '',
     'created_at' => $task['created_at'],
     'last_synced_at' => $task['last_synced_at'],
     'autorepeat_remaining' => (int)($task['autorepeat_remaining'] ?? 0),

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -7,6 +7,7 @@ import ProjectCard from '@/components/ProjectCard';
 import TaskFilterBar from '@/components/TaskFilterBar';
 import Navbar from '@/components/Navbar';
 import LinkRepositoryModal from '@/components/LinkRepositoryModal';
+import AutorepeatTasks from '@/components/AutorepeatTasks';
 import { components } from '@/types/api';
 
 type Project = components['schemas']['Project'];
@@ -71,6 +72,8 @@ export default function Dashboard() {
       <Navbar />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+        <AutorepeatTasks />
+
         <div className="flex flex-col md:flex-row md:items-center justify-between mb-8 gap-4">
           <div>
             <h2 className="text-2xl font-bold text-gray-900">Project Dashboard</h2>

--- a/web/src/components/AutorepeatTasks.tsx
+++ b/web/src/components/AutorepeatTasks.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import Link from 'next/link';
+import { useAutorepeatTasks } from '@/hooks/useAutorepeatTasks';
+import { useRelativePath } from '@/hooks/useRelativePath';
+import StatusBadge from './StatusBadge';
+
+export const AutorepeatTasks: React.FC = () => {
+  const { data: tasks, isLoading } = useAutorepeatTasks();
+  const { rel } = useRelativePath();
+
+  if (isLoading || !tasks || tasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-8 p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+      <h3 className="text-lg font-bold text-gray-900 mb-4">Running Autorepeat Tasks</h3>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Project</th>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Issue</th>
+              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {tasks.map((task) => (
+              <tr key={task.id}>
+                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  <a
+                    href={`https://github.com/${task.github_repo}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    {task.github_repo}
+                  </a>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <Link href={rel(`/tasks/${task.id}`)} className="text-blue-600 hover:underline">
+                    #{task.issue_number} - {task.title}
+                  </Link>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <StatusBadge status={task.status} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default AutorepeatTasks;

--- a/web/src/hooks/useAutorepeatTasks.ts
+++ b/web/src/hooks/useAutorepeatTasks.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import apiClient from '@/api/client';
+import { components } from '@/types/api';
+
+type Task = components['schemas']['Task'];
+
+export const useAutorepeatTasks = () => {
+  return useQuery({
+    queryKey: ['autorepeat-tasks'],
+    queryFn: async (): Promise<Task[]> => {
+      const response = await apiClient.get<Task[]>('/autorepeat-tasks.php');
+      return response.data;
+    },
+  });
+};

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -986,6 +986,52 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/autorepeat-tasks.php": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List running autorepeat tasks (JSON)
+         * @description Returns a list of all active autorepeat tasks for the authenticated user.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description A JSON list of tasks */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Task"][];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/task.php": {
         parameters: {
             query?: never;
@@ -1694,6 +1740,8 @@ export interface components {
             jules_status?: string | null;
             /** @example open */
             github_state?: string;
+            /** @example google/jules */
+            github_repo?: string;
             /**
              * Format: date-time
              * @example 2023-10-27T10:10:00Z


### PR DESCRIPTION
This change implements the "Running Autorepeat Tasks" section in the Next-Gen UI dashboard, achieving feature parity with the legacy UI. It includes a new RESTful endpoint `/api/autorepeat-tasks.php`, updates to the `Task` OpenAPI specification, and a new React component to display active autorepeat tasks across all projects. Additionally, it ensures that task-related API responses consistently include the repository name and autorepeat metadata.

Fixes #708

---
*PR created automatically by Jules for task [8307926148542510144](https://jules.google.com/task/8307926148542510144) started by @chatelao*