### PR TITLE
Restore per-project notification settings

### DIFF
--- a/src/frontend/api/project.php
+++ b/src/frontend/api/project.php
@@ -224,6 +224,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     exit;
 }
 
+$notificationService = new NotificationService($db);
+
 // Map internal database fields to OpenAPI schema
 echo json_encode([
     'id' => (int)$project['project_id'],
@@ -235,5 +237,6 @@ echo json_encode([
     'github_username' => $project['github_username'],
     'blockly_config' => !empty($project['blockly_config']) ? json_decode($project['blockly_config'], true) : null,
     'roadmap_data' => $project['roadmap_data'] ? json_decode($project['roadmap_data'], true) : null,
-    'roadmap_updated_at' => $project['roadmap_updated_at']
+    'roadmap_updated_at' => $project['roadmap_updated_at'],
+    'notification_settings' => $notificationService->getStatusSettings($projectId)
 ]);

--- a/web/src/app/projects/[id]/settings/ProjectSettingsView.tsx
+++ b/web/src/app/projects/[id]/settings/ProjectSettingsView.tsx
@@ -10,6 +10,30 @@ import Navbar from '@/components/Navbar';
 import Breadcrumbs from '@/components/Breadcrumbs';
 import BlocklyEditor from '@/components/blockly/BlocklyEditor';
 
+const statusGrouping = {
+  'CREATED': {
+    'created': 'Waiting for Agent'
+  },
+  'PROCESSING': {
+    'analyzing': 'Analyzing',
+    'planning': 'Planning',
+    'executing': 'Executing',
+    'verifying': 'Verifying',
+    'implemented': 'Implemented',
+    'checking': 'Checking'
+  },
+  'READY': {
+    'ready': 'Ready'
+  },
+  'FINISHED': {
+    'finished': 'Finished'
+  },
+  'FAILED': {
+    'failed_jules': 'Jules Failed',
+    'failed_pr': 'PR Failed'
+  }
+};
+
 export default function ProjectSettingsView({ id }: { id: string }) {
   const { rel } = useRelativePath();
   const router = useRouter();
@@ -17,7 +41,7 @@ export default function ProjectSettingsView({ id }: { id: string }) {
   const { data: project, isLoading: projectLoading, error: projectError, updateSettings, isUpdatingSettings, updateNotifications, isUpdatingNotifications, deleteProject, isDeleting } = useProject(projectId);
   const { data: user } = useUser();
 
-  const [activeTab, setActiveTab] = useState<'general' | 'webhook' | 'automation' | 'danger'>('general');
+  const [activeTab, setActiveTab] = useState<'general' | 'notifications' | 'webhook' | 'automation' | 'danger'>('general');
   const [repo, setRepo] = useState('');
   const [accountId, setAccountId] = useState<number | ''>('');
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -111,6 +135,7 @@ export default function ProjectSettingsView({ id }: { id: string }) {
           <nav className="flex space-x-8" aria-label="Tabs">
             {[
               { id: 'general', label: 'General' },
+              { id: 'notifications', label: 'Notifications' },
               { id: 'webhook', label: 'Webhook' },
               { id: 'automation', label: 'Automation' },
               { id: 'danger', label: 'Danger Zone' },
@@ -143,6 +168,52 @@ export default function ProjectSettingsView({ id }: { id: string }) {
         )}
 
         <div className="space-y-6">
+          {activeTab === 'notifications' && (
+            <section className="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Project State Subscriptions</h3>
+              <p className="text-sm text-gray-500 mb-6">Choose which status changes trigger a notification for this project.</p>
+
+              <div className="space-y-8">
+                {(Object.entries(statusGrouping) as [string, Record<string, string>][]).map(([group, statuses]) => (
+                  <div key={group} className="border-t border-gray-100 pt-4 first:border-0 first:pt-0">
+                    <h4 className="text-xs font-bold text-gray-900 mb-3 uppercase tracking-wider">{group}</h4>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                      {Object.entries(statuses).map(([id, label]) => (
+                        <div key={id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-100">
+                          <span className="text-xs font-medium text-gray-600">{label}</span>
+                          <button
+                            onClick={async () => {
+                              if (!project?.notification_settings) return;
+                              const newSettings = {
+                                ...project.notification_settings,
+                                [id]: !project.notification_settings[id],
+                              };
+                              try {
+                                await updateNotifications(newSettings);
+                              } catch (err: any) {
+                                setErrorMessage(err.response?.data?.error || 'Failed to update notification settings.');
+                              }
+                            }}
+                            disabled={isUpdatingNotifications}
+                            className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
+                              project?.notification_settings?.[id] ? 'bg-blue-600' : 'bg-gray-200'
+                            }`}
+                          >
+                            <span
+                              className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                                project?.notification_settings?.[id] ? 'translate-x-4' : 'translate-x-0'
+                              }`}
+                            />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
           {activeTab === 'general' && (
             <section className="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">General Configuration</h3>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -2032,6 +2032,7 @@ export interface components {
              * @example 2023-10-27T10:05:00Z
              */
             roadmap_updated_at?: string | null;
+            notification_settings?: Record<string, boolean>;
         };
         Task: {
             /** @example 42 */


### PR DESCRIPTION
Restored the per-project notification settings that were missing from the new UI. Added a new "Notifications" tab to the project settings page and updated the backend API to provide the necessary data.

Fixes #834

---
*PR created automatically by Jules for task [5563870280482054076](https://jules.google.com/task/5563870280482054076) started by @chatelao*