### PR TITLE
GitHub Issue Comment Notifications and Immediate Status Refresh

### DIFF
--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -304,20 +304,45 @@ class WebhookHandler
         $isJulesComment = ($login === 'google-labs-jules[bot]' || $login === 'jules');
         $body = $comment['body'] ?? '';
 
-        if ($isJulesComment && stripos($body, 'on it') !== false) {
-            $sessionId = $taskModel->extractSessionId($body);
-            if ($sessionId) {
-                $task = $taskModel->findByIssueNumber($project['project_id'], $issue['number']);
-                if ($task) {
-                    $connection = $this->db->getConnection();
-                    $stmt = $connection->prepare("UPDATE tasks SET jules_session_id = ? WHERE task_id = ?");
-                    $stmt->execute([$sessionId, $task['task_id']]);
+        $task = $taskModel->findByIssueNumber($project['project_id'], $issue['number']);
 
-                    if ($githubService && $julesService) {
-                        $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $notificationService, (int)$task['task_id']);
-                    }
-                }
+        if ($isJulesComment) {
+            $sessionId = $taskModel->extractSessionId($body);
+            if ($sessionId && $task) {
+                $connection = $this->db->getConnection();
+                $stmt = $connection->prepare("UPDATE tasks SET jules_session_id = ? WHERE task_id = ?");
+                $stmt->execute([$sessionId, $task['task_id']]);
             }
+
+            // Always refresh status when Jules comments to capture state transitions immediately
+            if ($task && $githubService && $julesService) {
+                $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $notificationService, (int)$task['task_id']);
+            }
+        }
+
+        // Notify about the comment
+        if ($notificationService) {
+            $userName = $comment['user']['login'] ?? 'Unknown';
+            $title = ($isJulesComment ? "🤖 Jules" : "💬 $userName") . " commented on #" . $issue['number'];
+
+            $notificationData = [
+                'project_id' => $project['project_id'],
+                'issue_number' => $issue['number'],
+                'source_url' => $comment['html_url'] ?? $issue['html_url'],
+                'is_system' => $isJulesComment || !$this->isUserTriggered($event)
+            ];
+
+            if ($task) {
+                $notificationData['task_id'] = $task['task_id'];
+            }
+
+            $notificationService->notify(
+                $project['user_id'],
+                'github_comment',
+                $title,
+                $body,
+                $notificationData
+            );
         }
 
         return true;

--- a/src/frontend/github/webhook.php
+++ b/src/frontend/github/webhook.php
@@ -54,7 +54,7 @@ if (empty($githubEvent)) {
 }
 
 // Return 200 for unhandled events to keep webhook healthy on GitHub
-if (!in_array($githubEvent, ['issues', 'ping', 'check_suite', 'pull_request'])) {
+if (!in_array($githubEvent, ['issues', 'ping', 'check_suite', 'pull_request', 'issue_comment'])) {
     http_response_code(200);
     exit("Event $githubEvent skipped");
 }

--- a/test/Unit/WebhookHandlerCommentTest.php
+++ b/test/Unit/WebhookHandlerCommentTest.php
@@ -43,11 +43,13 @@ class WebhookHandlerCommentTest extends TestCase
             'repository' => ['full_name' => 'owner/repo'],
             'action' => 'created',
             'issue' => [
-                'number' => 123
+                'number' => 123,
+                'html_url' => 'https://github.com/owner/repo/issues/123'
             ],
             'comment' => [
                 'user' => ['login' => 'google-labs-jules[bot]'],
-                'body' => 'Jules is [on it](https://jules.google.com/sessions/s123). When finished, you will see another comment.'
+                'body' => 'Jules is [on it](https://jules.google.com/sessions/s123). When finished, you will see another comment.',
+                'html_url' => 'https://github.com/owner/repo/issues/123#issuecomment-1'
             ]
         ];
 
@@ -79,15 +81,25 @@ class WebhookHandlerCommentTest extends TestCase
         // Mock refreshJulesStatus
         $this->taskModel->expects($this->once())
             ->method('refreshJulesStatus')
-            ->with(10, $this->githubService, $this->julesService, null, 456);
+            ->with(10, $this->githubService, $this->julesService, $this->notificationService, 456);
 
-        // We need to inject the mock taskModel into the handler.
-        // Since the handler creates Task internally, we might need to adjust the test or the handler.
-        // Looking at WebhookHandler::handle, it does: $taskModel = new Task($this->db);
-        // This is hard to mock without refactoring.
-        // Let's use a partial mock or reflection if needed, but wait, Task is just a wrapper around DB.
+        // Mock NotificationService
+        $this->notificationService->expects($this->once())
+            ->method('notify')
+            ->with(
+                10,
+                'github_comment',
+                '🤖 Jules commented on #123',
+                $event['comment']['body'],
+                $this->callback(function($data) {
+                    return $data['project_id'] === 1 &&
+                           $data['issue_number'] === 123 &&
+                           $data['task_id'] === 456 &&
+                           $data['is_system'] === true;
+                })
+            );
 
-        // Let's test the private handleIssueComment method using reflection to be sure.
+        // Let's test the private handleIssueComment method using reflection
         $reflection = new \ReflectionClass(WebhookHandler::class);
         $method = $reflection->getMethod('handleIssueComment');
         $method->setAccessible(true);
@@ -98,7 +110,7 @@ class WebhookHandlerCommentTest extends TestCase
             $this->taskModel,
             $this->githubService,
             $this->julesService,
-            null
+            $this->notificationService
         ]);
 
         $this->assertTrue($result);
@@ -106,16 +118,53 @@ class WebhookHandlerCommentTest extends TestCase
 
     public function testHandleIssueCommentNotJules()
     {
-        $project = ['project_id' => 1];
+        $project = [
+            'project_id' => 1,
+            'user_id' => 10,
+            'github_repo' => 'owner/repo'
+        ];
         $event = [
-            'issue' => ['number' => 123],
+            'issue' => [
+                'number' => 123,
+                'html_url' => 'https://github.com/owner/repo/issues/123'
+            ],
             'comment' => [
                 'user' => ['login' => 'someone-else'],
-                'body' => 'on it'
-            ]
+                'body' => 'This is a comment',
+                'html_url' => 'https://github.com/owner/repo/issues/123#issuecomment-2'
+            ],
+            'sender' => ['type' => 'User']
         ];
 
+        $task = [
+            'task_id' => 456,
+            'project_id' => 1,
+            'issue_number' => 123
+        ];
+
+        $this->taskModel->expects($this->once())
+            ->method('findByIssueNumber')
+            ->with(1, 123)
+            ->willReturn($task);
+
         $this->taskModel->expects($this->never())->method('extractSessionId');
+        $this->taskModel->expects($this->never())->method('refreshJulesStatus');
+
+        // Mock NotificationService
+        $this->notificationService->expects($this->once())
+            ->method('notify')
+            ->with(
+                10,
+                'github_comment',
+                '💬 someone-else commented on #123',
+                'This is a comment',
+                $this->callback(function($data) {
+                    return $data['project_id'] === 1 &&
+                           $data['issue_number'] === 123 &&
+                           $data['task_id'] === 456 &&
+                           $data['is_system'] === false;
+                })
+            );
 
         $reflection = new \ReflectionClass(WebhookHandler::class);
         $method = $reflection->getMethod('handleIssueComment');
@@ -127,7 +176,7 @@ class WebhookHandlerCommentTest extends TestCase
             $this->taskModel,
             $this->githubService,
             $this->julesService,
-            null
+            $this->notificationService
         ]);
 
         $this->assertTrue($result);


### PR DESCRIPTION
This change enables the `issue_comment` webhook event and integrates it into the notification system. Every comment on a GitHub issue now triggers a notification, with special handling for Jules: comments from Jules immediately refresh the task status to capture session IDs and state transitions (like moving to planning or executing) without waiting for the cronjob. Jules' comments are also marked as system events, ensuring they are broadcasted to external channels like Telegram by default.

Fixes #787

---
*PR created automatically by Jules for task [10324373705290288910](https://jules.google.com/task/10324373705290288910) started by @chatelao*