### PR TITLE
Sync auto-repeat status and count to GitHub labels

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -429,4 +429,40 @@ class GitHubService
         }
         return null;
     }
+
+    /**
+     * @throws Exception
+     */
+    public function updateAutorepeatLabels(string $repo, int $issueNumber, int $count): void
+    {
+        $issue = $this->getIssue($repo, $issueNumber);
+        $labels = $issue['labels'] ?? [];
+        $currentLabelNames = array_map(fn($l) => $l['name'], $labels);
+
+        $newLabels = [];
+        $labelsToRemove = [];
+
+        // Identify existing autorepeat labels to remove
+        foreach ($currentLabelNames as $name) {
+            $lowerName = strtolower($name);
+            if ($lowerName === 'autorepeat' || $lowerName === 'auto-repeat' || str_starts_with($lowerName, 'autorepeat:')) {
+                $labelsToRemove[] = $name;
+            }
+        }
+
+        if ($count > 0) {
+            $newLabels[] = 'autorepeat';
+            $newLabels[] = 'autorepeat: ' . $count;
+        }
+
+        // Remove old labels
+        foreach ($labelsToRemove as $labelName) {
+            $this->removeLabel($repo, $issueNumber, $labelName);
+        }
+
+        // Add new labels
+        foreach ($newLabels as $labelName) {
+            $this->addLabel($repo, $issueNumber, $labelName);
+        }
+    }
 }

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -434,7 +434,14 @@ class Task
         $connection = $this->db->getConnection();
         $driver = $connection->getAttribute(PDO::ATTR_DRIVER_NAME);
 
-        $finalAutorepeatRemaining = $autorepeatRemaining ?? 0;
+        // Try to extract from labels if not explicitly provided
+        $labelCount = isset($issue['labels']) ? $this->extractAutorepeatRemainingFromLabels($issue['labels']) : null;
+
+        // Final value to use in the INSERT part
+        $insertAutorepeatRemaining = $autorepeatRemaining ?? $labelCount ?? 0;
+
+        // Determine if we should update the existing value
+        $shouldUpdateAutorepeat = ($autorepeatRemaining !== null || $labelCount !== null);
 
         if ($driver === 'sqlite') {
             $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state, autorepeat_remaining)
@@ -444,7 +451,7 @@ class Task
                         body = excluded.body,
                         github_data = excluded.github_data,
                         github_state = excluded.github_state,
-                        autorepeat_remaining = " . ($autorepeatRemaining !== null ? "excluded.autorepeat_remaining" : "tasks.autorepeat_remaining") . ",
+                        autorepeat_remaining = " . ($shouldUpdateAutorepeat ? "excluded.autorepeat_remaining" : "tasks.autorepeat_remaining") . ",
                         status = CASE
                             WHEN excluded.github_state = 'closed' THEN 'finished'
                             WHEN status = 'pending' THEN 'created'
@@ -458,7 +465,7 @@ class Task
                         body = VALUES(body),
                         github_data = VALUES(github_data),
                         github_state = VALUES(github_state),
-                        autorepeat_remaining = " . ($autorepeatRemaining !== null ? "VALUES(autorepeat_remaining)" : "autorepeat_remaining") . ",
+                        autorepeat_remaining = " . ($shouldUpdateAutorepeat ? "VALUES(autorepeat_remaining)" : "autorepeat_remaining") . ",
                         status = CASE
                             WHEN VALUES(github_state) = 'closed' THEN 'finished'
                             WHEN status = 'pending' THEN 'created'
@@ -479,7 +486,7 @@ class Task
             json_encode($issue),
             $status,
             $issue['state'] ?? 'open',
-            $finalAutorepeatRemaining
+            $insertAutorepeatRemaining
         ]);
     }
 
@@ -619,11 +626,22 @@ class Task
         $labels = $githubData['labels'] ?? [];
         foreach ($labels as $label) {
             $name = strtolower($label['name'] ?? '');
-            if ($name === 'autorepeat' || $name === 'auto-repeat') {
+            if ($name === 'autorepeat' || $name === 'auto-repeat' || str_starts_with($name, 'autorepeat:')) {
                 return true;
             }
         }
         return false;
+    }
+
+    public function extractAutorepeatRemainingFromLabels(array $labels): ?int
+    {
+        foreach ($labels as $label) {
+            $name = strtolower($label['name'] ?? '');
+            if (preg_match('/^autorepeat:\s*(\d+)$/', $name, $matches)) {
+                return (int)$matches[1];
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -124,8 +124,9 @@ class WebhookHandler
         }
 
         try {
-            // 1. Add autorepeat label if requested
-            $githubService->addLabel($project['github_repo'], $task['issue_number'], 'autorepeat');
+            // 1. Update autorepeat labels if requested
+            $count = $task['autorepeat_remaining'] ?? 0;
+            $githubService->updateAutorepeatLabels($project['github_repo'], $task['issue_number'], $count);
 
             // 2. Merge PR
             $githubService->mergePullRequest($project['github_repo'], $prNumber, "Merged automatically via Auto-Repeat: " . $task['title']);
@@ -174,19 +175,11 @@ class WebhookHandler
             return;
         }
 
-        $autorepeatLabelName = '';
         $labels = $issue['labels'] ?? [];
-        foreach ($labels as $label) {
-            $name = strtolower($label['name'] ?? '');
-            if ($name === 'autorepeat' || $name === 'auto-repeat') {
-                $autorepeatLabelName = $label['name'];
-                break;
-            }
-        }
 
         $labelNames = array_filter(
             array_map(fn($l) => $l['name'], $labels),
-            fn($name) => strtolower($name) !== 'autorepeat' && strtolower($name) !== 'auto-repeat'
+            fn($name) => strtolower($name) !== 'autorepeat' && strtolower($name) !== 'auto-repeat' && !str_starts_with(strtolower($name), 'autorepeat:')
         );
 
         // Ensure 'Jules' label is present to trigger the agent for the new issue
@@ -222,10 +215,11 @@ class WebhookHandler
                 $newAutorepeatRemaining = max(0, ($task['autorepeat_remaining'] ?? 0) - 1);
                 if ($newAutorepeatRemaining > 0) {
                     $taskModel->upsert($project['user_id'], $project['project_id'], $newIssue, $newAutorepeatRemaining);
+                    $githubService->updateAutorepeatLabels($repo, $newIssue['number'], $newAutorepeatRemaining);
                 }
             }
 
-            $githubService->removeLabel($repo, $issue['number'], $autorepeatLabelName);
+            $githubService->updateAutorepeatLabels($repo, $issue['number'], 0);
 
             if ($notificationService) {
                 $notificationService->notify($project['user_id'], 'github_issue', "🔁 Auto-Repeat: #" . $issue['number'], "Task \"" . $issue['title'] . "\" was merged/closed with Auto-Repeat. A new issue has been created.", [

--- a/src/frontend/api/task.php
+++ b/src/frontend/api/task.php
@@ -62,10 +62,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $count = isset($input['autorepeat_remaining']) ? (int)$input['autorepeat_remaining'] : 0;
                 $taskModel->updateAutorepeatRemaining($taskId, $count);
 
-                if ($count === 0 && !empty($project['github_token'])) {
+                if (!empty($project['github_token'])) {
                     $githubService = new App\GitHubService(null, $project['github_token']);
-                    $githubService->removeLabel($project['github_repo'], $task['issue_number'], 'autorepeat');
-                    $githubService->removeLabel($project['github_repo'], $task['issue_number'], 'auto-repeat');
+                    $githubService->updateAutorepeatLabels($project['github_repo'], $task['issue_number'], $count);
                 }
 
                 echo json_encode(['status' => 'success', 'message' => 'Auto-repeat updated']);

--- a/test/Integration/AutorepeatPersistenceTest.php
+++ b/test/Integration/AutorepeatPersistenceTest.php
@@ -103,4 +103,43 @@ class AutorepeatPersistenceTest extends TestCase
         $task = $this->taskModel->findByIssueNumber(1, 456);
         $this->assertEquals(0, $task['autorepeat_remaining'], "Autorepeat remaining should default to 0 for new tasks");
     }
+
+    public function testUpsertExtractsCountFromLabels()
+    {
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'test/repo')");
+
+        $issue = [
+            'number' => 789,
+            'title' => 'Labeled Issue',
+            'body' => 'Body',
+            'state' => 'open',
+            'labels' => [
+                ['name' => 'bug'],
+                ['name' => 'autorepeat: 7']
+            ]
+        ];
+
+        // Upsert should find 'autorepeat: 7'
+        $this->taskModel->upsert(1, 1, $issue);
+
+        $task = $this->taskModel->findByIssueNumber(1, 789);
+        $this->assertEquals(7, $task['autorepeat_remaining'], "Autorepeat remaining should be extracted from labels");
+    }
+
+    public function testHasAutorepeatLabelSupportsNewFormat()
+    {
+        $task = [
+            'github_data' => json_encode([
+                'labels' => [['name' => 'autorepeat: 3']]
+            ])
+        ];
+        $this->assertTrue($this->taskModel->hasAutorepeatLabel($task));
+
+        $task2 = [
+            'github_data' => json_encode([
+                'labels' => [['name' => 'autorepeat']]
+            ])
+        ];
+        $this->assertTrue($this->taskModel->hasAutorepeatLabel($task2));
+    }
 }

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -102,9 +102,8 @@ class WebhookHandlerTest extends TestCase
         $githubService->expects($this->once())
             ->method('createIssue')
             ->with('owner/repo', 'Autorepeat Issue', 'Description', ['Jules']);
-        $githubService->expects($this->once())
-            ->method('removeLabel')
-            ->with('owner/repo', 123, 'autorepeat');
+        $githubService->expects($this->atLeastOnce())
+            ->method('updateAutorepeatLabels');
 
         $result = $this->handler->handle($project, $event, $githubService);
         $this->assertTrue($result);

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -89,9 +89,8 @@ class WebhookHandlerTest extends TestCase
         $githubService->expects($this->once())
             ->method('createIssue')
             ->with('owner/repo', 'Test Issue', 'Body', ['bug', 'Jules']);
-        $githubService->expects($this->once())
-            ->method('removeLabel')
-            ->with('owner/repo', 123, 'autorepeat');
+        $githubService->expects($this->atLeastOnce())
+            ->method('updateAutorepeatLabels');
 
         $this->assertTrue($this->handler->handle($project, $event, $githubService));
     }


### PR DESCRIPTION
This change ensures that auto-repeat information is persisted as labels on the GitHub issue, allowing for better visibility and bi-directional synchronization.

Key changes:
- **Label Management**: A new `updateAutorepeatLabels` method in `GitHubService` handles adding/removing the `autorepeat` marker and `autorepeat: {count}` labels.
- **Bi-directional Sync**: `Task::upsert` now parses these labels to extract the remaining count when it's not explicitly provided, allowing manual label updates on GitHub to sync back to the system.
- **Workflow Integration**: Labels are automatically updated when the count changes via the web UI, when a task is auto-merged, or when it's duplicated (carrying over the decremented count).
- **Robustness**: The system purges old autorepeat labels (including legacy `auto-repeat` format) before applying the current count label to ensure consistency.

Fixes #814

---
*PR created automatically by Jules for task [10972512948169157184](https://jules.google.com/task/10972512948169157184) started by @chatelao*