### PR TITLE
Implement Roadmap Milestone 4.2: Default to Next-Gen UI

### DIFF
--- a/NEXT_GEN_UI_ROADMAP.md
+++ b/NEXT_GEN_UI_ROADMAP.md
@@ -104,9 +104,9 @@ The final phase involves migrating all remaining features and decommissioning th
 - ✅ **Milestone 4.1: Administrative & Advanced Features**
     - ✅ Port Settings, User Management (Admin Dashboard).
     - ✅ Roadmap/Template management.
-- 🚧 **Milestone 4.2: User Migration**
-    - 🚧 Default all users to the New UI.
-    - ⏳ Provide a "Switch back to Legacy" toggle for a limited time to gather feedback.
+- ✅ **Milestone 4.2: User Migration**
+    - ✅ Default all users to the New UI (handled in `index.php` and OAuth callbacks).
+    - ✅ Provide a "Switch back to Legacy" toggle in Settings and handle `legacy=0/1` preference state.
 - ⏳ **Milestone 4.3: Legacy Decommission**
     - ⏳ Remove PHP frontend templates and Alpine.js dependencies.
     - ⏳ Complete refactoring of the backend into a pure API server (e.g., transitioning to NestJS).

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1605,6 +1605,8 @@ components:
           type: integer
         github_failed:
           type: integer
+        telegram_connected:
+          type: boolean
 
     GitHubIssueEvent:
       type: object

--- a/src/frontend/api/sync-status.php
+++ b/src/frontend/api/sync-status.php
@@ -77,7 +77,8 @@ try {
         'jules_failed' => (int)($counts['jules_failed'] ?? 0),
         'github_running' => (int)($counts['github_running'] ?? 0),
         'github_passed' => (int)($counts['github_passed'] ?? 0),
-        'github_failed' => (int)($counts['github_failed'] ?? 0)
+        'github_failed' => (int)($counts['github_failed'] ?? 0),
+        'telegram_connected' => (bool)$userModel->getTelegramChatId($userId)
     ]);
 } catch (Exception $e) {
     http_response_code(500);

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -17,12 +17,19 @@ $user = $auth->isLoggedIn() ? $userModel->findById($auth->getUserId()) : null;
 
 // Handle Legacy Preference
 if (isset($_GET['legacy'])) {
-    setcookie('prefer_legacy', (string)$_GET['legacy'], time() + (86400 * 30), "/"); // 30 days
-    $_COOKIE['prefer_legacy'] = (string)$_GET['legacy'];
+    $legacy = (string)$_GET['legacy'];
+    if ($legacy === '0') {
+        setcookie('prefer_legacy', '', time() - 3600, "/");
+        header('Location: /web/');
+        exit;
+    } else {
+        setcookie('prefer_legacy', '1', time() + (86400 * 30), "/");
+        $_COOKIE['prefer_legacy'] = '1';
+    }
 }
 
 // Default Redirection to Next-Gen UI
-if ($user && !isset($_COOKIE['prefer_legacy']) && !isset($_GET['legacy'])) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1') {
     header('Location: /web/');
     exit;
 }

--- a/src/frontend/navbar-icons.php
+++ b/src/frontend/navbar-icons.php
@@ -49,7 +49,7 @@ if ((isset($_GET['success']) && $_GET['success'] === 'synced') || (isset($_GET['
     $syncMessage = $_GET['error'];
 }
 
-$nextGenUrl = '/web/';
+$nextGenUrl = '/index.php?legacy=0';
 $currentScript = basename($_SERVER['SCRIPT_NAME']);
 if ($currentScript === 'project.php' && isset($_GET['id'])) {
     $nextGenUrl = '/web/projects/' . (int)$_GET['id'] . '/';

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -282,6 +282,21 @@ export default function SettingsPage() {
                 </div>
               </div>
             </section>
+
+            {/* UI Preference */}
+            <section className="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Interface Preference</h3>
+              <p className="text-sm text-gray-500 mb-4">Switch back to the legacy PHP-based interface if you encounter issues or prefer the old design.</p>
+              <button
+                onClick={() => {
+                  document.cookie = "prefer_legacy=1; path=/; max-age=" + (30 * 24 * 60 * 60);
+                  window.location.href = rel('/index.php?legacy=1');
+                }}
+                className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              >
+                Switch to Legacy UI
+              </button>
+            </section>
           </div>
         )}
 

--- a/web/src/components/StatusIndicators.tsx
+++ b/web/src/components/StatusIndicators.tsx
@@ -44,6 +44,13 @@ const StatusIndicators: React.FC = () => {
           <Link href={rel('/tasks?filter=jules_failed')} className="text-red-600 hover:underline">{status.jules_failed}</Link>
         </span>
       </div>
+
+      {/* Telegram Status */}
+      <div className={`flex items-center ${status.telegram_connected ? 'text-gray-900' : 'text-gray-300'}`} title={`Telegram: ${status.telegram_connected ? 'Connected' : 'Not Linked'}`}>
+        <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M20.665 3.717l-17.73 6.837c-1.21.486-1.203 1.161-.222 1.462l4.552 1.42l10.532-6.645c.498-.303.953-.14.579.192l-8.533 7.701l-.333 4.981c.488 0 .704-.224.977-.488l2.347-2.284l4.882 3.606c.899.496 1.542.24 1.766-.83l3.201-15.084c.328-1.315-.502-1.912-1.362-1.523z"/>
+        </svg>
+      </div>
     </div>
   );
 };

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -2253,6 +2253,7 @@ export interface components {
             github_running?: number;
             github_passed?: number;
             github_failed?: number;
+            telegram_connected?: boolean;
         };
         GitHubIssueEvent: {
             /** @example opened */


### PR DESCRIPTION
I have implemented Milestone 4.2 of the Next-Gen UI roadmap. This involved making the Next-Gen UI the default for all users while providing a clear path to opt back into the legacy interface if needed.

Key changes:
- Modified `src/frontend/index.php` to handle default redirection to `/web/` and manage the `prefer_legacy` cookie.
- Added a "Switch to Legacy UI" button in `web/src/app/settings/page.tsx`.
- Updated `src/frontend/navbar-icons.php` to ensure switching back to Next-Gen UI via `/index.php?legacy=0` correctly clears the preference.
- Enhanced `SyncStatus` API and `StatusIndicators` component to show Telegram link status, improving feature parity.
- Updated `NEXT_GEN_UI_ROADMAP.md` to reflect these completions.
- Regenerated TypeScript types from the updated OpenAPI spec.

Fixes #723

---
*PR created automatically by Jules for task [9188769976924286677](https://jules.google.com/task/9188769976924286677) started by @chatelao*