### PR TITLE
Implement Custom Blockly Blocks and Refine Roadmap

### DIFF
--- a/BLOCKLY_ROADMAP.md
+++ b/BLOCKLY_ROADMAP.md
@@ -35,10 +35,11 @@
 - [x] Implement persistence logic (saving to API on change/save).
 
 ## Phase 3: Custom Block Definitions
-- [ ] Define the `OnEvent` trigger block.
-- [ ] Implement Action blocks (Merge, Duplicate, Set Label, Notify).
-- [ ] Implement Logic/Predicate blocks (Check Label, Is Task Ready).
-- [ ] Configure `javascriptGenerator` to produce clean, proxy-aware JS code.
+- [x] Define the `OnEvent` trigger block.
+- [x] Implement basic Action blocks (`Merge`, `Duplicate`, `Notify`).
+- [ ] Implement advanced Action blocks (`Set Label`, `Remove Label`, `Post Comment`, `Trigger Agent`).
+- [ ] Implement Logic/Predicate blocks (`Read Label`, `Is Task Ready`).
+- [x] Configure `javascriptGenerator` to produce clean, proxy-aware JS code.
 
 ## Phase 4: JavaScript Execution Sandbox
 - [ ] Select and integrate a JS sandbox engine (e.g., PHP `v8js` or Node.js bridge).

--- a/web/src/components/blockly/BlocklyComponent.tsx
+++ b/web/src/components/blockly/BlocklyComponent.tsx
@@ -3,6 +3,10 @@
 import React, { useEffect, useRef } from 'react';
 import * as Blockly from 'blockly';
 import { javascriptGenerator } from 'blockly/javascript';
+import { defineCustomBlocks } from './custom_blocks';
+
+// Initialize custom blocks
+defineCustomBlocks();
 
 interface BlocklyComponentProps {
   initialXml?: string;
@@ -42,6 +46,24 @@ const BlocklyComponent: React.FC<BlocklyComponentProps> = ({
       toolbox: toolboxConfig || {
         kind: 'categoryToolbox',
         contents: [
+          {
+            kind: 'category',
+            name: 'Events',
+            colour: '230',
+            contents: [
+              { kind: 'block', type: 'on_event' },
+            ],
+          },
+          {
+            kind: 'category',
+            name: 'Actions',
+            colour: '160',
+            contents: [
+              { kind: 'block', type: 'notify' },
+              { kind: 'block', type: 'merge' },
+              { kind: 'block', type: 'duplicate' },
+            ],
+          },
           {
             kind: 'category',
             name: 'Logic',

--- a/web/src/components/blockly/custom_blocks.ts
+++ b/web/src/components/blockly/custom_blocks.ts
@@ -1,0 +1,85 @@
+import * as Blockly from 'blockly';
+import { javascriptGenerator } from 'blockly/javascript';
+
+export const defineCustomBlocks = () => {
+  // on_event trigger block
+  Blockly.Blocks['on_event'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("On Event")
+          .appendField(new Blockly.FieldDropdown([
+            ["Issue Labeled", "ISSUE_LABELED"],
+            ["Issue Closed", "ISSUE_CLOSED"],
+            ["PR Created", "PR_CREATED"],
+            ["PR Merged", "PR_MERGED"],
+            ["Checks Completed", "CHECKS_COMPLETED"],
+            ["Agent Error", "AGENT_ERROR"]
+          ]), "EVENT");
+      this.appendStatementInput("STACK")
+          .setCheck(null)
+          .appendField("do");
+      this.setColour(230);
+      this.setTooltip("Trigger logic when a specific system or GitHub event occurs.");
+      this.setHelpUrl("");
+    }
+  };
+
+  javascriptGenerator.forBlock['on_event'] = (block: Blockly.Block, generator: any) => {
+    const dropdown_event = block.getFieldValue('EVENT');
+    const statements_stack = generator.statementToCode(block, 'STACK');
+    return `onEvent("${dropdown_event}", (event) => {\n${statements_stack}});\n`;
+  };
+
+  // notify action block
+  Blockly.Blocks['notify'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Notify")
+          .appendField(new Blockly.FieldTextInput("Message..."), "MESSAGE");
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+      this.setColour(160);
+      this.setTooltip("Send a notification via Telegram and In-App Inbox.");
+      this.setHelpUrl("");
+    }
+  };
+
+  javascriptGenerator.forBlock['notify'] = (block: Blockly.Block) => {
+    const text_message = block.getFieldValue('MESSAGE');
+    return `notify("${text_message}");\n`;
+  };
+
+  // merge action block
+  Blockly.Blocks['merge'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Merge Pull Request");
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+      this.setColour(160);
+      this.setTooltip("Merge the Pull Request associated with the current task.");
+      this.setHelpUrl("");
+    }
+  };
+
+  javascriptGenerator.forBlock['merge'] = () => {
+    return `merge();\n`;
+  };
+
+  // duplicate action block
+  Blockly.Blocks['duplicate'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Duplicate Issue");
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+      this.setColour(160);
+      this.setTooltip("Create a copy of the current issue (useful for auto-repeat).");
+      this.setHelpUrl("");
+    }
+  };
+
+  javascriptGenerator.forBlock['duplicate'] = () => {
+    return `duplicate();\n`;
+  };
+};


### PR DESCRIPTION
I have implemented a set of custom Blockly blocks as part of Phase 3 of the Blockly Automation Engine roadmap. This includes:

1.  **Custom Block Definitions**: Added `on_event` (trigger), `notify`, `merge`, and `duplicate` (actions) in a new `web/src/components/blockly/custom_blocks.ts` file.
2.  **JavaScript Generators**: Implemented generators for these blocks to produce clean, proxy-aware JavaScript code (e.g., `onEvent("EVENT", (event) => { ... })`).
3.  **UI Integration**: Updated `BlocklyComponent.tsx` to initialize these custom blocks and added new "Events" and "Actions" categories to the default toolbox.
4.  **Roadmap Update**: Granularized "Phase 3: Custom Block Definitions" in `BLOCKLY_ROADMAP.md` and marked the completed basic blocks as done.

Verified the changes with `npx tsc --noEmit` in the `web/` directory.

Fixes #771

---
*PR created automatically by Jules for task [189778732280402281](https://jules.google.com/task/189778732280402281) started by @chatelao*