### PR TITLE
Fix layout overflows and rendering errors in detail views

### DIFF
--- a/web/src/app/projects/[id]/ProjectDetailView.tsx
+++ b/web/src/app/projects/[id]/ProjectDetailView.tsx
@@ -95,15 +95,17 @@ export default function ProjectDetailView({ id }: { id: string }) {
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
-          <div className="lg:col-span-3">
+          <div className="lg:col-span-3 min-w-0">
             <TaskFilterBar
               search={search}
               onSearchChange={setSearch}
               statusFilter={statusFilter}
               onStatusFilterChange={setStatusFilter}
+              searchLabel="Search Tasks"
+              searchPlaceholder="Search by title or issue number..."
             />
 
-            <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+            <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-x-auto">
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">
                   <tr>
@@ -155,7 +157,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
             </div>
           </div>
 
-          <div className="lg:col-span-1 space-y-6">
+          <div className="lg:col-span-1 space-y-6 min-w-0">
             <div className="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
               <h3 className="text-lg font-bold text-gray-900 mb-4">Roadmap</h3>
               {project.roadmap_data && project.roadmap_data.length > 0 ? (

--- a/web/src/app/tasks/[id]/TaskDetailView.tsx
+++ b/web/src/app/tasks/[id]/TaskDetailView.tsx
@@ -79,18 +79,22 @@ export default function TaskDetailView({ id }: { id: string }) {
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
-          <div className="lg:col-span-3 space-y-6">
+          <div className="lg:col-span-3 space-y-6 min-w-0">
             {/* Header */}
             <div className="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
               <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center space-x-3">
-                  <TaskStatusSquare task={task} />
-                  <h2 className="text-2xl font-bold text-gray-900">
+                <div className="flex items-center space-x-3 min-w-0">
+                  <div className="flex-shrink-0">
+                    <TaskStatusSquare task={task} />
+                  </div>
+                  <h2 className="text-2xl font-bold text-gray-900 truncate">
                     <span className="text-gray-400 mr-2">#{task.issue_number}</span>
                     {task.title}
                   </h2>
                 </div>
-                <StatusBadge status={task.status} />
+                <div className="flex-shrink-0">
+                  <StatusBadge status={task.status} />
+                </div>
               </div>
               <div className="flex flex-wrap gap-2 mb-6">
                 {task.labels?.map((label, index) => (
@@ -300,7 +304,7 @@ export default function TaskDetailView({ id }: { id: string }) {
           </div>
 
           {/* Sidebar */}
-          <div className="lg:col-span-1">
+          <div className="lg:col-span-1 min-w-0">
             <TaskSidebar task={task} />
           </div>
         </div>

--- a/web/src/components/TaskFilterBar.tsx
+++ b/web/src/components/TaskFilterBar.tsx
@@ -8,6 +8,8 @@ interface TaskFilterBarProps {
   onSearchChange: (value: string) => void;
   statusFilter: TaskStatus | 'all';
   onStatusFilterChange: (value: TaskStatus | 'all') => void;
+  searchLabel?: string;
+  searchPlaceholder?: string;
 }
 
 const statuses: { value: TaskStatus | 'all'; label: string }[] = [
@@ -30,12 +32,14 @@ export const TaskFilterBar: React.FC<TaskFilterBarProps> = ({
   onSearchChange,
   statusFilter,
   onStatusFilterChange,
+  searchLabel = 'Search Repositories',
+  searchPlaceholder = 'e.g. google/jules',
 }) => {
   return (
     <div className="flex flex-col md:flex-row gap-4 mb-6 bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
-      <div className="flex-grow">
+      <div className="flex-grow min-w-0">
         <label htmlFor="search" className="block text-xs font-medium text-gray-700 mb-1">
-          Search Repositories
+          {searchLabel}
         </label>
         <div className="relative">
           <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -47,7 +51,7 @@ export const TaskFilterBar: React.FC<TaskFilterBarProps> = ({
             type="text"
             id="search"
             className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 sm:text-sm transition-colors"
-            placeholder="e.g. google/jules"
+            placeholder={searchPlaceholder}
             value={search}
             onChange={(e) => onSearchChange(e.target.value)}
           />


### PR DESCRIPTION
This PR fixes the rendering errors where the layout was being cut off or "halved" due to CSS Grid items expanding to fit their content (especially long titles or wide tables). By adding `min-w-0` to the grid columns and enabling horizontal scrolling for tables, the layout now remains stable within the viewport. Additionally, the `TaskFilterBar` component was refactored to allow context-specific labels.

Fixes #763

---
*PR created automatically by Jules for task [3154019470884325119](https://jules.google.com/task/3154019470884325119) started by @chatelao*