### PR TITLE
Gate Next-Gen UI redirections with build existence check

### DIFF
--- a/src/frontend/admin/index.php
+++ b/src/frontend/admin/index.php
@@ -16,11 +16,8 @@ if (!$auth->isLoggedIn()) {
     exit;
 }
 
-$currentUser = $userModel->findById($auth->getUserId());
-$user = $currentUser;
-
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/../web/index.html')) {
+if ($auth->isLoggedIn() && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/../web/index.html')) {
     header('Location: /web/admin/');
     exit;
 }
@@ -28,6 +25,9 @@ if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUE
 if (!$auth->isAdmin()) {
     die("Access denied. Admin privileges required.");
 }
+
+$currentUser = $userModel->findById($auth->getUserId());
+$user = $currentUser;
 $taskModel = new Task($db);
 $allUsers = $userModel->getAllUsersWithProjectCount();
 

--- a/src/frontend/admin/index.php
+++ b/src/frontend/admin/index.php
@@ -16,8 +16,11 @@ if (!$auth->isLoggedIn()) {
     exit;
 }
 
+$currentUser = $userModel->findById($auth->getUserId());
+$user = $currentUser;
+
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/../web/index.html')) {
     header('Location: /web/admin/');
     exit;
 }
@@ -25,9 +28,6 @@ if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUE
 if (!$auth->isAdmin()) {
     die("Access denied. Admin privileges required.");
 }
-
-$currentUser = $userModel->findById($auth->getUserId());
-$user = $currentUser;
 $taskModel = new Task($db);
 $allUsers = $userModel->getAllUsersWithProjectCount();
 

--- a/src/frontend/github/callback.php
+++ b/src/frontend/github/callback.php
@@ -64,7 +64,7 @@ if (isset($_GET['code']) && isset($_GET['state'])) {
                 $userModel->addGitHubAccount($user['user_id'], $githubData['access_token'], $githubData['github_username']);
 
                 $auth->login($user);
-                $redirectUrl = file_exists(__DIR__ . '/../web/index.html') ? '/web/' : '../index.php';
+                $redirectUrl = file_exists(__DIR__ . '/../web/index.html') ? '/web/' : '/index.php';
                 header('Location: ' . $redirectUrl);
                 exit;
             } else {

--- a/src/frontend/github/callback.php
+++ b/src/frontend/github/callback.php
@@ -64,7 +64,8 @@ if (isset($_GET['code']) && isset($_GET['state'])) {
                 $userModel->addGitHubAccount($user['user_id'], $githubData['access_token'], $githubData['github_username']);
 
                 $auth->login($user);
-                header('Location: /web/');
+                $redirectUrl = file_exists(__DIR__ . '/../web/index.html') ? '/web/' : '../index.php';
+                header('Location: ' . $redirectUrl);
                 exit;
             } else {
                 throw new Exception("Failed to create or update user from GitHub data.");

--- a/src/frontend/google/callback.php
+++ b/src/frontend/google/callback.php
@@ -14,7 +14,8 @@ if (isset($_GET['code'])) {
         $googleUser = $auth->authenticate($_GET['code']);
         $user = $userModel->createOrUpdate($googleUser);
         $auth->login($user);
-        header('Location: /web/');
+        $redirectUrl = file_exists(__DIR__ . '/../web/index.html') ? '/web/' : '../index.php';
+        header('Location: ' . $redirectUrl);
         exit;
     } catch (Exception $e) {
         echo "Error: " . htmlspecialchars($e->getMessage());

--- a/src/frontend/google/callback.php
+++ b/src/frontend/google/callback.php
@@ -14,7 +14,7 @@ if (isset($_GET['code'])) {
         $googleUser = $auth->authenticate($_GET['code']);
         $user = $userModel->createOrUpdate($googleUser);
         $auth->login($user);
-        $redirectUrl = file_exists(__DIR__ . '/../web/index.html') ? '/web/' : '../index.php';
+        $redirectUrl = file_exists(__DIR__ . '/../web/index.html') ? '/web/' : '/index.php';
         header('Location: ' . $redirectUrl);
         exit;
     } catch (Exception $e) {

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -29,7 +29,7 @@ if (isset($_GET['legacy'])) {
 }
 
 // Next-Gen UI Redirection & Safeguard
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1') {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && file_exists(__DIR__ . '/web/index.html')) {
     $requestUri = $_SERVER['REQUEST_URI'] ?? '';
     $isWebPath = strpos($requestUri, '/web/') !== false;
 

--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -29,7 +29,8 @@ if (isset($_GET['legacy'])) {
 }
 
 // Next-Gen UI Redirection & Safeguard
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && file_exists(__DIR__ . '/web/index.html')) {
+$nextGenExists = file_exists(__DIR__ . '/web/index.html');
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && $nextGenExists) {
     $requestUri = $_SERVER['REQUEST_URI'] ?? '';
     $isWebPath = strpos($requestUri, '/web/') !== false;
 
@@ -74,6 +75,11 @@ if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && file_exists(__DIR__ . 
             exit;
         }
     }
+} elseif (strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') !== false && !$nextGenExists) {
+    // If we are in /web/ but Next-Gen UI is not installed, redirect back to root dashboard
+    // to avoid being stuck in a /web/ path that renders the legacy UI incorrectly.
+    header('Location: /index.php');
+    exit;
 }
 
 $githubAccounts = $user ? $userModel->getGitHubAccounts($user['user_id']) : [];

--- a/src/frontend/logs.php
+++ b/src/frontend/logs.php
@@ -23,7 +23,7 @@ if (!$auth->isLoggedIn()) {
 $user = $userModel->findById($auth->getUserId());
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     header('Location: /web/logs/');
     exit;
 }

--- a/src/frontend/notifications.php
+++ b/src/frontend/notifications.php
@@ -23,7 +23,7 @@ $userId = $auth->getUserId();
 $user = $userModel->findById($userId);
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     header('Location: /web/notifications/');
     exit;
 }

--- a/src/frontend/project.php
+++ b/src/frontend/project.php
@@ -31,7 +31,7 @@ if (!$auth->isLoggedIn()) {
 $user = $userModel->findById($auth->getUserId());
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     $projectId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
     $redirectUrl = '/web/';
     if ($projectId > 0) {

--- a/src/frontend/settings.php
+++ b/src/frontend/settings.php
@@ -25,7 +25,7 @@ if (!$auth->isLoggedIn()) {
 $user = $userModel->findById($auth->getUserId());
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     header('Location: /web/settings/');
     exit;
 }

--- a/src/frontend/task.php
+++ b/src/frontend/task.php
@@ -25,7 +25,7 @@ if (!$auth->isLoggedIn()) {
 $user = $userModel->findById($auth->getUserId());
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     $taskId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
     $redirectUrl = '/web/';
     if ($taskId > 0) {

--- a/src/frontend/templates.php
+++ b/src/frontend/templates.php
@@ -21,7 +21,7 @@ if (!$auth->isLoggedIn()) {
 $user = $userModel->findById($auth->getUserId());
 
 // Default Redirection to Next-Gen UI
-if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false) {
+if ($user && ($_COOKIE['prefer_legacy'] ?? '') !== '1' && strpos($_SERVER['REQUEST_URI'] ?? '', '/web/') === false && file_exists(__DIR__ . '/web/index.html')) {
     header('Location: /web/templates/');
     exit;
 }


### PR DESCRIPTION
This change prevents users from being "locked" in a redirection loop to the Next-Gen UI when its build artifacts are missing. It adds a file_exists check for src/frontend/web/index.html to all redirection points in the legacy PHP frontend, ensuring users stay on or fall back to the legacy UI when the Next-Gen UI is not installed. It also fixes an undefined variable bug in the admin dashboard.

Fixes #753

---
*PR created automatically by Jules for task [3652710532020706883](https://jules.google.com/task/3652710532020706883) started by @chatelao*