### PR TITLE
Automate merge for autorepeat tasks with passing checks

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -22,6 +22,25 @@ class GitHubService
     /**
      * @throws Exception
      */
+    public function getCombinedStatus(string $repo, string $ref): array
+    {
+        $parts = explode('/', $repo);
+        if (count($parts) !== 2) {
+            throw new Exception("Invalid repository name: $repo");
+        }
+
+        [$username, $repository] = $parts;
+
+        return $this->apiCall(
+            'GitHub API',
+            "GET combined_status $repo/commits/$ref/status",
+            fn() => $this->client->api('repo')->statuses()->combined($username, $repository, $ref)
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
     public function getRepository(string $repo): array
     {
         $parts = explode('/', $repo);
@@ -412,7 +431,7 @@ class GitHubService
                 'secret' => $secret,
                 'insecure_ssl' => '0'
             ],
-            'events' => ['issues', 'check_suite', 'issue_comment'],
+            'events' => ['issues', 'check_suite', 'issue_comment', 'status', 'check_run', 'pull_request'],
             'active' => true,
         ]);
     }

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -28,7 +28,7 @@ class Task
     {
     }
 
-    public function resolveStatus(array $task, ?array $prData = null, ?array $checkSuitesData = null): string
+    public function resolveStatus(array $task, ?array $prData = null, ?array $checkSuitesData = null, ?array $commitStatusesData = null): string
     {
         $githubState = $task['github_state'] ?? 'open';
         if ($githubState === 'closed') {
@@ -49,7 +49,7 @@ class Task
             // Check results from check suites
             // Handle both webhook (singular 'check_suite') and API (array 'check_suites')
             $suites = [];
-            $suitesProvided = ($checkSuitesData !== null);
+            $checksProvided = ($checkSuitesData !== null || $commitStatusesData !== null);
 
             if ($checkSuitesData) {
                 if (isset($checkSuitesData['check_suites'])) {
@@ -61,45 +61,64 @@ class Task
                 }
             }
 
-            if (!empty($suites)) {
-                $failed = false;
-                $running = false;
-                $success = true;
+            $failed = false;
+            $running = false;
+            $hasAnyChecks = false;
 
+            if (!empty($suites)) {
+                $hasAnyChecks = true;
                 foreach ($suites as $suite) {
                     $status = $suite['status'] ?? '';
                     $conclusion = $suite['conclusion'] ?? '';
 
                     if ($status !== 'completed' && $status !== 'skipped') {
                         $running = true;
-                        $success = false;
                     } elseif (in_array($conclusion, ['failure', 'timed_out', 'cancelled', 'action_required', 'startup_failure'])) {
                         $failed = true;
-                        $success = false;
                     } elseif ($conclusion === 'success' || $conclusion === 'neutral' || $conclusion === 'skipped' || $conclusion === 'stale') {
-                        // Keep success = true (or whatever it is)
+                        // Success
                     } elseif (empty($conclusion)) {
-                        // Completed but no conclusion yet? Treat as still running/checking to avoid false failure
                         $running = true;
-                        $success = false;
                     } else {
-                        // Any other completed conclusion (including unknown ones) is considered a failure for safety
                         $failed = true;
-                        $success = false;
                     }
                 }
+            }
 
-                if ($failed) {
-                    return self::STATUS_FAILED_PR;
+            // Check legacy commit statuses
+            if ($commitStatusesData) {
+                // If it's a combined status object
+                if (isset($commitStatusesData['statuses'])) {
+                    $statuses = $commitStatusesData['statuses'];
+                    if (!empty($statuses)) {
+                        $hasAnyChecks = true;
+                        foreach ($statuses as $status) {
+                            $state = $status['state'] ?? '';
+                            if ($state === 'pending') {
+                                $running = true;
+                            } elseif ($state === 'failure' || $state === 'error') {
+                                $failed = true;
+                            }
+                        }
+                    }
                 }
-                if ($success) {
-                    return self::STATUS_READY;
+            }
+
+            if ($failed) {
+                return self::STATUS_FAILED_PR;
+            }
+            if ($hasAnyChecks && !$running) {
+                return self::STATUS_READY;
+            }
+
+            if ($running || $julesStatus === 'finished' || $julesStatus === 'completed') {
+                if ($julesStatus === 'finished' || $julesStatus === 'completed') {
+                    // If Jules finished and checks were provided but NONE found, keep it as implemented for manual confirmation
+                    if ($checksProvided && !$hasAnyChecks) {
+                        return self::STATUS_IMPLEMENTED;
+                    }
                 }
-                if ($running || $julesStatus === 'finished' || $julesStatus === 'completed') {
-                    return self::STATUS_CHECKING;
-                }
-            } elseif ($julesStatus === 'finished' || $julesStatus === 'completed') {
-                return $suitesProvided ? self::STATUS_READY : self::STATUS_CHECKING;
+                return self::STATUS_CHECKING;
             }
         }
 
@@ -974,6 +993,7 @@ class Task
 
             // Also check PR checks if we have a PR
             $checkSuites = null;
+            $commitStatuses = null;
             if ($prUrl) {
                 try {
                     $prNumber = $githubService->extractPrNumber($prUrl);
@@ -982,6 +1002,7 @@ class Task
                         $sha = $pr['head']['sha'] ?? null;
                         if ($sha) {
                             $checkSuites = $githubService->getCheckSuites($task['github_repo'], $sha);
+                            $commitStatuses = $githubService->getCombinedStatus($task['github_repo'], $sha);
                         } else {
                             Logger::getInstance($this->db)->log($userId, $task['task_id'], "Could not find head SHA for PR $prUrl", 'warning');
                         }
@@ -993,7 +1014,7 @@ class Task
 
             $tempTask = $task;
             $tempTask['jules_status'] = $julesStatus;
-            $mappedStatus = $this->resolveStatus($tempTask, $pr ?? null, $checkSuites);
+            $mappedStatus = $this->resolveStatus($tempTask, $pr ?? null, $checkSuites, $commitStatuses);
 
             if ($mappedStatus !== $task['status'] || $julesStatus !== $task['jules_status']) {
                 $updateStmt = $this->db->getConnection()->prepare(

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -31,10 +31,12 @@ class WebhookHandler
         $issue = $event['issue'] ?? null;
         $pullRequest = $event['pull_request'] ?? null;
         $checkSuite = $event['check_suite'] ?? null;
+        $checkRun = $event['check_run'] ?? null;
+        $status = $event['status'] ?? null;
         $comment = $event['comment'] ?? null;
 
         // Skip events without an action, except for check_suite which might have different triggers
-        if (empty($action) && !$checkSuite) {
+        if (empty($action) && !$checkSuite && !$checkRun && !$status) {
             return true;
         }
 
@@ -51,7 +53,7 @@ class WebhookHandler
             return $this->handlePullRequest($project, $event, $effectiveNotifService, $githubService, $sandboxService, $githubEvent);
         }
 
-        if ($checkSuite) {
+        if ($checkSuite || $checkRun || $status) {
             return $this->handleCheckSuite($project, $event, $taskModel, $effectiveNotifService, $githubService, $sandboxService, $githubEvent);
         }
 
@@ -124,6 +126,17 @@ class WebhookHandler
         }
 
         try {
+            $logger = Logger::getInstance($this->db);
+            $pr = $githubService->getPullRequest($project['github_repo'], $prNumber);
+            $mergeableState = $pr['mergeable_state'] ?? 'unknown';
+
+            if ($mergeableState !== 'clean' && $mergeableState !== 'unstable' && $mergeableState !== 'has_hooks') {
+                $logger->log($project['user_id'], $task['task_id'], "Auto-merge skipped: PR #$prNumber is in state '$mergeableState'", 'warning');
+                return;
+            }
+
+            $logger->log($project['user_id'], $task['task_id'], "Auto-merging PR #$prNumber (state: $mergeableState)...", 'info');
+
             // 1. Update autorepeat labels if requested
             $count = $task['autorepeat_remaining'] ?? 0;
             $githubService->updateAutorepeatLabels($project['github_repo'], $task['issue_number'], $count);
@@ -139,7 +152,7 @@ class WebhookHandler
             $taskModel->markAsMerged($task['task_id']);
 
         } catch (\Exception $e) {
-            Logger::getInstance($this->db)->log($project['user_id'], $task['task_id'], "Auto-merge failed: " . $e->getMessage(), 'error');
+            Logger::getInstance($this->db)->log($project['user_id'], $task['task_id'], "Auto-merge failed for PR #$prNumber: " . $e->getMessage(), 'error');
         }
     }
 
@@ -276,6 +289,14 @@ class WebhookHandler
             try {
                 $issue = $githubService->getIssue($project['github_repo'], $task['issue_number']);
                 $taskModel->upsert($project['user_id'], $project['project_id'], $issue);
+
+                $userModel = new User($this->db);
+                $user = $userModel->findById($project['user_id']);
+                $julesService = new JulesService(null, $user['jules_api_key'] ?? null);
+
+                // Call refreshJulesStatus to ensure status is updated and auto-merge is attempted
+                $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $notificationService, (int)$task['task_id']);
+
                 $task = $taskModel->findById($task['task_id']); // Refresh local task object
             } catch (\Exception $e) {
                 // Ignore sync errors during PR events
@@ -418,8 +439,25 @@ class WebhookHandler
                 }
             }
 
+            // Fetch combined status as well
+            $commitStatusesData = null;
+            if ($githubService) {
+                try {
+                    $prNumber = $githubService->extractPrNumber($task['pr_url'] ?? '');
+                    if ($prNumber) {
+                        $prData = $prData ?: $githubService->getPullRequest($project['github_repo'], $prNumber);
+                        $sha = $prData['head']['sha'] ?? null;
+                        if ($sha) {
+                            $commitStatusesData = $githubService->getCombinedStatus($project['github_repo'], $sha);
+                        }
+                    }
+                } catch (\Exception $e) {
+                    // Ignore commit status fetch errors
+                }
+            }
+
             // Fallback to the single check suite from the event if API fetch fails or is not available
-            $newStatus = $taskModel->resolveStatus($task, $prData, $checkSuitesData ?: $checkSuite);
+            $newStatus = $taskModel->resolveStatus($task, $prData, $checkSuitesData ?: $checkSuite, $commitStatusesData);
 
             if ($newStatus !== $task['status']) {
                 $taskModel->updateStatus($task['task_id'], $newStatus);

--- a/src/frontend/github/webhook.php
+++ b/src/frontend/github/webhook.php
@@ -55,7 +55,7 @@ if (empty($githubEvent)) {
 }
 
 // Return 200 for unhandled events to keep webhook healthy on GitHub
-if (!in_array($githubEvent, ['issues', 'ping', 'check_suite', 'pull_request', 'issue_comment'])) {
+if (!in_array($githubEvent, ['issues', 'ping', 'check_suite', 'pull_request', 'issue_comment', 'status', 'check_run'])) {
     http_response_code(200);
     exit("Event $githubEvent skipped");
 }

--- a/test/Unit/TaskStateTest.php
+++ b/test/Unit/TaskStateTest.php
@@ -53,7 +53,8 @@ class TaskStateTest extends TestCase
         $task = ['github_state' => 'open', 'jules_status' => 'finished', 'pr_url' => 'https://github.com/owner/repo/pull/1'];
         // empty array means data was fetched and there are no check suites
         $checkSuitesData = ['total_count' => 0, 'check_suites' => []];
-        $this->assertEquals(Task::STATUS_READY, $this->taskModel->resolveStatus($task, null, $checkSuitesData));
+        // Now it should be IMPLEMENTED if no checks are found (manual confirmation required)
+        $this->assertEquals(Task::STATUS_IMPLEMENTED, $this->taskModel->resolveStatus($task, null, $checkSuitesData));
     }
 
     public function testResolveStatusWithWebhookCheckSuiteSuccess()

--- a/test/Unit/TaskStatusReproductionTest.php
+++ b/test/Unit/TaskStatusReproductionTest.php
@@ -41,4 +41,56 @@ class TaskStatusReproductionTest extends TestCase
         $status = $this->taskModel->resolveStatus($task, null, null);
         $this->assertEquals(Task::STATUS_CHECKING, $status, "If check suites are null, it stays in CHECKING");
     }
+
+    public function testResolveStatusWithJulesFinishedButNoSuitesProvided()
+    {
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1'
+        ];
+
+        // Now, if check suites are empty AND provided, it should return IMPLEMENTED (requiring manual confirmation)
+        $status = $this->taskModel->resolveStatus($task, null, ['check_suites' => []], ['statuses' => []]);
+
+        $this->assertEquals(Task::STATUS_IMPLEMENTED, $status, "If check suites are empty but provided, it should return IMPLEMENTED");
+    }
+
+    public function testResolveStatusWithLegacyCommitStatuses()
+    {
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1'
+        ];
+
+        $commitStatuses = [
+            'statuses' => [
+                ['state' => 'success'],
+                ['state' => 'success']
+            ]
+        ];
+
+        $status = $this->taskModel->resolveStatus($task, null, null, $commitStatuses);
+        $this->assertEquals(Task::STATUS_READY, $status, "Successful legacy commit statuses should lead to READY");
+    }
+
+    public function testResolveStatusWithPendingLegacyCommitStatus()
+    {
+        $task = [
+            'github_state' => 'open',
+            'jules_status' => 'finished',
+            'pr_url' => 'https://github.com/owner/repo/pull/1'
+        ];
+
+        $commitStatuses = [
+            'statuses' => [
+                ['state' => 'success'],
+                ['state' => 'pending']
+            ]
+        ];
+
+        $status = $this->taskModel->resolveStatus($task, null, null, $commitStatuses);
+        $this->assertEquals(Task::STATUS_CHECKING, $status, "Pending legacy commit status should stay in CHECKING");
+    }
 }


### PR DESCRIPTION
This PR addresses the issue where autorepeat tasks were not merging automatically even when checks passed. It expands status resolution to include legacy commit statuses, adds support for more GitHub events, and improves the robustness of the auto-merge process with better logging and mergeability checks. It also ensures that tasks without any checks still require manual confirmation by not transitioning them to the 'ready' state automatically.

Fixes #830

---
*PR created automatically by Jules for task [527435754751747004](https://jules.google.com/task/527435754751747004) started by @chatelao*