### PR TITLE
Fix Navbar and Modal z-index overlap

### DIFF
--- a/web/src/components/LinkRepositoryModal.tsx
+++ b/web/src/components/LinkRepositoryModal.tsx
@@ -59,7 +59,7 @@ const LinkRepositoryModal: React.FC<LinkRepositoryModalProps> = ({ isOpen, onClo
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black bg-opacity-50">
+    <div className="fixed inset-0 z-[150] flex items-center justify-center p-4 bg-black bg-opacity-50">
       <div className="bg-white rounded-xl shadow-xl max-w-md w-full overflow-hidden">
         <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
           <h3 className="text-lg font-bold text-gray-900">Link New Repository</h3>

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -53,7 +53,7 @@ const NavbarContent = () => {
   };
 
   return (
-    <nav className="bg-white border-b border-gray-200 px-4 py-3 sticky top-0 z-50">
+    <nav className="bg-white border-b border-gray-200 px-4 py-3 sticky top-0 z-[100]">
       <div className="max-w-7xl mx-auto flex justify-between items-center">
         <div className="flex items-center space-x-8">
           <Link href={rel('/')} className="text-xl font-bold text-gray-900 hover:text-blue-600 transition-colors">
@@ -122,7 +122,7 @@ const NavbarContent = () => {
 const Navbar = () => {
   return (
     <Suspense fallback={
-      <nav className="bg-white border-b border-gray-200 px-4 py-3 sticky top-0 z-50">
+      <nav className="bg-white border-b border-gray-200 px-4 py-3 sticky top-0 z-[100]">
         <div className="max-w-7xl mx-auto flex justify-between items-center">
           <div className="text-xl font-bold text-gray-900">Agent Control</div>
         </div>


### PR DESCRIPTION
This change addresses a visual glitch where the Blockly automation editor's toolbox would overlap the sticky navigation bar when the user scrolled the page. 

Key changes:
- Updated `web/src/components/Navbar.tsx` to increase its z-index from `z-50` to `z-[100]`. This ensures the Navbar stays on top of most page content, including the Blockly components.
- Updated `web/src/components/LinkRepositoryModal.tsx` to increase its z-index from `z-50` to `z-[150]`. This maintains the correct hierarchy where modals appear above the navigation bar.

Verified the fix by running unit tests and performing a successful production build in the `web` directory.

Fixes #802

---
*PR created automatically by Jules for task [9795158012389850876](https://jules.google.com/task/9795158012389850876) started by @chatelao*