### PR TITLE
Restore Merge Buttons in Next-Gen UI

### DIFF
--- a/src/frontend/api/tasks.php
+++ b/src/frontend/api/tasks.php
@@ -60,6 +60,8 @@ $output = array_map(function($task) {
         ];
     }, $githubData['labels'] ?? []);
 
+    $prDetails = !empty($task['github_pr_data']) ? json_decode($task['github_pr_data'], true) : null;
+
     return [
         'id' => (int)$task['task_id'],
         'project_id' => (int)$task['project_id'],
@@ -76,7 +78,14 @@ $output = array_map(function($task) {
         'created_at' => $task['created_at'],
         'last_synced_at' => $task['last_synced_at'],
         'autorepeat_remaining' => (int)($task['autorepeat_remaining'] ?? 0),
-        'labels' => $labels
+        'labels' => $labels,
+        'pr_details' => $prDetails ? [
+            'title' => $prDetails['title'] ?? '',
+            'state' => $prDetails['state'] ?? '',
+            'merged' => $prDetails['merged'] ?? false,
+            'mergeable_state' => $prDetails['mergeable_state'] ?? null,
+            'draft' => $prDetails['draft'] ?? null
+        ] : null,
     ];
 }, $tasks);
 

--- a/web/src/app/projects/[id]/ProjectDetailView.tsx
+++ b/web/src/app/projects/[id]/ProjectDetailView.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useProject } from '@/hooks/useProject';
 import { useRelativePath } from '@/hooks/useRelativePath';
 import { useTasks } from '@/hooks/useTasks';
+import { useTaskActions } from '@/hooks/useTaskActions';
 import { useTemplates } from '@/hooks/useTemplates';
 import StatusBadge from '@/components/StatusBadge';
 import TaskFilterBar from '@/components/TaskFilterBar';
@@ -20,6 +21,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
   const { data: project, isLoading: projectLoading, error: projectError, syncIssues, isSyncing, createFromTemplate, isCreatingFromTemplate, createFromRoadmap, isCreatingFromRoadmap } = useProject(projectId);
   const { data: tasks, isLoading: tasksLoading } = useTasks(projectId);
   const { data: templates } = useTemplates();
+  const { performAction, isPerformingAction, performingActionId } = useTaskActions();
 
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<TaskStatus | 'all'>('all');
@@ -138,9 +140,33 @@ export default function ProjectDetailView({ id }: { id: string }) {
                           <StatusBadge status={task.status} />
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                          <Link href={rel(`/tasks/?id=${task.id}`)} className="text-blue-600 hover:text-blue-900">
-                            Details
-                          </Link>
+                          <div className="flex flex-col items-end space-y-2">
+                            {task.pr_url &&
+                              task.pr_details?.state === 'open' &&
+                              task.pr_details?.mergeable_state === 'clean' &&
+                              !task.pr_details?.draft &&
+                              task.github_state === 'open' && (
+                                <>
+                                  <button
+                                    onClick={() => task.id && performAction({ id: task.id, action: 'merge_close' })}
+                                    disabled={isPerformingAction && performingActionId === task.id}
+                                    className="text-white bg-purple-600 hover:bg-purple-700 font-medium rounded text-xs px-2 py-1 disabled:opacity-50 transition-colors w-full"
+                                  >
+                                    Merge & Close
+                                  </button>
+                                  <button
+                                    onClick={() => task.id && performAction({ id: task.id, action: 'merge_close_duplicate' })}
+                                    disabled={isPerformingAction && performingActionId === task.id}
+                                    className="text-white bg-indigo-600 hover:bg-indigo-700 font-medium rounded text-xs px-2 py-1 disabled:opacity-50 transition-colors w-full"
+                                  >
+                                    Merge & Duplicate
+                                  </button>
+                                </>
+                              )}
+                            <Link href={rel(`/tasks/?id=${task.id}`)} className="text-blue-600 hover:text-blue-900">
+                              Details
+                            </Link>
+                          </div>
                         </td>
                       </tr>
                     ))

--- a/web/src/app/tasks/[id]/TaskDetailView.tsx
+++ b/web/src/app/tasks/[id]/TaskDetailView.tsx
@@ -295,24 +295,28 @@ export default function TaskDetailView({ id }: { id: string }) {
                     </button>
                   </>
                 )}
-                {(task.status === 'ready' || task.status === 'implemented') && task.github_state === 'open' && (
-                  <>
-                    <button
-                      onClick={() => performAction({ action: 'merge_close' })}
-                      disabled={isPerformingAction}
-                      className="px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 disabled:opacity-50 transition-colors"
-                    >
-                      Merge PR
-                    </button>
-                    <button
-                      onClick={() => performAction({ action: 'merge_close_duplicate' })}
-                      disabled={isPerformingAction}
-                      className="px-4 py-2 bg-indigo-600 text-white rounded-md text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors"
-                    >
-                      Merge, Close & Duplicate
-                    </button>
-                  </>
-                )}
+                {task.pr_url &&
+                  task.pr_details?.state === 'open' &&
+                  task.pr_details?.mergeable_state === 'clean' &&
+                  !task.pr_details?.draft &&
+                  task.github_state === 'open' && (
+                    <>
+                      <button
+                        onClick={() => performAction({ action: 'merge_close' })}
+                        disabled={isPerformingAction}
+                        className="px-4 py-2 bg-purple-600 text-white rounded-md text-sm font-medium hover:bg-purple-700 disabled:opacity-50 transition-colors shadow-sm"
+                      >
+                        Merge & Close
+                      </button>
+                      <button
+                        onClick={() => performAction({ action: 'merge_close_duplicate' })}
+                        disabled={isPerformingAction}
+                        className="px-4 py-2 bg-indigo-600 text-white rounded-md text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 transition-colors shadow-sm"
+                      >
+                        Merge, Close & Duplicate
+                      </button>
+                    </>
+                  )}
               </div>
             </div>
 

--- a/web/src/hooks/useTaskActions.ts
+++ b/web/src/hooks/useTaskActions.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import apiClient from '@/api/client';
+
+export const useTaskActions = () => {
+  const queryClient = useQueryClient();
+
+  const taskActionMutation = useMutation({
+    mutationFn: async ({
+      id,
+      action,
+      autorepeat_remaining,
+    }: {
+      id: number | string;
+      action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate' | 'update_autorepeat';
+      autorepeat_remaining?: number;
+    }) => {
+      const response = await apiClient.post(`task.php?id=${id}`, { action, autorepeat_remaining });
+      return response.data;
+    },
+    onSuccess: (_, variables) => {
+      const { id } = variables;
+      queryClient.invalidateQueries({ queryKey: ['task', id.toString()] });
+      queryClient.invalidateQueries({ queryKey: ['task', Number(id)] });
+      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      queryClient.invalidateQueries({ queryKey: ['task-logs', id.toString()] });
+      queryClient.invalidateQueries({ queryKey: ['task-logs', Number(id)] });
+    },
+  });
+
+  return {
+    performAction: taskActionMutation.mutate,
+    performActionAsync: taskActionMutation.mutateAsync,
+    isPerformingAction: taskActionMutation.isPending,
+    performingActionId: taskActionMutation.variables?.id,
+    actionError: taskActionMutation.error,
+    actionSuccess: taskActionMutation.isSuccess,
+  };
+};


### PR DESCRIPTION
Restored the merge and close buttons in the new UI by updating backend APIs to provide PR metadata and implementing mergeability-based visibility logic in both task detail and project task list views. Added a reusable `useTaskActions` hook to handle these actions across different components.

Fixes #818

---
*PR created automatically by Jules for task [5516098642233528573](https://jules.google.com/task/5516098642233528573) started by @chatelao*