### PR TITLE
Automate SSH Deployment for Main and Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,12 @@ jobs:
           test/screenshots/
           docs/_build/html/
           CODE_QUALITY.md
+
+  deploy:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/deploy.yml
+    with:
+      include_vendor: true
+      lts_target: false
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,24 @@ on:
         required: true
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      include_vendor:
+        description: 'Include vendor directory'
+        required: true
+        type: boolean
+        default: false
+      lts_target:
+        description: 'LTS target'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   deploy:
     name: Deploy to Webserver
     runs-on: ubuntu-latest
-    if: github.actor == github.repository_owner
+    if: github.actor == github.repository_owner || github.event_name == 'workflow_call'
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.event.release.tag_name }} agent-control-php-${{ github.event.release.tag_name }}.zip
+
+  deploy:
+    needs: upload
+    uses: ./.github/workflows/deploy.yml
+    with:
+      include_vendor: true
+      lts_target: true
+    secrets: inherit


### PR DESCRIPTION
This change automates the previously manual SSH deployment process. 

1. **Reusable Workflow**: `.github/workflows/deploy.yml` now supports both manual triggering via `workflow_dispatch` and automated calling via `workflow_call`. It accepts `include_vendor` and `lts_target` as inputs.
2. **Main Branch Deployment**: The CI workflow (`.github/workflows/ci.yml`) now includes a `deploy` job that runs after successful tests when a push occurs on the `main` branch (including PR merges). It performs a standard deployment (`lts_target: false`).
3. **Release Deployment**: The Release workflow (`.github/workflows/release.yml`) now includes a `deploy` job that runs after the release asset is uploaded. It performs an LTS deployment (`lts_target: true`).
4. **Secret Handling**: Both automated triggers use `secrets: inherit` to pass the necessary SFTP credentials to the deployment workflow.
5. **Permissions**: The `deploy` job in `deploy.yml` now checks for `workflow_call` event name to ensure automated runs are not blocked by the existing ownership check for manual triggers.

Fixes #725

---
*PR created automatically by Jules for task [16932295814246295092](https://jules.google.com/task/16932295814246295092) started by @chatelao*