### PR TITLE
Add Duplicate option to finished task

### DIFF
--- a/src/frontend/api/task.php
+++ b/src/frontend/api/task.php
@@ -150,6 +150,58 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
             break;
 
+        case 'duplicate':
+            try {
+                $githubToken = $project['github_token'] ?? null;
+                if (!$githubToken) {
+                    throw new Exception("GitHub token not found for this project.");
+                }
+
+                $githubService = new App\GitHubService(null, $githubToken);
+                $githubData = json_decode($task['github_data'] ?? '{}', true);
+                $labels = $githubData['labels'] ?? [];
+
+                $labelNames = array_filter(
+                    array_map(fn($l) => $l['name'], $labels),
+                    fn($name) => strtolower($name) !== 'autorepeat' && strtolower($name) !== 'auto-repeat' && !str_starts_with(strtolower($name), 'autorepeat:')
+                );
+
+                // Ensure 'Jules' label is present to trigger the agent for the new issue
+                $hasJules = false;
+                foreach ($labelNames as $ln) {
+                    if (strtolower($ln) === 'jules') {
+                        $hasJules = true;
+                        break;
+                    }
+                }
+                if (!$hasJules) {
+                    $labelNames[] = 'Jules';
+                }
+
+                $newIssue = $githubService->createIssue($project['github_repo'], $task['title'], $task['body'] ?? null, array_values($labelNames));
+
+                if (!empty($newIssue['number'])) {
+                    $taskModel->upsert($userId, $project['project_id'], $newIssue);
+
+                    $notificationService = new App\NotificationService($db);
+                    $notificationService->notify($userId, 'github_issue', "🔁 Task Duplicated: #" . $task['issue_number'], "Task \"" . $task['title'] . "\" was manually duplicated. A new issue #" . $newIssue['number'] . " has been created.", [
+                        'task_id' => $taskId,
+                        'project_id' => $project['project_id'],
+                        'status' => App\Task::STATUS_CREATED,
+                        'source_url' => $newIssue['html_url'] ?? '',
+                        'is_system' => false
+                    ]);
+
+                    echo json_encode(['status' => 'success', 'message' => 'Task duplicated successfully', 'new_issue_number' => $newIssue['number']]);
+                } else {
+                    throw new Exception("Failed to create new issue on GitHub.");
+                }
+            } catch (Exception $e) {
+                http_response_code(500);
+                echo json_encode(['error' => 'Failed to duplicate task: ' . $e->getMessage()]);
+            }
+            break;
+
         default:
             http_response_code(400);
             echo json_encode(['error' => 'Invalid or missing action']);

--- a/web/src/app/tasks/[id]/TaskDetailView.tsx
+++ b/web/src/app/tasks/[id]/TaskDetailView.tsx
@@ -295,6 +295,15 @@ export default function TaskDetailView({ id }: { id: string }) {
                     </button>
                   </>
                 )}
+                {task.status === 'finished' && (
+                  <button
+                    onClick={() => performAction({ action: 'duplicate' })}
+                    disabled={isPerformingAction}
+                    className="px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 disabled:opacity-50 transition-colors shadow-sm"
+                  >
+                    Duplicate Task
+                  </button>
+                )}
                 {task.pr_url &&
                   task.pr_details?.state === 'open' &&
                   task.pr_details?.mergeable_state === 'clean' &&

--- a/web/src/hooks/useTask.ts
+++ b/web/src/hooks/useTask.ts
@@ -17,7 +17,7 @@ export const useTask = (id: number | string | undefined) => {
   });
 
   const taskActionMutation = useMutation({
-    mutationFn: async ({ action, autorepeat_remaining }: { action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate' | 'update_autorepeat', autorepeat_remaining?: number }) => {
+    mutationFn: async ({ action, autorepeat_remaining }: { action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate' | 'update_autorepeat' | 'duplicate', autorepeat_remaining?: number }) => {
       const response = await apiClient.post(`task.php?id=${id}`, { action, autorepeat_remaining });
       return response.data;
     },

--- a/web/src/hooks/useTaskActions.ts
+++ b/web/src/hooks/useTaskActions.ts
@@ -11,7 +11,7 @@ export const useTaskActions = () => {
       autorepeat_remaining,
     }: {
       id: number | string;
-      action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate' | 'update_autorepeat';
+      action: 'trigger_agent' | 'merge_close' | 'merge_close_duplicate' | 'update_autorepeat' | 'duplicate';
       autorepeat_remaining?: number;
     }) => {
       const response = await apiClient.post(`task.php?id=${id}`, { action, autorepeat_remaining });


### PR DESCRIPTION
This change introduces the ability for users to manually duplicate a task once it has reached the 'finished' status.

Key changes:
- **Backend API:** Added a new `duplicate` case in `src/frontend/api/task.php`. It creates a new GitHub issue using the current task's title and body, ensuring the 'Jules' label is present and auto-repeat labels are removed. The new issue is then synced to the local database.
- **Frontend Hooks:** Updated `web/src/hooks/useTask.ts` and `web/src/hooks/useTaskActions.ts` to include the `duplicate` action in the allowed mutation types.
- **Frontend UI:** Added a "Duplicate Task" button in `web/src/app/tasks/[id]/TaskDetailView.tsx` that appears only when the task status is `finished`.

These changes allow users to easily restart a successful task or use it as a template for new work without relying on the automatic auto-repeat mechanism.

Fixes #821

---
*PR created automatically by Jules for task [15063785842726230469](https://jules.google.com/task/15063785842726230469) started by @chatelao*