### PR TITLE
Fix Next-Gen UI API Routing Conflict

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { getRelativePath } from '@/utils/paths';
 
 const apiClient = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || '/api',
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || '/api/',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/web/src/hooks/useAdminTools.ts
+++ b/web/src/hooks/useAdminTools.ts
@@ -9,7 +9,7 @@ export const useDbCheck = () => {
   return useQuery({
     queryKey: ['admin', 'db-check'],
     queryFn: async (): Promise<DbCheckResults> => {
-      const response = await apiClient.get<DbCheckResults>('/admin-db-check.php');
+      const response = await apiClient.get<DbCheckResults>('admin-db-check.php');
       return response.data;
     },
   });
@@ -19,7 +19,7 @@ export const useMigrationStatus = () => {
   return useQuery({
     queryKey: ['admin', 'migration-status'],
     queryFn: async (): Promise<MigrationStatus> => {
-      const response = await apiClient.get<MigrationStatus>('/admin-upgrade.php');
+      const response = await apiClient.get<MigrationStatus>('admin-upgrade.php');
       return response.data;
     },
   });
@@ -34,7 +34,7 @@ export const useApplyPatch = () => {
         status: string;
         message: string;
         logs: string[];
-      }>('/admin-upgrade.php', { patch });
+      }>('admin-upgrade.php', { patch });
       return response.data;
     },
     onSuccess: () => {

--- a/web/src/hooks/useAdminUsers.ts
+++ b/web/src/hooks/useAdminUsers.ts
@@ -8,7 +8,7 @@ export const useAdminUsers = () => {
   return useQuery({
     queryKey: ['admin-users'],
     queryFn: async (): Promise<AdminUser[]> => {
-      const response = await apiClient.get<AdminUser[]>('/admin-users.php');
+      const response = await apiClient.get<AdminUser[]>('admin-users.php');
       return response.data;
     },
   });

--- a/web/src/hooks/useAutorepeatTasks.ts
+++ b/web/src/hooks/useAutorepeatTasks.ts
@@ -8,7 +8,7 @@ export const useAutorepeatTasks = () => {
   return useQuery({
     queryKey: ['autorepeat-tasks'],
     queryFn: async (): Promise<Task[]> => {
-      const response = await apiClient.get<Task[]>('/autorepeat-tasks.php');
+      const response = await apiClient.get<Task[]>('autorepeat-tasks.php');
       return response.data;
     },
   });

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -15,7 +15,7 @@ export const useNotifications = (action: 'list' | 'unread_count' = 'list') => {
   return useQuery({
     queryKey: ['notifications', action],
     queryFn: async (): Promise<NotificationResponse> => {
-      const response = await apiClient.get<NotificationResponse>(`/notifications.php?action=${action}`);
+      const response = await apiClient.get<NotificationResponse>(`notifications.php?action=${action}`);
       return response.data;
     },
     // Poll for unread count every 15 seconds
@@ -28,7 +28,7 @@ export const useNotificationActions = () => {
 
   const markReadMutation = useMutation({
     mutationFn: async (notificationId: number) => {
-      await apiClient.post('/notifications.php', {
+      await apiClient.post('notifications.php', {
         action: 'mark_read',
         notification_id: notificationId,
       });
@@ -40,7 +40,7 @@ export const useNotificationActions = () => {
 
   const markAllReadMutation = useMutation({
     mutationFn: async () => {
-      await apiClient.post('/notifications.php', {
+      await apiClient.post('notifications.php', {
         action: 'mark_all_read',
       });
     },
@@ -51,7 +51,7 @@ export const useNotificationActions = () => {
 
   const clearAllMutation = useMutation({
     mutationFn: async () => {
-      await apiClient.post('/notifications.php', {
+      await apiClient.post('notifications.php', {
         action: 'clear_all',
       });
     },

--- a/web/src/hooks/usePerformanceLogs.ts
+++ b/web/src/hooks/usePerformanceLogs.ts
@@ -8,7 +8,7 @@ export const usePerformanceLogs = () => {
   return useQuery({
     queryKey: ['performance-logs'],
     queryFn: async (): Promise<PerformanceLog[]> => {
-      const response = await apiClient.get<PerformanceLog[]>('/performance-logs.php');
+      const response = await apiClient.get<PerformanceLog[]>('performance-logs.php');
       return response.data;
     },
   });

--- a/web/src/hooks/useProject.ts
+++ b/web/src/hooks/useProject.ts
@@ -10,7 +10,7 @@ export const useProject = (id: string | number) => {
   const query = useQuery({
     queryKey: ['projects', id],
     queryFn: async (): Promise<Project> => {
-      const response = await apiClient.get<Project>(`/project.php?id=${id}`);
+      const response = await apiClient.get<Project>(`project.php?id=${id}`);
       return response.data;
     },
     enabled: !!id,
@@ -18,7 +18,7 @@ export const useProject = (id: string | number) => {
 
   const syncMutation = useMutation({
     mutationFn: async () => {
-      const response = await apiClient.post(`/project.php?id=${id}`, {
+      const response = await apiClient.post(`project.php?id=${id}`, {
         action: 'sync_issues',
       });
       return response.data;
@@ -32,7 +32,7 @@ export const useProject = (id: string | number) => {
 
   const createFromTemplateMutation = useMutation({
     mutationFn: async ({ templateId, params }: { templateId: number; params: Record<string, string> }) => {
-      const response = await apiClient.post(`/project.php?id=${id}`, {
+      const response = await apiClient.post(`project.php?id=${id}`, {
         action: 'create_from_template',
         template_id: templateId,
         params,
@@ -46,7 +46,7 @@ export const useProject = (id: string | number) => {
 
   const createFromRoadmapMutation = useMutation({
     mutationFn: async (roadmapName: string) => {
-      const response = await apiClient.post(`/project.php?id=${id}`, {
+      const response = await apiClient.post(`project.php?id=${id}`, {
         action: 'create_from_roadmap',
         roadmap_name: roadmapName,
       });
@@ -59,7 +59,7 @@ export const useProject = (id: string | number) => {
 
   const updateSettingsMutation = useMutation({
     mutationFn: async (data: { github_repo: string; github_account_id: number }) => {
-      const response = await apiClient.post(`/project.php?id=${id}`, {
+      const response = await apiClient.post(`project.php?id=${id}`, {
         action: 'update_settings',
         ...data,
       });
@@ -73,7 +73,7 @@ export const useProject = (id: string | number) => {
 
   const updateNotificationsMutation = useMutation({
     mutationFn: async (statusSettings: Record<string, boolean>) => {
-      const response = await apiClient.post(`/project.php?id=${id}`, {
+      const response = await apiClient.post(`project.php?id=${id}`, {
         action: 'update_notifications',
         status_settings: statusSettings,
       });
@@ -86,7 +86,7 @@ export const useProject = (id: string | number) => {
 
   const deleteMutation = useMutation({
     mutationFn: async () => {
-      const response = await apiClient.delete(`/project.php?id=${id}`);
+      const response = await apiClient.delete(`project.php?id=${id}`);
       return response.data;
     },
     onSuccess: () => {

--- a/web/src/hooks/useProjects.ts
+++ b/web/src/hooks/useProjects.ts
@@ -8,7 +8,7 @@ export const useProjects = () => {
   return useQuery({
     queryKey: ['projects'],
     queryFn: async (): Promise<Project[]> => {
-      const response = await apiClient.get<Project[]>('/projects.php');
+      const response = await apiClient.get<Project[]>('projects.php');
       return response.data;
     },
   });
@@ -20,7 +20,7 @@ export const useCreateProject = () => {
   return useMutation({
     mutationFn: async (data: { github_repo: string; github_account_id: number }) => {
       const response = await apiClient.post<{ project_id: number; status: string; message: string }>(
-        '/projects.php',
+        'projects.php',
         data
       );
       return response.data;

--- a/web/src/hooks/useSyncStatus.ts
+++ b/web/src/hooks/useSyncStatus.ts
@@ -8,7 +8,7 @@ export const useSyncStatus = (fast: boolean = true) => {
   return useQuery({
     queryKey: ['sync-status', fast],
     queryFn: async (): Promise<SyncStatus> => {
-      const response = await apiClient.get<SyncStatus>(`/sync-status.php?fast=${fast ? 1 : 0}`);
+      const response = await apiClient.get<SyncStatus>(`sync-status.php?fast=${fast ? 1 : 0}`);
       return response.data;
     },
     // Poll every 30 seconds for status updates

--- a/web/src/hooks/useTask.ts
+++ b/web/src/hooks/useTask.ts
@@ -10,7 +10,7 @@ export const useTask = (id: number | string | undefined) => {
   const query = useQuery({
     queryKey: ['task', id],
     queryFn: async (): Promise<Task> => {
-      const response = await apiClient.get<Task>(`/task.php?id=${id}`);
+      const response = await apiClient.get<Task>(`task.php?id=${id}`);
       return response.data;
     },
     enabled: !!id,
@@ -18,7 +18,7 @@ export const useTask = (id: number | string | undefined) => {
 
   const taskActionMutation = useMutation({
     mutationFn: async ({ action, autorepeat_remaining }: { action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate' | 'update_autorepeat', autorepeat_remaining?: number }) => {
-      const response = await apiClient.post(`/task.php?id=${id}`, { action, autorepeat_remaining });
+      const response = await apiClient.post(`task.php?id=${id}`, { action, autorepeat_remaining });
       return response.data;
     },
     onSuccess: () => {

--- a/web/src/hooks/useTaskLogs.ts
+++ b/web/src/hooks/useTaskLogs.ts
@@ -8,7 +8,7 @@ export const useTaskLogs = (taskId: number | string | undefined) => {
   return useQuery({
     queryKey: ['task-logs', taskId],
     queryFn: async (): Promise<TaskLog[]> => {
-      const response = await apiClient.get<TaskLog[]>(`/task-logs.php?id=${taskId}`);
+      const response = await apiClient.get<TaskLog[]>(`task-logs.php?id=${taskId}`);
       return response.data;
     },
     enabled: !!taskId,

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -8,7 +8,7 @@ export const useTasks = (projectId: number | undefined, filter: string = 'all_op
   return useQuery({
     queryKey: ['tasks', projectId, filter],
     queryFn: async (): Promise<Task[]> => {
-      let url = '/tasks.php';
+      let url = 'tasks.php';
       const params = new URLSearchParams();
 
       if (projectId) {

--- a/web/src/hooks/useTemplates.ts
+++ b/web/src/hooks/useTemplates.ts
@@ -10,14 +10,14 @@ export const useTemplates = () => {
   const query = useQuery({
     queryKey: ['templates'],
     queryFn: async (): Promise<Template[]> => {
-      const response = await apiClient.get<Template[]>('/templates.php');
+      const response = await apiClient.get<Template[]>('templates.php');
       return response.data;
     },
   });
 
   const saveTemplate = useMutation({
     mutationFn: async (template: Partial<Template>) => {
-      const response = await apiClient.post('/templates.php', {
+      const response = await apiClient.post('templates.php', {
         id: template.id,
         name: template.name,
         title_template: template.title_template,
@@ -33,7 +33,7 @@ export const useTemplates = () => {
 
   const deleteTemplate = useMutation({
     mutationFn: async (id: number) => {
-      const response = await apiClient.delete(`/templates.php?id=${id}`);
+      const response = await apiClient.delete(`templates.php?id=${id}`);
       return response.data;
     },
     onSuccess: () => {

--- a/web/src/hooks/useUser.ts
+++ b/web/src/hooks/useUser.ts
@@ -8,7 +8,7 @@ export const useUser = () => {
   return useQuery({
     queryKey: ['user'],
     queryFn: async (): Promise<User> => {
-      const response = await apiClient.get<User>('/user.php');
+      const response = await apiClient.get<User>('user.php');
       return response.data;
     },
   });
@@ -19,7 +19,7 @@ export const useUpdateUser = () => {
 
   return useMutation({
     mutationFn: async (data: Partial<User>) => {
-      const response = await apiClient.post<User>('/user.php', data);
+      const response = await apiClient.post<User>('user.php', data);
       return response.data;
     },
     onSuccess: (newUser) => {

--- a/web/src/hooks/useWebhookLogs.ts
+++ b/web/src/hooks/useWebhookLogs.ts
@@ -8,7 +8,7 @@ export const useWebhookLogs = () => {
   return useQuery({
     queryKey: ['webhook-logs'],
     queryFn: async (): Promise<WebhookLog[]> => {
-      const response = await apiClient.get<WebhookLog[]>('/webhook-logs.php');
+      const response = await apiClient.get<WebhookLog[]>('webhook-logs.php');
       return response.data;
     },
   });


### PR DESCRIPTION
I fixed the issue where projects and other data were inaccessible in the Next-Gen UI. The problem was caused by a common Axios pitfall: when a `baseURL` is configured (like `/api`), providing a request path with a leading slash (like `/project.php`) causes Axios to treat it as an absolute path from the domain root, bypassing the `/api` prefix. This led the React frontend to fetch the Legacy UI's HTML instead of the JSON API data.

I resolved this by ensuring the `baseURL` has a trailing slash (`/api/`) and removing the leading slashes from all API calls across 14 different hook files. I also verified the fix by building the frontend and running the full suite of backend unit tests.

Fixes #731

---
*PR created automatically by Jules for task [6383130817446732761](https://jules.google.com/task/6383130817446732761) started by @chatelao*