### PR TITLE
Fix infinite redirect loop in index.php

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -29,7 +29,7 @@ if (isset($_GET['legacy'])) {
 }
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1') {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
     header('Location: /web/');
     exit;
 }


### PR DESCRIPTION
This PR fixes an `ERR_TOO_MANY_REDIRECTS` error on `https://ai.2u2.ch/web/`.

The issue was caused by the unconditional redirect from `src/frontend/index.php` to `/web/` for authenticated users. If the web server configuration uses `index.php` as a fallback for the `/web/` path (common in Single Page Application routing or when the directory is missing), it results in an infinite loop.

Changes:
- Added a check for `strpos($_SERVER['REQUEST_URI'], '/web/') === false` in the redirection logic of `src/frontend/index.php`.
- Verified the fix via syntax check and code review.

Fixes #729

---
*PR created automatically by Jules for task [16951735837745074593](https://jules.google.com/task/16951735837745074593) started by @chatelao*