### PR TITLE
Fix unnecessary horizontal scrollbar in Next-Gen UI

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -14,6 +14,10 @@
   }
 }
 
+html, body {
+  overflow-x: clip;
+}
+
 body {
   color: var(--foreground);
   background: var(--background);

--- a/web/src/components/TaskStatusSquare.tsx
+++ b/web/src/components/TaskStatusSquare.tsx
@@ -62,7 +62,7 @@ export const TaskStatusSquare: React.FC<TaskStatusSquareProps> = ({ task }) => {
         className={`block w-6 h-6 rounded shadow-sm transition-transform duration-200 hover:scale-125 hover:z-10 ${colorClass}`}
         aria-label={`Task #${task.issue_number}: ${label}`}
       />
-      <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-[10px] rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
+      <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-[10px] rounded invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-lg">
         #{task.issue_number}: {emoji} {label} - {task.title}
       </div>
     </div>


### PR DESCRIPTION
This PR addresses the issue where the Next-Gen UI window would sometimes have an unnecessary horizontal scrollbar. The fix involves:
1. Modifying `web/src/components/TaskStatusSquare.tsx` to use `invisible group-hover:visible` on tooltips. This prevents the `whitespace-nowrap` content from expanding the page width when the tooltip is hidden (even if it has `opacity-0`).
2. Adding `overflow-x: clip` to the `html` and `body` elements in `web/src/app/globals.css`. This is a modern CSS approach to prevent horizontal overflow that doesn't interfere with `sticky` positioning.

Verification:
- Ran `npm run build` in the `web/` directory successfully.
- Verified using a Playwright script that `document.documentElement.scrollWidth` matches `document.documentElement.clientWidth` (1920px).

Fixes #762

---
*PR created automatically by Jules for task [2450675465602902610](https://jules.google.com/task/2450675465602902610) started by @chatelao*