### PR TITLE
Add Create GitHub Issue functionality to project page

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -468,7 +468,18 @@ paths:
               properties:
                 action:
                   type: string
-                  enum: [sync_issues, create_from_template, create_from_roadmap, update_settings, update_notifications]
+                  enum: [sync_issues, create_from_template, create_from_roadmap, update_settings, update_notifications, create_github_issue]
+                title:
+                  type: string
+                  description: Required for 'create_github_issue'
+                body:
+                  type: string
+                  description: Optional for 'create_github_issue'
+                labels:
+                  type: array
+                  items:
+                    type: string
+                  description: Optional labels for 'create_github_issue'
                 template_id:
                   type: integer
                   description: Required for 'create_from_template'

--- a/src/frontend/api/project.php
+++ b/src/frontend/api/project.php
@@ -191,6 +191,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
             break;
 
+        case 'create_github_issue':
+            $title = trim($input['title'] ?? '');
+            $body = trim($input['body'] ?? '');
+            $labels = $input['labels'] ?? ['Jules'];
+            if (empty($title)) {
+                http_response_code(400);
+                echo json_encode(['error' => 'Title is required']);
+                exit;
+            }
+            try {
+                $githubToken = $project['github_token'] ?? null;
+                if (!$githubToken) {
+                    throw new Exception("GitHub token not found for this project.");
+                }
+
+                $githubService = new GitHubService(null, $githubToken);
+                $githubService->createIssue($project['github_repo'], $title, $body, (array)$labels);
+
+                echo json_encode(['status' => 'success', 'message' => 'GitHub issue created']);
+            } catch (Exception $e) {
+                http_response_code(500);
+                echo json_encode(['error' => 'Error creating issue: ' . $e->getMessage()]);
+            }
+            break;
+
         default:
             http_response_code(400);
             echo json_encode(['error' => 'Invalid or missing action']);

--- a/web/src/app/projects/[id]/ProjectDetailView.tsx
+++ b/web/src/app/projects/[id]/ProjectDetailView.tsx
@@ -8,8 +8,8 @@ import { useTasks } from '@/hooks/useTasks';
 import { useTemplates } from '@/hooks/useTemplates';
 import StatusBadge from '@/components/StatusBadge';
 import TaskFilterBar from '@/components/TaskFilterBar';
-import Navbar from '@/components/Navbar';
 import Breadcrumbs from '@/components/Breadcrumbs';
+import CreateIssueModal from '@/components/CreateIssueModal';
 import { components } from '@/types/api';
 
 type TaskStatus = components['schemas']['Task']['status'];
@@ -17,12 +17,13 @@ type TaskStatus = components['schemas']['Task']['status'];
 export default function ProjectDetailView({ id }: { id: string }) {
   const { rel } = useRelativePath();
   const projectId = parseInt(id);
-  const { data: project, isLoading: projectLoading, error: projectError, syncIssues, isSyncing, createFromTemplate, isCreatingFromTemplate, createFromRoadmap, isCreatingFromRoadmap } = useProject(projectId);
+  const { data: project, isLoading: projectLoading, error: projectError, syncIssues, isSyncing, createFromTemplate, isCreatingFromTemplate, createFromRoadmap, isCreatingFromRoadmap, createGithubIssue, isCreatingGithubIssue } = useProject(projectId);
   const { data: tasks, isLoading: tasksLoading } = useTasks(projectId);
   const { data: templates } = useTemplates();
 
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<TaskStatus | 'all'>('all');
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
   const filteredTasks = useMemo(() => {
     if (!tasks) return [];
@@ -78,6 +79,15 @@ export default function ProjectDetailView({ id }: { id: string }) {
               </svg>
               {isSyncing ? 'Syncing...' : 'Sync Issues'}
             </button>
+            <button
+              onClick={() => setIsCreateModalOpen(true)}
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-all"
+            >
+              <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+              </svg>
+              Create Issue
+            </button>
             <Link
               href={rel(`/projects/?id=${id}&settings=true`)}
               className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-all"
@@ -86,6 +96,13 @@ export default function ProjectDetailView({ id }: { id: string }) {
             </Link>
           </div>
         </div>
+
+        <CreateIssueModal
+          isOpen={isCreateModalOpen}
+          onClose={() => setIsCreateModalOpen(false)}
+          onSubmit={(title, body) => createGithubIssue({ title, body })}
+          isSubmitting={isCreatingGithubIssue}
+        />
 
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
           <div className="lg:col-span-3 min-w-0">

--- a/web/src/components/CreateIssueModal.tsx
+++ b/web/src/components/CreateIssueModal.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface CreateIssueModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (title: string, body: string) => Promise<void>;
+  isSubmitting: boolean;
+}
+
+const CreateIssueModal: React.FC<CreateIssueModalProps> = ({ isOpen, onClose, onSubmit, isSubmitting }) => {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    setError(null);
+    try {
+      await onSubmit(title, body);
+      setTitle('');
+      setBody('');
+      onClose();
+    } catch (err: any) {
+      console.error('Failed to create issue:', err);
+      setError(err.response?.data?.error || err.message || 'Failed to create issue. Please try again.');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[150] flex items-center justify-center p-4 bg-black bg-opacity-50">
+      <div className="bg-white rounded-xl shadow-xl max-w-lg w-full overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-gray-50">
+          <h3 className="text-lg font-bold text-gray-900">Create New GitHub Issue</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+            <input
+              type="text"
+              placeholder="Enter issue title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+              required
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Body (Optional)</label>
+            <textarea
+              placeholder="Describe the issue..."
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={5}
+              className="w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+            />
+          </div>
+
+          <div className="pt-4 flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-2 border border-gray-300 text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting || !title.trim()}
+              className="flex-1 px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50"
+            >
+              {isSubmitting ? 'Creating...' : 'Create Issue'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default CreateIssueModal;

--- a/web/src/hooks/useProject.ts
+++ b/web/src/hooks/useProject.ts
@@ -44,6 +44,20 @@ export const useProject = (id: string | number) => {
     },
   });
 
+  const createGithubIssueMutation = useMutation({
+    mutationFn: async ({ title, body }: { title: string; body?: string }) => {
+      const response = await apiClient.post(`project.php?id=${id}`, {
+        action: 'create_github_issue',
+        title,
+        body,
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tasks', id] });
+    },
+  });
+
   const createFromRoadmapMutation = useMutation({
     mutationFn: async (roadmapName: string) => {
       const response = await apiClient.post(`project.php?id=${id}`, {
@@ -105,6 +119,8 @@ export const useProject = (id: string | number) => {
     syncError: syncMutation.error,
     createFromTemplate: createFromTemplateMutation.mutateAsync,
     isCreatingFromTemplate: createFromTemplateMutation.isPending,
+    createGithubIssue: createGithubIssueMutation.mutateAsync,
+    isCreatingGithubIssue: createGithubIssueMutation.isPending,
     createFromRoadmap: createFromRoadmapMutation.mutateAsync,
     isCreatingFromRoadmap: createFromRoadmapMutation.isPending,
     updateSettings: updateSettingsMutation.mutateAsync,

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -809,7 +809,13 @@ export interface paths {
                 content: {
                     "application/json": {
                         /** @enum {string} */
-                        action: "sync_issues" | "create_from_template" | "create_from_roadmap" | "update_settings" | "update_notifications";
+                        action: "sync_issues" | "create_from_template" | "create_from_roadmap" | "update_settings" | "update_notifications" | "create_github_issue";
+                        /** @description Required for 'create_github_issue' */
+                        title?: string;
+                        /** @description Optional for 'create_github_issue' */
+                        body?: string;
+                        /** @description Optional labels for 'create_github_issue' */
+                        labels?: string[];
                         /** @description Required for 'create_from_template' */
                         template_id?: number;
                         /** @description Parameter values for the template */


### PR DESCRIPTION
This PR adds the ability for users to create a GitHub issue directly from the Project Detail page in the Next-Gen UI.

Key changes:
- **API**: Added `create_github_issue` action to `/api/project.php` POST endpoint. It accepts `title`, `body` (optional), and `labels` (optional, defaults to `['Jules']`).
- **Backend**: Implemented the new action in `src/frontend/api/project.php`, leveraging `GitHubService`.
- **Frontend Hook**: Added `createGithubIssue` to `useProject` hook for easy access to the mutation.
- **UI**: 
    - Created `CreateIssueModal.tsx` which provides a form to enter issue details and displays error messages if creation fails.
    - Added a green "Create Issue" button to the header of `ProjectDetailView.tsx` (next to Settings).
    - The task list automatically refreshes upon successful creation.

Verified with backend PHPUnit tests and frontend Vitest tests.

Fixes #811

---
*PR created automatically by Jules for task [745600137134278789](https://jules.google.com/task/745600137134278789) started by @chatelao*