### PR TITLE
Fix Autorepeat Persistence during Task Synchronization

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -429,10 +429,12 @@ class Task
         $this->deleteByIssueNumbersNotIn($projectId, $issueNumbers);
     }
 
-    public function upsert(int $userId, int $projectId, array $issue, int $autorepeatRemaining = 0): bool
+    public function upsert(int $userId, int $projectId, array $issue, ?int $autorepeatRemaining = null): bool
     {
         $connection = $this->db->getConnection();
         $driver = $connection->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $finalAutorepeatRemaining = $autorepeatRemaining ?? 0;
 
         if ($driver === 'sqlite') {
             $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state, autorepeat_remaining)
@@ -442,7 +444,7 @@ class Task
                         body = excluded.body,
                         github_data = excluded.github_data,
                         github_state = excluded.github_state,
-                        autorepeat_remaining = excluded.autorepeat_remaining,
+                        autorepeat_remaining = " . ($autorepeatRemaining !== null ? "excluded.autorepeat_remaining" : "tasks.autorepeat_remaining") . ",
                         status = CASE
                             WHEN excluded.github_state = 'closed' THEN 'finished'
                             WHEN status = 'pending' THEN 'created'
@@ -456,7 +458,7 @@ class Task
                         body = VALUES(body),
                         github_data = VALUES(github_data),
                         github_state = VALUES(github_state),
-                        autorepeat_remaining = VALUES(autorepeat_remaining),
+                        autorepeat_remaining = " . ($autorepeatRemaining !== null ? "VALUES(autorepeat_remaining)" : "autorepeat_remaining") . ",
                         status = CASE
                             WHEN VALUES(github_state) = 'closed' THEN 'finished'
                             WHEN status = 'pending' THEN 'created'
@@ -477,7 +479,7 @@ class Task
             json_encode($issue),
             $status,
             $issue['state'] ?? 'open',
-            $autorepeatRemaining
+            $finalAutorepeatRemaining
         ]);
     }
 

--- a/test/Integration/AutorepeatPersistenceTest.php
+++ b/test/Integration/AutorepeatPersistenceTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\Task;
+use PDO;
+use Tests\TestDatabaseTrait;
+
+class AutorepeatPersistenceTest extends TestCase
+{
+    use TestDatabaseTrait;
+
+    private $db;
+    private $pdo;
+    private $taskModel;
+
+    protected function setUp(): void
+    {
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        $this->pdo->exec("DROP TABLE IF EXISTS tasks");
+        $this->pdo->exec("DROP TABLE IF EXISTS projects");
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
+
+        $this->pdo->exec("CREATE TABLE projects (
+            project_id $pk,
+            user_id INT NOT NULL,
+            github_repo VARCHAR(255) NOT NULL
+        )");
+
+        $this->pdo->exec("CREATE TABLE tasks (
+            task_id $pk,
+            user_id INT NOT NULL,
+            project_id INT NOT NULL,
+            issue_number INT NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            body TEXT,
+            status TEXT DEFAULT 'created',
+            github_state VARCHAR(20) DEFAULT 'open',
+            github_data TEXT,
+            autorepeat_remaining INT DEFAULT 0,
+            created_at $timestamp,
+            updated_at $timestamp,
+            UNIQUE(project_id, issue_number)
+        )");
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        $this->taskModel = new Task($this->db);
+    }
+
+    public function testUpsertPreservesAutorepeatRemaining()
+    {
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'test/repo')");
+
+        $issue = [
+            'number' => 123,
+            'title' => 'Test Issue',
+            'body' => 'Initial Body',
+            'state' => 'open'
+        ];
+
+        // 1. Create task with autorepeat_remaining = 5
+        $this->taskModel->upsert(1, 1, $issue, 5);
+
+        $task = $this->taskModel->findByIssueNumber(1, 123);
+        $this->assertEquals(5, $task['autorepeat_remaining']);
+
+        // 2. Upsert with null (default) - should preserve the value 5
+        $issue['body'] = 'Updated Body';
+        $this->taskModel->upsert(1, 1, $issue);
+
+        $task = $this->taskModel->findByIssueNumber(1, 123);
+        $this->assertEquals(5, $task['autorepeat_remaining'], "Autorepeat remaining should be preserved when upserted with null");
+        $this->assertEquals('Updated Body', $task['body']);
+
+        // 3. Upsert with explicit value - should update to the new value
+        $this->taskModel->upsert(1, 1, $issue, 3);
+        $task = $this->taskModel->findByIssueNumber(1, 123);
+        $this->assertEquals(3, $task['autorepeat_remaining'], "Autorepeat remaining should be updated when an explicit value is provided");
+    }
+
+    public function testUpsertDefaultsToZeroOnNewTask()
+    {
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'test/repo')");
+
+        $issue = [
+            'number' => 456,
+            'title' => 'New Issue',
+            'body' => 'New Body',
+            'state' => 'open'
+        ];
+
+        // Upsert new task without explicit autorepeat_remaining
+        $this->taskModel->upsert(1, 1, $issue);
+
+        $task = $this->taskModel->findByIssueNumber(1, 456);
+        $this->assertEquals(0, $task['autorepeat_remaining'], "Autorepeat remaining should default to 0 for new tasks");
+    }
+}


### PR DESCRIPTION
This PR fixes a bug where the `autorepeat_remaining` count was being inadvertently reset to 0 during task synchronization or when handling GitHub webhooks. 

The root cause was in the `Task::upsert` method, which defaulted the `autorepeatRemaining` parameter to `0`. Consequently, any call to `upsert` that didn't provide this value (like those from `WebhookHandler` or `syncIssues`) would overwrite the existing count in the database.

Changes:
- Updated `Task::upsert` signature to `?int $autorepeatRemaining = null`.
- Modified SQL `UPDATE` logic to use the existing column value when `autorepeatRemaining` is `null`.
- Added an integration test `test/Integration/AutorepeatPersistenceTest.php` to ensure the value is preserved on updates and correctly defaulted to 0 on new task creation.

Fixes #809

---
*PR created automatically by Jules for task [3639196611548641660](https://jules.google.com/task/3639196611548641660) started by @chatelao*