### PR TITLE
Add Task Countdown Design and Roadmap docs

### DIFF
--- a/COUNT_DOWN_DESIGN.md
+++ b/COUNT_DOWN_DESIGN.md
@@ -1,0 +1,92 @@
+# Design: Task Countdown & Delayed Auto-Repeat
+
+## Overview
+The "Temporal Countdown" mechanism extends the existing Auto-Repeat feature by introducing time-based delays between task iterations. This allows for scheduled periodic tasks (e.g., daily audits, weekly syncs) without requiring external scheduling tools.
+
+## 1. Database Schema Changes
+
+A new migration `src/sql/020_add_autorepeat_delay_and_scheduled_at_to_tasks.sql` will introduce the following columns to the `tasks` table:
+
+| Column | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `autorepeat_delay` | `INT` | `0` | Delay in seconds between iterations. |
+| `scheduled_at` | `DATETIME` | `NULL` | The timestamp when the next iteration should be triggered. |
+
+## 2. Backend Implementation
+
+### 2.1 Webhook & Duplication Logic (`App\WebhookHandler`)
+
+The `maybeDuplicateTask` method will be updated to respect the `autorepeat_delay`:
+
+1.  **Detection**: Check if `autorepeat_remaining > 0` and `autorepeat` label is present.
+2.  **Delay Calculation**:
+    - If `autorepeat_delay > 0`:
+        - Calculate `scheduled_at = NOW() + autorepeat_delay`.
+        - Set `status = 'scheduled'`.
+        - **Crucial**: Do NOT add the `Jules` label to the new GitHub issue yet.
+    - Else:
+        - Add `Jules` label immediately.
+        - Set `status = 'created'`.
+3.  **Persistence**: Call `Task::upsert` with the new fields.
+
+### 2.2 Scheduled Task Processor (`App\Task`)
+
+A new method `processScheduledTasks()` will be added to the `Task` class:
+
+1.  **Query**: Fetch all tasks where `status = 'scheduled'` and `scheduled_at <= NOW()`.
+2.  **Execution**: For each task:
+    - Call `GitHubService::addLabel(repo, number, 'Jules')`.
+    - Update task status to `created`.
+    - Clear `scheduled_at` (set to `NULL`).
+    - Log the trigger event: "Scheduled task triggered after [X] seconds delay."
+
+### 2.3 Periodic Trigger (`src/frontend/cronjob.php`)
+
+The global cron job will be updated to call the scheduled task processor:
+
+```php
+$taskModel->processScheduledTasks($scopedGithubService, $notificationService);
+```
+
+This ensures that even if no webhooks are received, scheduled tasks are released exactly when their delay expires.
+
+## 3. API Integration
+
+### 3.1 `api/openapi.yaml`
+Update the `Task` schema to include:
+- `autorepeat_delay` (integer, seconds).
+- `scheduled_at` (string, ISO-8601).
+
+### 3.2 Endpoint Updates
+- `GET /api/task.php`: Return the new fields.
+- `POST /api/task.php`: Support updating `autorepeat_delay`.
+
+## 4. Next-Gen UI (React)
+
+### 4.1 Task Detail View (`TaskDetailView.tsx`)
+- **Configuration**: Add an "Auto-Repeat Delay" section.
+    - Use a numeric input with a unit selector (Minutes, Hours, Days).
+    - Convert selected units to seconds for API storage.
+- **Status Display**: If a task is in `scheduled` state:
+    - Display a "Scheduled" badge (e.g., orange/brown).
+    - Render a `CountdownTimer` component showing "Next run in: HH:MM:SS".
+
+### 4.2 Dashboard & Autorepeat Table
+- Update `AutorepeatTasks` component to show the countdown timer in the "Status" column for scheduled tasks.
+- Allow users to manually "Trigger Now" a scheduled task, which bypasses the delay and adds the `Jules` label immediately.
+
+## 5. State Transition Flow
+
+```mermaid
+graph TD
+    A[Task Finished] --> B{Auto-Repeat?}
+    B -- No --> C[End]
+    B -- Yes --> D{Delay > 0?}
+    D -- No --> E[Create Issue + Jules Label]
+    E --> F[Status: created]
+    D -- Yes --> G[Create Issue No Label]
+    G --> H[Status: scheduled]
+    H --> I[Cron: scheduled_at passed]
+    I --> J[Add Jules Label]
+    J --> F
+```

--- a/COUNT_DOWN_ROADMAP.md
+++ b/COUNT_DOWN_ROADMAP.md
@@ -1,0 +1,43 @@
+# Roadmap: Task Countdown & Delayed Auto-Repeat
+
+## Progress Overview
+
+| Phase | Description | Status |
+|-------|-------------|--------|
+| 1 | Database Schema & API | 🌑 |
+| 2 | Backend Logic (Scheduling) | 🌑 |
+| 3 | UI Integration (Next-Gen) | 🌑 |
+| 4 | Verification & Edge Cases | 🌑 |
+
+## Goals
+
+- Allow users to specify a time delay between auto-repeated tasks.
+- Provide a clear countdown UI for scheduled tasks.
+- Ensure reliable execution of scheduled releases via periodic cron jobs.
+- Support manual override (immediate trigger) of scheduled tasks.
+
+## Phase 1: Database Schema & API
+- [ ] Create migration `src/sql/020_add_autorepeat_delay_and_scheduled_at_to_tasks.sql`.
+- [ ] Update `App\Task` model to support the new columns in `upsert` and `create`.
+- [ ] Update `api/openapi.yaml` with `autorepeat_delay` and `scheduled_at` fields.
+- [ ] Update `/api/task.php` to expose and accept these new fields.
+
+## Phase 2: Backend Logic (Scheduling)
+- [ ] Update `WebhookHandler::maybeDuplicateTask` to calculate `scheduled_at` and set status to `scheduled`.
+- [ ] Implement `Task::processScheduledTasks()` to release tasks whose time has come.
+- [ ] Integrate `processScheduledTasks()` into `src/frontend/cronjob.php`.
+- [ ] Add logging to track scheduling events in `task_logs`.
+
+## Phase 3: UI Integration (Next-Gen)
+- [ ] Implement `CountdownTimer` component in `web/src/components/`.
+- [ ] Update `TaskDetailView.tsx` with configuration inputs for `autorepeat_delay`.
+- [ ] Update `TaskStatusSquare.tsx` or similar to handle the `scheduled` state visually.
+- [ ] Add "Trigger Now" action to the task detail and dashboard views for scheduled tasks.
+- [ ] Update `AutorepeatTasks` table to show the remaining time until the next run.
+
+## Phase 4: Verification & Edge Cases
+- [ ] Test immediate auto-repeat (delay = 0) remains unchanged.
+- [ ] Test delayed auto-repeat (delay > 0) correctly sets `scheduled_at`.
+- [ ] Verify cron job releases the task and adds the `Jules` label.
+- [ ] Test behavior when `autorepeat_remaining` reaches 0 (no further scheduling).
+- [ ] Verify that manual label removal on a scheduled task correctly impacts the next iteration.


### PR DESCRIPTION
I have created the `COUNT_DOWN_DESIGN.md` and `COUNT_DOWN_ROADMAP.md` files as requested.

### COUNT_DOWN_DESIGN.md
This document outlines the technical architecture for the "Temporal Countdown" feature, including:
- **Database Schema**: New `autorepeat_delay` and `scheduled_at` columns.
- **Backend Logic**: Updates to `WebhookHandler` for delayed duplication and a new `Task::processScheduledTasks` method for the cron job.
- **API**: Updates to `openapi.yaml` and task endpoints.
- **Frontend**: Design for configuration inputs and countdown timers in the Next-Gen UI.

### COUNT_DOWN_ROADMAP.md
This document breaks down the implementation into four phases:
1. **Database Schema & API**
2. **Backend Logic (Scheduling)**
3. **UI Integration (Next-Gen)**
4. **Verification & Edge Cases**

Both documents were verified for content and consistency. PHP syntax checks were performed on related backend files to ensure no regressions.

Fixes #777

---
*PR created automatically by Jules for task [7084951525814374840](https://jules.google.com/task/7084951525814374840) started by @chatelao*