### PR TITLE
Implement Telegram /status command

### DIFF
--- a/CHAT_ROADMAP.md
+++ b/CHAT_ROADMAP.md
@@ -63,3 +63,6 @@
 - [x] Update `NotificationService` to support automatic and manual message cleanup.
 - [x] Implement `/cleanup` command in `TelegramWebhookHandler`.
 - [x] Verify cleanup flow by marking a notification as read and using manual command.
+
+## Phase 8: Advanced Interactions
+- [x] Implement `/status` command to pull current task summary.

--- a/src/backend/TelegramWebhookHandler.php
+++ b/src/backend/TelegramWebhookHandler.php
@@ -56,7 +56,39 @@ class TelegramWebhookHandler
             return $this->handleCleanup($chatId);
         }
 
+        if ($text === '/status') {
+            return $this->handleStatus($chatId);
+        }
+
         return false;
+    }
+
+    private function handleStatus(int $chatId): bool
+    {
+        $user = $this->userModel->findByTelegramChatId($chatId);
+        if (!$user) {
+            $this->telegramService->sendMessage($chatId, "Unauthorized. Please link your account.");
+            return false;
+        }
+
+        $taskModel = new Task($this->userModel->getDb());
+        $counts = $taskModel->getTaskCounts((int)$user['user_id']);
+
+        $text = "<b>Task Status Summary</b>\n\n";
+        $text .= "📝 <b>Open Issues:</b> " . ($counts['open_issues'] ?? 0) . "\n";
+        $text .= "✅ <b>Completed Tasks:</b> " . ($counts['completed_tasks'] ?? 0) . "\n\n";
+
+        $text .= "<b>Jules Status:</b>\n";
+        $text .= "🚧 Processing: " . (($counts['jules_analyzing'] ?? 0) + ($counts['jules_executing'] ?? 0)) . "\n";
+        $text .= "❌ Failed: " . ($counts['jules_failed'] ?? 0) . "\n\n";
+
+        $text .= "<b>GitHub Status:</b>\n";
+        $text .= "🔍 Running: " . ($counts['github_running'] ?? 0) . "\n";
+        $text .= "🚀 Passed: " . ($counts['github_passed'] ?? 0) . "\n";
+        $text .= "❌ Failed: " . ($counts['github_failed'] ?? 0) . "\n";
+
+        $this->telegramService->sendMessage($chatId, $text);
+        return true;
     }
 
     private function handleCallback(array $callbackQuery): bool


### PR DESCRIPTION
This change implements the `/status` command for the Telegram bot, allowing users to pull a current summary of their task statuses directly from the chat.

Key changes:
- **TelegramWebhookHandler.php**: Added logic to handle the `/status` command. It uses the existing `Task::getTaskCounts()` method to aggregate data and sends a formatted HTML message with emojis back to the user.
- **CHAT_ROADMAP.md**: Added "Phase 8: Advanced Interactions" and documented the implementation of the `/status` command.

This fulfills the conceptual goal of supporting "Asynchronous (Pull)" interactions mentioned in CHAT_CONCEPT.md.

Fixes #776

---
*PR created automatically by Jules for task [7700489353272215963](https://jules.google.com/task/7700489353272215963) started by @chatelao*