### PR TITLE
Fix Legacy Path Resolution and Improve Context-Aware Linking

### DIFF
--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -1,13 +1,41 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import Link from 'next/link';
 import { useUser } from '@/hooks/useUser';
 import { useRelativePath } from '@/hooks/useRelativePath';
+import { usePathname } from 'next/navigation';
 
 const Navbar = () => {
   const { data: user } = useUser();
   const { rel } = useRelativePath();
+  const pathname = usePathname() || '/';
+
+  const legacyUrl = useMemo(() => {
+    // pathname example: /projects/13/ or /tasks/42/ or /
+    const segments = pathname.split('/').filter(Boolean);
+
+    if (segments[0] === 'projects' && segments[1]) {
+      return rel(`/project.php?id=${segments[1]}`);
+    }
+    if (segments[0] === 'tasks' && segments[1]) {
+      return rel(`/task.php?id=${segments[1]}`);
+    }
+    if (segments[0] === 'settings') {
+      return rel('/settings.php');
+    }
+    if (segments[0] === 'templates') {
+      return rel('/templates.php');
+    }
+    if (segments[0] === 'logs') {
+      return rel('/logs.php');
+    }
+    if (segments[0] === 'admin') {
+      return rel('/admin/index.php');
+    }
+
+    return rel('/index.php');
+  }, [pathname, rel]);
 
   return (
     <nav className="bg-white border-b border-gray-200 px-4 py-3 sticky top-0 z-10">
@@ -34,7 +62,7 @@ const Navbar = () => {
                 Admin
               </Link>
             )}
-            <a href="/" className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
+            <a href={legacyUrl} className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
               Legacy UI
             </a>
           </div>

--- a/web/src/utils/paths.ts
+++ b/web/src/utils/paths.ts
@@ -25,7 +25,7 @@ export const getRelativePath = (targetPath: string, currentPathname: string): st
                    targetPath.startsWith('/admin/') ||
                    targetPath.startsWith('/logout.php') ||
                    targetPath.startsWith('/index.php') ||
-                   targetPath.endsWith('.php');
+                   /\.php(\?|$)/.test(targetPath);
 
   // Calculate how many levels we are deep within the /web basePath
   const segments = pathname.split('/').filter(s => s.length > 0);


### PR DESCRIPTION
The Next-Gen UI was failing to correctly resolve links to legacy PHP pages when they contained query parameters (e.g., `/project.php?id=13`). This was because the `isLegacy` check in `getRelativePath` relied on a brittle `endsWith('.php')` condition.

I fixed this by updating the `isLegacy` detection to use a robust regular expression: `/\.php(\?|$)/`. This ensures that any path containing `.php` followed by a query string or the end of the line is correctly identified as a legacy route and resolved relative to the domain root.

Furthermore, I improved the user experience by making the "Legacy UI" link in the global Navbar context-aware. Instead of always linking to the dashboard, it now automatically maps the current Next-Gen UI page (e.g., `/projects/15`) to the corresponding legacy PHP page (e.g., `project.php?id=15`).

Verification:
- Manual test cases for path resolution passed.
- Successfully built the Next-Gen UI (`npm run build`).
- Passed all TypeScript checks (`npx tsc --noEmit`).
- All backend unit tests passed (`php vendor/bin/phpunit test/Unit`).

Fixes #707

---
*PR created automatically by Jules for task [18152282589960706763](https://jules.google.com/task/18152282589960706763) started by @chatelao*