### PR TITLE
Implement central Breadcrumbs component and add missing breadcrumbs

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Navbar from '@/components/Navbar';
+import Breadcrumbs from '@/components/Breadcrumbs';
 import Link from 'next/link';
 import { useAdminUsers } from '@/hooks/useAdminUsers';
 import { useUser } from '@/hooks/useUser';
@@ -51,6 +52,7 @@ export default function AdminDashboard() {
       <Navbar />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+        <Breadcrumbs items={[{ label: 'Admin' }]} />
         <div className="mb-8 flex justify-between items-center">
           <div>
             <h1 className="text-2xl font-bold text-gray-900">User Management</h1>

--- a/web/src/app/logs/page.tsx
+++ b/web/src/app/logs/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import Navbar from '@/components/Navbar';
+import Breadcrumbs from '@/components/Breadcrumbs';
 import { usePerformanceLogs } from '@/hooks/usePerformanceLogs';
 import { useWebhookLogs } from '@/hooks/useWebhookLogs';
 import { useUser } from '@/hooks/useUser';
@@ -86,6 +87,7 @@ export default function LogsPage() {
       <Navbar />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+        <Breadcrumbs items={[{ label: 'System Logs' }]} />
         <div className="mb-6">
           <h1 className="text-2xl font-bold text-gray-900">System Logs</h1>
           <p className="text-sm text-gray-500 mt-1">Monitor system performance and external integrations.</p>

--- a/web/src/app/notifications/page.tsx
+++ b/web/src/app/notifications/page.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useNotifications, useNotificationActions } from '@/hooks/useNotifications';
 import { useRelativePath } from '@/hooks/useRelativePath';
 import Navbar from '@/components/Navbar';
+import Breadcrumbs from '@/components/Breadcrumbs';
 import Link from 'next/link';
 
 export default function NotificationsPage() {
@@ -18,30 +19,7 @@ export default function NotificationsPage() {
       <Navbar />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
-        <nav className="flex mb-5" aria-label="Breadcrumb">
-          <ol className="inline-flex items-center space-x-1 md:space-x-2">
-            <li className="inline-flex items-center">
-              <Link href={rel('/')} className="text-gray-700 hover:text-gray-900 inline-flex items-center text-sm">
-                <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                  <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path>
-                </svg>
-                Dashboard
-              </Link>
-            </li>
-            <li>
-              <div className="flex items-center">
-                <svg className="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
-                  <path
-                    fillRule="evenodd"
-                    d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                    clipRule="evenodd"
-                  ></path>
-                </svg>
-                <span className="text-gray-400 ml-1 md:ml-2 font-medium text-sm">Notifications</span>
-              </div>
-            </li>
-          </ol>
-        </nav>
+        <Breadcrumbs items={[{ label: 'Notifications' }]} />
 
         <div className="mb-6 flex justify-between items-center">
           <h1 className="text-2xl font-bold text-gray-900">Notifications</h1>

--- a/web/src/app/projects/[id]/ProjectDetailView.tsx
+++ b/web/src/app/projects/[id]/ProjectDetailView.tsx
@@ -9,6 +9,7 @@ import { useTemplates } from '@/hooks/useTemplates';
 import StatusBadge from '@/components/StatusBadge';
 import TaskFilterBar from '@/components/TaskFilterBar';
 import Navbar from '@/components/Navbar';
+import Breadcrumbs from '@/components/Breadcrumbs';
 import { components } from '@/types/api';
 
 type TaskStatus = components['schemas']['Task']['status'];
@@ -60,13 +61,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
         <div className="flex flex-col md:flex-row md:items-center justify-between mb-8 gap-4">
           <div>
-            <nav className="flex mb-2" aria-label="Breadcrumb">
-              <ol className="flex items-center space-x-2 text-sm text-gray-500">
-                <li><Link href={rel('/')} className="hover:text-gray-700">Dashboard</Link></li>
-                <li><svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd"></path></svg></li>
-                <li className="font-medium text-gray-900 truncate max-w-[200px]">{project.github_repo}</li>
-              </ol>
-            </nav>
+            <Breadcrumbs items={[{ label: project.github_repo || 'Project' }]} />
             <h2 className="text-3xl font-bold text-gray-900">{project.github_repo}</h2>
             <p className="text-gray-500 text-sm mt-1">
               Linked as <span className="font-medium">{project.github_username}</span>

--- a/web/src/app/projects/[id]/settings/ProjectSettingsView.tsx
+++ b/web/src/app/projects/[id]/settings/ProjectSettingsView.tsx
@@ -7,6 +7,7 @@ import { useProject } from '@/hooks/useProject';
 import { useUser } from '@/hooks/useUser';
 import { useRelativePath } from '@/hooks/useRelativePath';
 import Navbar from '@/components/Navbar';
+import Breadcrumbs from '@/components/Breadcrumbs';
 import BlocklyEditor from '@/components/blockly/BlocklyEditor';
 
 export default function ProjectSettingsView({ id }: { id: string }) {
@@ -97,15 +98,12 @@ export default function ProjectSettingsView({ id }: { id: string }) {
     <div className="min-h-screen bg-gray-50 pb-12">
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
         <div className="mb-6">
-          <nav className="flex mb-2" aria-label="Breadcrumb">
-            <ol className="flex items-center space-x-2 text-sm text-gray-500">
-              <li><Link href={rel('/')} className="hover:text-gray-700">Dashboard</Link></li>
-              <li><svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd"></path></svg></li>
-              <li><Link href={rel(`/projects/?id=${id}`)} className="hover:text-gray-700 truncate max-w-[150px] inline-block">{project?.github_repo}</Link></li>
-              <li><svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd"></path></svg></li>
-              <li className="font-medium text-gray-900">Settings</li>
-            </ol>
-          </nav>
+          <Breadcrumbs
+            items={[
+              { label: project?.github_repo || 'Project', href: `/projects/?id=${id}` },
+              { label: 'Settings' },
+            ]}
+          />
           <h1 className="text-2xl font-bold text-gray-900">Project Settings</h1>
         </div>
 

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import Navbar from '@/components/Navbar';
 import { useUser, useUpdateUser } from '@/hooks/useUser';
 import apiClient from '@/api/client';
 import { useRelativePath } from '@/hooks/useRelativePath';
+import Breadcrumbs from '@/components/Breadcrumbs';
 import BlocklyEditor from '@/components/blockly/BlocklyEditor';
 import TemplateManager from '@/components/TemplateManager';
 
@@ -125,6 +126,7 @@ export default function SettingsPage() {
       <Navbar />
 
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+        <Breadcrumbs items={[{ label: 'Settings' }]} />
         <div className="mb-6">
           <h1 className="text-2xl font-bold text-gray-900">Account Settings</h1>
           <p className="text-sm text-gray-500 mt-1">Manage your AI keys, integrations, and notification preferences.</p>

--- a/web/src/app/tasks/[id]/TaskDetailView.tsx
+++ b/web/src/app/tasks/[id]/TaskDetailView.tsx
@@ -8,6 +8,7 @@ import StatusBadge from '@/components/StatusBadge';
 import TaskStatusSquare from '@/components/TaskStatusSquare';
 import TaskSidebar from '@/components/TaskSidebar';
 import Navbar from '@/components/Navbar';
+import Breadcrumbs from '@/components/Breadcrumbs';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -76,6 +77,12 @@ export default function TaskDetailView({ id }: { id: string }) {
   return (
     <div className="min-h-screen bg-gray-50 pb-12">
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+        <Breadcrumbs
+          items={[
+            { label: task.github_repo || 'Project', href: `/projects/?id=${task.project_id}` },
+            { label: `#${task.issue_number} - ${task.title}` },
+          ]}
+        />
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
           <div className="lg:col-span-3 space-y-6 min-w-0">
             {/* Header */}

--- a/web/src/app/tasks/page.tsx
+++ b/web/src/app/tasks/page.tsx
@@ -6,6 +6,7 @@ import { useTasks } from '@/hooks/useTasks';
 import { useRelativePath } from '@/hooks/useRelativePath';
 import Navbar from '@/components/Navbar';
 import StatusBadge from '@/components/StatusBadge';
+import Breadcrumbs from '@/components/Breadcrumbs';
 import Link from 'next/link';
 import TaskDetailView from './[id]/TaskDetailView';
 import { ReadonlyURLSearchParams } from 'next/navigation';
@@ -46,30 +47,7 @@ function TasksList({ rel, searchParams }: TasksListProps) {
 
   return (
     <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
-      <nav className="flex mb-5" aria-label="Breadcrumb">
-        <ol className="inline-flex items-center space-x-1 md:space-x-2">
-          <li className="inline-flex items-center">
-            <Link href={rel('/')} className="text-gray-700 hover:text-gray-900 inline-flex items-center text-sm">
-              <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path>
-              </svg>
-              Dashboard
-            </Link>
-          </li>
-          <li>
-            <div className="flex items-center">
-              <svg className="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
-                <path
-                  fillRule="evenodd"
-                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                  clipRule="evenodd"
-                ></path>
-              </svg>
-              <span className="text-gray-400 ml-1 md:ml-2 font-medium text-sm">{title}</span>
-            </div>
-          </li>
-        </ol>
-      </nav>
+      <Breadcrumbs items={[{ label: title }]} />
 
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900">{title}</h1>

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { useRelativePath } from '@/hooks/useRelativePath';
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+}
+
+export default function Breadcrumbs({ items }: BreadcrumbsProps) {
+  const { rel } = useRelativePath();
+
+  return (
+    <nav className="flex mb-5" aria-label="Breadcrumb">
+      <ol className="inline-flex items-center space-x-1 md:space-x-2">
+        <li className="inline-flex items-center">
+          <Link href={rel('/')} className="text-gray-700 hover:text-gray-900 inline-flex items-center text-sm">
+            <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"></path>
+            </svg>
+            Dashboard
+          </Link>
+        </li>
+        {items.map((item, index) => (
+          <li key={index}>
+            <div className="flex items-center">
+              <svg className="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fillRule="evenodd"
+                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                  clipRule="evenodd"
+                ></path>
+              </svg>
+              {item.href ? (
+                <Link
+                  href={rel(item.href)}
+                  className="ml-1 md:ml-2 text-sm font-medium text-gray-700 hover:text-gray-900 truncate max-w-[150px] md:max-w-[250px]"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <span className="ml-1 md:ml-2 text-sm font-medium text-gray-400 truncate max-w-[150px] md:max-w-[250px]">
+                  {item.label}
+                </span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}


### PR DESCRIPTION
This PR introduces a central Breadcrumbs component in web/src/components/Breadcrumbs.tsx to ensure consistent styling and link generation. Breadcrumbs have been added to the Task Detail, Settings, Logs, and Admin pages. Existing pages have been refactored to use this new component. All breadcrumb links use the useRelativePath hook for environment portability.

Fixes #800

---
*PR created automatically by Jules for task [15224255196105197206](https://jules.google.com/task/15224255196105197206) started by @chatelao*