### PR TITLE
Fix Next-Gen UI Routing and Deep Redirection

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -29,9 +29,54 @@ if (isset($_GET['legacy'])) {
 }
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
-    header('Location: /web/');
-    exit;
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1') {
+    $requestUri = $_SERVER['REQUEST_URI'] ?? '';
+    $isWebPath = strpos($requestUri, '/web/') !== false;
+
+    if (!$isWebPath) {
+        // Map legacy pages to Next-Gen routes to preserve context
+        $nextGenUrl = '/web/';
+        $currentScript = basename($_SERVER['SCRIPT_NAME']);
+
+        if ($currentScript === 'project.php' && isset($_GET['id'])) {
+            $nextGenUrl = '/web/projects/' . (int)$_GET['id'] . '/';
+        } elseif ($currentScript === 'task.php' && isset($_GET['id'])) {
+            $nextGenUrl = '/web/tasks/' . (int)$_GET['id'] . '/';
+        } elseif ($currentScript === 'settings.php') {
+            $nextGenUrl = '/web/settings/';
+        } elseif ($currentScript === 'templates.php') {
+            $nextGenUrl = '/web/templates/';
+        } elseif ($currentScript === 'logs.php') {
+            $nextGenUrl = '/web/logs/';
+        } elseif (strpos($_SERVER['SCRIPT_NAME'], '/admin/') !== false) {
+            $nextGenUrl = '/web/admin/';
+        }
+
+        header('Location: ' . $nextGenUrl);
+        exit;
+    } elseif ($isWebPath && basename($_SERVER['SCRIPT_NAME']) === 'index.php') {
+        // Safeguard: If we are inside /web/ but landed in the legacy index.php,
+        // it means the server fell back to the root index.php (e.g. missing static file).
+        // We must not render the legacy UI here.
+        $uriPath = parse_url($requestUri, PHP_URL_PATH);
+        if ($uriPath !== '/web/' && $uriPath !== '/web/index.php') {
+            // If it's a known mapable path mistakenly called under /web/
+            // e.g. /web/project.php?id=16
+            $mappedUrl = null;
+            if (strpos($uriPath, 'project.php') !== false && isset($_GET['id'])) {
+                $mappedUrl = '/web/projects/' . (int)$_GET['id'] . '/';
+            } elseif (strpos($uriPath, 'task.php') !== false && isset($_GET['id'])) {
+                $mappedUrl = '/web/tasks/' . (int)$_GET['id'] . '/';
+            }
+
+            if ($mappedUrl && $mappedUrl !== $requestUri) {
+                header('Location: ' . $mappedUrl);
+            } else {
+                header('Location: /web/');
+            }
+            exit;
+        }
+    }
 }
 
 $githubAccounts = $user ? $userModel->getGitHubAccounts($user['user_id']) : [];

--- a/web/src/utils/paths.ts
+++ b/web/src/utils/paths.ts
@@ -20,9 +20,10 @@ export const getRelativePath = (targetPath: string, currentPathname: string): st
   }
 
   // 3. Identify if the path is intended to be outside the /web basePath (Legacy UI)
+  // We exclude /admin/ here because Next-Gen UI has its own /admin routes.
+  // Legacy admin paths usually end in .php which is caught by the regex below.
   const isLegacy = targetPath.startsWith('/github/') ||
                    targetPath.startsWith('/google/') ||
-                   targetPath.startsWith('/admin/') ||
                    targetPath.startsWith('/logout.php') ||
                    targetPath.startsWith('/index.php') ||
                    /\.php(\?|$)/.test(targetPath);
@@ -49,5 +50,12 @@ export const getRelativePath = (targetPath: string, currentPathname: string): st
   }
 
   const upToWebRoot = depth > 0 ? '../'.repeat(depth) : './';
-  return upToWebRoot + target + (target.includes('.') ? '' : '/');
+
+  // Don't append a trailing slash if it already has one, or if it's a file, or has query/hash
+  const needsTrailingSlash = !target.endsWith('/') &&
+                             !target.includes('.') &&
+                             !target.includes('?') &&
+                             !target.includes('#');
+
+  return upToWebRoot + target + (needsTrailingSlash ? '/' : '');
 };


### PR DESCRIPTION
This change fixes the issue where subpages in the Next-Gen UI were unreachable or incorrectly redirected.

Key improvements:
1. **Deep Redirection**: When the system automatically redirects an authenticated user to the Next-Gen UI, it now maps the specific legacy page they were trying to access to the corresponding React route. For example, `project.php?id=16` now correctly redirects to `/web/projects/16/` instead of just the dashboard.
2. **Robust Path Generation**: The `getRelativePath` utility now correctly handles URLs with query parameters (`?`) or hashes (`#`), preventing it from incorrectly appending a trailing slash that would break the link.
3. **Next-Gen Admin Support**: Fixed a bug where any path starting with `/admin` was always treated as legacy, allowing the Next-Gen admin routes to work correctly.
4. **Fallback Safeguard**: Added logic to `index.php` to handle cases where the web server falls back to the root PHP script for missing assets under `/web/`, ensuring it redirects back to the Next-Gen app instead of showing the legacy dashboard.

Fixes #739

---
*PR created automatically by Jules for task [10989774065818501114](https://jules.google.com/task/10989774065818501114) started by @chatelao*