### PR TITLE
Fix "Test Broadcast" button in Settings

### DIFF
--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -105,13 +105,12 @@ export default function SettingsPage() {
     setIsTesting(true);
     setTestStatus(null);
     try {
-      // API call should be absolute to domain root, as per user requirement "(not the ones to the API)"
-      const response = await apiClient.post('/ajax-notifications.php?action=test_broadcast', {});
+      const response = await apiClient.post('notifications.php', { action: 'test_broadcast' });
       if (response.data.status === 'success') {
         const channels = Object.keys(response.data.channels).filter((c: any) => response.data.channels[c]);
         setTestStatus({ status: 'success', message: `Test broadcast sent to: ${channels.join(', ')}` });
       } else {
-        setTestStatus({ status: 'error', message: response.data.error || 'Test failed' });
+        setTestStatus({ status: 'error', message: response.data.error || response.data.message || 'Test failed' });
       }
     } catch (err) {
       setTestStatus({ status: 'error', message: 'Connection error' });


### PR DESCRIPTION
The "Test Broadcast" button in the settings page was failing because it was targeting a legacy PHP endpoint that uses session-based authentication, which is incompatible with the JWT-based authentication used in the Next-Gen UI.

I updated the \`sendTestBroadcast\` function in \`web/src/app/settings/page.tsx\` to use the modern \`notifications.php\` API endpoint. The request now correctly sends the \`action\` parameter in the JSON body. Additionally, I improved the error handling to capture and display more descriptive error messages from the server.

Fixes #803

---
*PR created automatically by Jules for task [4627025519394990373](https://jules.google.com/task/4627025519394990373) started by @chatelao*