### PR TITLE
Fix double redirect loop when Next-Gen UI is missing

### DIFF
--- a/src/frontend/admin/index.php
+++ b/src/frontend/admin/index.php
@@ -17,7 +17,7 @@ if (!$auth->isLoggedIn()) {
 }
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($auth->isLoggedIn() && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/../web/index.html')) {
     header('Location: /web/admin/');
     exit;
 }

--- a/src/frontend/github/callback.php
+++ b/src/frontend/github/callback.php
@@ -64,7 +64,8 @@ if (isset($_GET['code']) && isset($_GET['state'])) {
                 $userModel->addGitHubAccount($user['user_id'], $githubData['access_token'], $githubData['github_username']);
 
                 $auth->login($user);
-                header('Location: /web/');
+                $redirectUrl = file_exists(__DIR__ . '/../web/index.html') ? '/web/' : '/index.php';
+                header('Location: ' . $redirectUrl);
                 exit;
             } else {
                 throw new Exception("Failed to create or update user from GitHub data.");

--- a/src/frontend/google/callback.php
+++ b/src/frontend/google/callback.php
@@ -14,7 +14,8 @@ if (isset($_GET['code'])) {
         $googleUser = $auth->authenticate($_GET['code']);
         $user = $userModel->createOrUpdate($googleUser);
         $auth->login($user);
-        header('Location: /web/');
+        $redirectUrl = file_exists(__DIR__ . '/../web/index.html') ? '/web/' : '/index.php';
+        header('Location: ' . $redirectUrl);
         exit;
     } catch (Exception $e) {
         echo "Error: " . htmlspecialchars($e->getMessage());

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -29,7 +29,8 @@ if (isset($_GET['legacy'])) {
 }
 
 // Next-Gen UI Redirection & Safeguard
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1') {
+$nextGenExists = file_exists(__DIR__ . '/web/index.html');
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && $nextGenExists) {
     $requestUri = $_SERVER['REQUEST_URI'] ?? '';
     $isWebPath = strpos($requestUri, '/web/') !== false;
 
@@ -74,6 +75,11 @@ if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1') {
             exit;
         }
     }
+} elseif (strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') !== false && !$nextGenExists) {
+    // If we are in /web/ but Next-Gen UI is not installed, redirect back to root dashboard
+    // to avoid being stuck in a /web/ path that renders the legacy UI incorrectly.
+    header('Location: /index.php');
+    exit;
 }
 
 $githubAccounts = $user ? $userModel->getGitHubAccounts($user['user_id']) : [];

--- a/src/frontend/logs.php
+++ b/src/frontend/logs.php
@@ -23,7 +23,7 @@ if (!$auth->isLoggedIn()) {
 $user = $userModel->findById($auth->getUserId());
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     header('Location: /web/logs/');
     exit;
 }

--- a/src/frontend/notifications.php
+++ b/src/frontend/notifications.php
@@ -23,7 +23,7 @@ $userId = $auth->getUserId();
 $user = $userModel->findById($userId);
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     header('Location: /web/notifications/');
     exit;
 }

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -31,7 +31,7 @@ if (!$auth->isLoggedIn()) {
 $user = $userModel->findById($auth->getUserId());
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     $projectId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
     $redirectUrl = '/web/';
     if ($projectId > 0) {

--- a/src/frontend/settings.php
+++ b/src/frontend/settings.php
@@ -25,7 +25,7 @@ if (!$auth->isLoggedIn()) {
 $user = $userModel->findById($auth->getUserId());
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     header('Location: /web/settings/');
     exit;
 }

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -25,7 +25,7 @@ if (!$auth->isLoggedIn()) {
 $user = $userModel->findById($auth->getUserId());
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     $taskId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
     $redirectUrl = '/web/';
     if ($taskId > 0) {

--- a/src/frontend/templates.php
+++ b/src/frontend/templates.php
@@ -21,7 +21,7 @@ if (!$auth->isLoggedIn()) {
 $user = $userModel->findById($auth->getUserId());
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     header('Location: /web/templates/');
     exit;
 }


### PR DESCRIPTION
This change prevents the PHP backend from redirecting users to the Next-Generation React UI (/web/) if the UI static files are not actually installed (i.e., if src/frontend/web/index.html is missing). This fixes a "double redirect" issue where users would lose their context (e.g., project IDs) and end up on the dashboard or stuck in a loop.

Key changes:
- Added `file_exists` checks to `index.php`, `project.php`, `task.php`, `settings.php`, `templates.php`, `logs.php`, `notifications.php`, and `admin/index.php`.
- Updated `google/callback.php` and `github/callback.php` to fallback to legacy index if Next-Gen UI is missing.
- Implemented a safeguard in `src/frontend/index.php` that detects broken /web/ paths and returns the user to the legacy dashboard.
- Fixed a bug in `src/frontend/admin/index.php` where redirection was checked against an uninitialized `$user` variable.

Fixes #750

---
*PR created automatically by Jules for task [3951264293503759206](https://jules.google.com/task/3951264293503759206) started by @chatelao*