### PR TITLE
Implement and test Phase 6 Blockly workflows

### DIFF
--- a/BLOCKLY_ROADMAP.md
+++ b/BLOCKLY_ROADMAP.md
@@ -62,16 +62,16 @@
 - [x] Implement a "Dry Run" mode for testing Blockly logic without performing actions.
 
 ## Phase 6: End-to-End Workflows
-- [ ] Test "Auto-Merge on CI Success" workflow.
-  - [ ] Create a project with auto-merge blockly script.
-  - [ ] Trigger check_suite completed event via mock.
-  - [ ] Verify PR is merged on GitHub.
+- [x] Test "Auto-Merge on CI Success" workflow.
+  - [x] Create a project with auto-merge blockly script.
+  - [x] Trigger check_suite completed event via mock.
+  - [x] Verify PR is merged on GitHub.
 - [x] Test "Auto-Repeat on Issue Closed" workflow (via `duplicate()` action).
   - [x] Create a project with auto-repeat blockly script.
   - [x] Trigger issues closed event via mock.
   - [x] Verify new issue is created on GitHub.
-- [ ] Test "Custom Telegram Notification on Agent Error" workflow.
-  - [ ] Create a global blockly script for AGENT_ERROR.
-  - [ ] Simulate agent failure.
-  - [ ] Verify Telegram notification is sent.
+- [x] Test "Custom Telegram Notification on Agent Error" workflow.
+  - [x] Create a global blockly script for AGENT_ERROR.
+  - [x] Simulate agent failure.
+  - [x] Verify Telegram notification is sent.
 - [ ] Verify that manual JS edits correctly sync back to Blockly (where possible).

--- a/src/backend/SandboxService.php
+++ b/src/backend/SandboxService.php
@@ -41,9 +41,9 @@ class SandboxService
             return ['success' => false, 'handledEvents' => []];
         }
 
-        $project = $projectModel->findById($task['project_id']);
+        $project = $projectModel->findById((int)$task['project_id']);
         if (!$project) {
-            $logger->log($userId, $taskId, "SandboxService: Project not found.", 'error');
+            $logger->log($userId, $taskId, "SandboxService: Project not found (Project ID: " . $task['project_id'] . ").", 'error');
             return ['success' => false, 'handledEvents' => []];
         }
 

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -314,7 +314,10 @@ class Task
     public function findByPrUrl(string $prUrl): ?array
     {
         $stmt = $this->db->getConnection()->prepare(
-            "SELECT * FROM tasks WHERE pr_url = ?"
+            "SELECT t.*, p.github_repo
+             FROM tasks t
+             JOIN projects p ON t.project_id = p.project_id
+             WHERE t.pr_url = ?"
         );
         $stmt->execute([$prUrl]);
         $task = $stmt->fetch();
@@ -324,7 +327,10 @@ class Task
     public function findByIssueNumber(int $projectId, int $issueNumber): ?array
     {
         $stmt = $this->db->getConnection()->prepare(
-            "SELECT * FROM tasks WHERE project_id = ? AND issue_number = ?"
+            "SELECT t.*, p.github_repo
+             FROM tasks t
+             JOIN projects p ON t.project_id = p.project_id
+             WHERE t.project_id = ? AND t.issue_number = ?"
         );
         $stmt->execute([$projectId, $issueNumber]);
         $task = $stmt->fetch();

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -988,8 +988,8 @@ class Task
                 if ($julesData) {
                     $julesStatus = $julesData['status'];
                     $julesUrl = $julesData['url'] ?? $julesUrl;
-            } else {
-                Logger::getInstance($this->db)->log($userId, $task['task_id'], "refreshJulesStatus: fetchSessionStatus returned null for session $sessionId", 'warning');
+                } else {
+                    Logger::getInstance($this->db)->log($userId, $task['task_id'], "refreshJulesStatus: fetchSessionStatus returned null for session $sessionId", 'warning');
                 }
             }
 

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -988,6 +988,8 @@ class Task
                 if ($julesData) {
                     $julesStatus = $julesData['status'];
                     $julesUrl = $julesData['url'] ?? $julesUrl;
+            } else {
+                Logger::getInstance($this->db)->log($userId, $task['task_id'], "refreshJulesStatus: fetchSessionStatus returned null for session $sessionId", 'warning');
                 }
             }
 

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -87,7 +87,7 @@ class WebhookHandler
 
             // Re-fetch task to get updated status
             $task = $taskModel->findByIssueNumber((int)$project['project_id'], (int)$issue['number']);
-            if ($task && $task['status'] === Task::STATUS_FAILED_JULES) {
+            if ($task && ($task['status'] ?? '') === Task::STATUS_FAILED_JULES) {
                 $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService, 'AGENT_ERROR');
             }
         }

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -362,6 +362,9 @@ class WebhookHandler
 
                 // Re-fetch task to get updated status
                 $task = $taskModel->findByIssueNumber((int)$project['project_id'], (int)$issue['number']);
+                if ($task && ($task['status'] ?? '') === Task::STATUS_FAILED_JULES) {
+                    $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService, 'AGENT_ERROR');
+                }
             }
         }
 

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -100,8 +100,8 @@ class WebhookHandler
             $notificationData = [
                 'task_id' => $task['task_id'],
                 'project_id' => $project['project_id'],
-                'issue_number' => $issue['number'],
-                'source_url' => $issue['html_url'],
+                'issue_number' => $issue['number'] ?? 0,
+                'source_url' => $issue['html_url'] ?? '',
                 'is_system' => !$this->isUserTriggered($event)
             ];
 

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -84,6 +84,12 @@ class WebhookHandler
 
         if ($result && $task && $julesService && $githubService) {
             $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $effectiveNotifService, (int)$task['task_id']);
+
+            // Re-fetch task to get updated status
+            $task = $taskModel->findByIssueNumber((int)$project['project_id'], (int)$issue['number']);
+            if ($task && $task['status'] === Task::STATUS_FAILED_JULES) {
+                $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService, 'AGENT_ERROR');
+            }
         }
 
         if ($result && $task) {
@@ -342,10 +348,6 @@ class WebhookHandler
 
         $task = $taskModel->findByIssueNumber($project['project_id'], $issue['number']);
 
-        if ($task) {
-            $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService);
-        }
-
         if ($isJulesComment) {
             $sessionId = $taskModel->extractSessionId($body);
             if ($sessionId && $task) {
@@ -357,7 +359,14 @@ class WebhookHandler
             // Always refresh status when Jules comments to capture state transitions immediately
             if ($task && $githubService && $julesService) {
                 $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $notificationService, (int)$task['task_id']);
+
+                // Re-fetch task to get updated status
+                $task = $taskModel->findByIssueNumber((int)$project['project_id'], (int)$issue['number']);
             }
+        }
+
+        if ($task) {
+            $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService);
         }
 
         // Notify about the comment
@@ -420,8 +429,6 @@ class WebhookHandler
                 continue;
             }
 
-            $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService);
-
             // Fetch latest PR and Check Suites for a complete view
             $prData = null;
             $checkSuitesData = null;
@@ -461,6 +468,7 @@ class WebhookHandler
 
             if ($newStatus !== $task['status']) {
                 $taskModel->updateStatus($task['task_id'], $newStatus);
+                $task['status'] = $newStatus; // Update local object for Blockly
 
                 if ($notificationService) {
                     $title = $newStatus === Task::STATUS_FAILED_PR ? "❌ PR Failed: #" . $task['issue_number'] : "✅ PR Fixed: #" . $task['issue_number'];
@@ -493,6 +501,8 @@ class WebhookHandler
                 // This handles cases where a previous merge attempt might have failed but is now possible.
                 $this->autoMergeAndDuplicate($project, array_merge($task, ['status' => $newStatus]), $githubService, $notificationService);
             }
+
+            $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService);
         }
 
         return true;
@@ -517,6 +527,8 @@ class WebhookHandler
                 if ($action === 'closed' && ($payload['pull_request']['merged'] ?? false)) return 'PR_MERGED';
                 break;
             case 'check_suite':
+            case 'check_run':
+            case 'status':
                 if ($action === 'completed' || empty($action)) return 'CHECKS_COMPLETED';
                 break;
         }
@@ -524,7 +536,7 @@ class WebhookHandler
         return null;
     }
 
-    private function runBlocklyAutomations(array $project, array $event, string $githubEvent, ?int $taskId, ?SandboxService $sandboxService): void
+    private function runBlocklyAutomations(array $project, array $event, string $githubEvent, ?int $taskId, ?SandboxService $sandboxService, ?string $overrideEvent = null): void
     {
         if (!$sandboxService || !$taskId) {
             return;
@@ -536,7 +548,7 @@ class WebhookHandler
         $userModel = new User($this->db);
         $user = $userModel->findById($userId);
 
-        $blocklyEvent = $this->mapToBlocklyEvent($githubEvent, $event);
+        $blocklyEvent = $overrideEvent ?: $this->mapToBlocklyEvent($githubEvent, $event);
         $eventContext = [
             'type' => $blocklyEvent ?: $githubEvent, // Fallback to raw github event if not mapped
             'github_event' => $githubEvent,

--- a/test/Integration/BlocklyWorkflowPhase6Test.php
+++ b/test/Integration/BlocklyWorkflowPhase6Test.php
@@ -89,6 +89,7 @@ class BlocklyWorkflowPhase6Test extends TestCase
             jules_status VARCHAR(50),
             jules_url TEXT,
             autorepeat_remaining INT DEFAULT 0,
+            github_repo VARCHAR(255),
             last_synced_at DATETIME,
             created_at $timestamp,
             updated_at $timestamp,
@@ -170,6 +171,7 @@ class BlocklyWorkflowPhase6Test extends TestCase
         // Task is already in CHECKING status, with a PR URL
         $this->pdo->prepare("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, status, pr_url, github_data)
                           VALUES (1, 1, 1, 101, 'Fix Bug', 'checking', 'https://github.com/owner/repo/pull/42', '{\"labels\":[]}')")->execute();
+        $this->pdo->exec("UPDATE tasks SET github_repo = 'owner/repo' WHERE task_id = 1");
 
         $project = [
             'project_id' => 1,
@@ -254,6 +256,7 @@ class BlocklyWorkflowPhase6Test extends TestCase
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo, github_account_id) VALUES (1, 1, 'owner/repo', 1)");
         $this->pdo->prepare("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, status, github_data)
                           VALUES (1, 1, 1, 101, 'Broken Task', 'created', '{\"labels\":[]}')")->execute();
+        $this->pdo->exec("UPDATE tasks SET github_repo = 'owner/repo' WHERE task_id = 1");
 
         $project = [
             'project_id' => 1,

--- a/test/Integration/BlocklyWorkflowPhase6Test.php
+++ b/test/Integration/BlocklyWorkflowPhase6Test.php
@@ -36,7 +36,8 @@ class BlocklyWorkflowPhase6Test extends TestCase
         // Reset tables
         $tables = [
             'task_logs', 'tasks', 'projects', 'users', 'user_github_accounts',
-            'notifications'
+            'notifications', 'task_notification_settings', 'user_event_notification_settings',
+            'project_status_notification_settings', 'user_notification_settings'
         ];
         foreach ($tables as $table) {
             $this->pdo->exec("DROP TABLE IF EXISTS $table");

--- a/test/Integration/BlocklyWorkflowPhase6Test.php
+++ b/test/Integration/BlocklyWorkflowPhase6Test.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\WebhookHandler;
+use App\SandboxService;
+use App\GitHubService;
+use App\NotificationService;
+use App\JulesService;
+use App\Logger;
+use App\Task;
+use App\Project;
+use App\User;
+use PDO;
+use Tests\TestDatabaseTrait;
+
+class BlocklyWorkflowPhase6Test extends TestCase
+{
+    use TestDatabaseTrait;
+
+    private $db;
+    private $pdo;
+    private $githubService;
+    private $notificationService;
+    private $julesService;
+    private $sandboxService;
+    private $webhookHandler;
+
+    protected function setUp(): void
+    {
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        // Reset tables
+        $tables = [
+            'task_logs', 'tasks', 'projects', 'users', 'user_github_accounts',
+            'notifications'
+        ];
+        foreach ($tables as $table) {
+            $this->pdo->exec("DROP TABLE IF EXISTS $table");
+        }
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
+
+        $this->pdo->exec("CREATE TABLE users (
+            user_id $pk,
+            email VARCHAR(255) UNIQUE,
+            blockly_config TEXT,
+            jules_api_key VARCHAR(255),
+            jules_quota_usage INT DEFAULT 0,
+            jules_quota_limit INT DEFAULT 0,
+            jules_quota_updated_at DATETIME
+        )");
+
+        $this->pdo->exec("CREATE TABLE user_github_accounts (
+            github_account_id $pk,
+            user_id INT NOT NULL,
+            github_token VARCHAR(255),
+            github_username VARCHAR(255)
+        )");
+
+        $this->pdo->exec("CREATE TABLE projects (
+            project_id $pk,
+            user_id INT NOT NULL,
+            github_repo VARCHAR(255) NOT NULL,
+            github_account_id INT,
+            blockly_config TEXT,
+            webhook_secret VARCHAR(255),
+            created_at $timestamp
+        )");
+
+        $this->pdo->exec("CREATE TABLE tasks (
+            task_id $pk,
+            user_id INT NOT NULL,
+            project_id INT NOT NULL,
+            issue_number INT NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            body TEXT,
+            status TEXT DEFAULT 'created',
+            github_state VARCHAR(20) DEFAULT 'open',
+            github_data TEXT,
+            github_pr_data TEXT,
+            pr_url VARCHAR(255),
+            jules_session_id VARCHAR(255),
+            jules_status VARCHAR(50),
+            jules_url TEXT,
+            autorepeat_remaining INT DEFAULT 0,
+            last_synced_at DATETIME,
+            created_at $timestamp,
+            updated_at $timestamp,
+            UNIQUE(project_id, issue_number)
+        )");
+
+        $this->pdo->exec("CREATE TABLE task_logs (
+            log_id $pk,
+            task_id INT NOT NULL,
+            user_id INT NOT NULL,
+            message TEXT,
+            level VARCHAR(20),
+            created_at $timestamp
+        )");
+
+        $this->pdo->exec("CREATE TABLE notifications (
+            notification_id $pk,
+            user_id INT NOT NULL,
+            project_id INT,
+            type VARCHAR(50),
+            title VARCHAR(255),
+            message TEXT,
+            data TEXT,
+            is_read BOOLEAN DEFAULT 0,
+            created_at $timestamp
+        )");
+
+        $this->pdo->exec("CREATE TABLE task_notification_settings (
+            task_id INT PRIMARY KEY,
+            is_muted BOOLEAN DEFAULT 0
+        )");
+
+        $this->pdo->exec("CREATE TABLE user_event_notification_settings (
+            user_id INT NOT NULL,
+            notification_type VARCHAR(50) NOT NULL,
+            is_enabled BOOLEAN DEFAULT 1,
+            PRIMARY KEY (user_id, notification_type)
+        )");
+
+        $this->pdo->exec("CREATE TABLE project_status_notification_settings (
+            project_id INT NOT NULL,
+            status VARCHAR(50) NOT NULL,
+            is_enabled BOOLEAN DEFAULT 1,
+            PRIMARY KEY (project_id, status)
+        )");
+
+        $this->pdo->exec("CREATE TABLE user_notification_settings (
+            user_id INT NOT NULL,
+            channel VARCHAR(50) NOT NULL,
+            is_enabled BOOLEAN DEFAULT 1,
+            PRIMARY KEY (user_id, channel)
+        )");
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        $this->githubService = $this->createMock(GitHubService::class);
+        $this->notificationService = $this->createMock(NotificationService::class);
+        $this->julesService = $this->createMock(JulesService::class);
+
+        $this->sandboxService = new SandboxService($this->db, $this->githubService, $this->notificationService, $this->julesService);
+        $this->webhookHandler = new WebhookHandler($this->db);
+
+        Logger::resetInstance();
+        new Logger($this->db);
+    }
+
+    public function testAutoMergeOnCiSuccess()
+    {
+        // 1. Setup: Project with Blockly auto-merge script
+        $jsCode = "onEvent('CHECKS_COMPLETED', (event) => { if (isTaskReady()) { merge(); } });";
+        $blocklyConfig = json_encode(['js' => $jsCode]);
+
+        $this->pdo->exec("INSERT INTO users (user_id, email) VALUES (1, 'test@example.com')");
+        $this->pdo->exec("INSERT INTO user_github_accounts (github_account_id, user_id, github_username, github_token) VALUES (1, 1, 'testuser', 'token')");
+        $stmt = $this->pdo->prepare("INSERT INTO projects (project_id, user_id, github_repo, blockly_config, github_account_id) VALUES (1, 1, 'owner/repo', ?, 1)");
+        $stmt->execute([$blocklyConfig]);
+
+        // Task is already in CHECKING status, with a PR URL
+        $this->pdo->prepare("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, status, pr_url, github_data)
+                          VALUES (1, 1, 1, 101, 'Fix Bug', 'checking', 'https://github.com/owner/repo/pull/42', '{\"labels\":[]}')")->execute();
+
+        $project = [
+            'project_id' => 1,
+            'user_id' => 1,
+            'github_repo' => 'owner/repo',
+            'blockly_config' => $blocklyConfig
+        ];
+
+        // 2. Mock GitHub API: PR checks now pass
+        $this->githubService->method('extractPrNumber')->willReturn(42);
+        $this->githubService->method('getPullRequest')->willReturn([
+            'state' => 'open',
+            'head' => ['sha' => 'abcdef']
+        ]);
+        $this->githubService->method('getCheckSuites')->willReturn([
+            'check_suites' => [['status' => 'completed', 'conclusion' => 'success']]
+        ]);
+        $this->githubService->method('getCombinedStatus')->willReturn(['statuses' => []]);
+
+        // Expectation: merge() should be called by Blockly
+        $this->githubService->expects($this->once())
+            ->method('mergePullRequest')
+            ->with('owner/repo', 42, 'Merged via Blockly Automation');
+
+        // 3. Trigger check_suite completed event
+        $payload = [
+            'action' => 'completed',
+            'check_suite' => [
+                'pull_requests' => [['url' => 'https://api.github.com/repos/owner/repo/pulls/42']]
+            ],
+            'repository' => ['full_name' => 'owner/repo']
+        ];
+
+        $this->webhookHandler->handle($project, $payload, $this->githubService, $this->notificationService, $this->julesService, $this->sandboxService, 'check_suite');
+
+        // 4. Verification: Task status updated to ready (then probably finished if merge was successful, but merge is mocked here)
+        $stmt = $this->pdo->query("SELECT status FROM tasks WHERE task_id = 1");
+        $this->assertEquals('ready', $stmt->fetchColumn());
+
+        // Verify Blockly log
+        $stmt = $this->pdo->query("SELECT message FROM task_logs WHERE task_id = 1 AND message LIKE '%Blockly Action [Local]: Merged PR #42%'");
+        $logMessage = $stmt->fetchColumn();
+        if (!$logMessage) {
+            $allLogs = $this->pdo->query("SELECT message FROM task_logs WHERE task_id = 1")->fetchAll(PDO::FETCH_COLUMN);
+            $this->fail("Log message not found. Available logs: " . implode(", ", $allLogs));
+        }
+        $this->assertNotEmpty($logMessage);
+    }
+
+    private function withConsecutive(array ...$parameterGroups): array
+    {
+        $count = 0;
+        $callbacks = [];
+        $totalParams = count($parameterGroups[0]);
+        for ($i = 0; $i < $totalParams; $i++) {
+            $callbacks[] = $this->callback(function ($actual) use ($parameterGroups, $i, &$count, $totalParams) {
+                $groupIndex = (int)($count / $totalParams);
+                if ($groupIndex >= count($parameterGroups)) {
+                    return true;
+                }
+                $expected = $parameterGroups[$groupIndex][$i];
+                $count++;
+
+                if ($expected instanceof \PHPUnit\Framework\Constraint\Constraint) {
+                    return $expected->evaluate($actual, '', true);
+                }
+                return ($actual === $expected);
+            });
+        }
+        return $callbacks;
+    }
+
+    public function testAgentErrorReporting()
+    {
+        // 1. Setup: Global Blockly script for AGENT_ERROR
+        $jsCode = "onEvent('AGENT_ERROR', (event) => { notify('Agent failed on task: ' + event.payload.issue.title); });";
+        $blocklyConfig = json_encode(['js' => $jsCode]);
+
+        $stmt = $this->pdo->prepare("INSERT INTO users (user_id, email, blockly_config, jules_api_key) VALUES (1, 'test@example.com', ?, 'fake_key')");
+        $stmt->execute([$blocklyConfig]);
+        $this->pdo->exec("INSERT INTO user_github_accounts (github_account_id, user_id, github_username, github_token) VALUES (1, 1, 'testuser', 'token')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo, github_account_id) VALUES (1, 1, 'owner/repo', 1)");
+        $this->pdo->prepare("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, status, github_data)
+                          VALUES (1, 1, 1, 101, 'Broken Task', 'created', '{\"labels\":[]}')")->execute();
+
+        $project = [
+            'project_id' => 1,
+            'user_id' => 1,
+            'github_repo' => 'owner/repo',
+            'blockly_config' => null
+        ];
+
+        // 2. Mock Jules API failure
+        $this->julesService->method('fetchSessionStatus')->willReturn(['status' => 'failed']);
+
+        // Expectation: notify() should be called by Blockly (after task_status notification)
+        $this->notificationService->expects($this->exactly(2))
+            ->method('notify')
+            ->with(...$this->withConsecutive(
+                [
+                    1,
+                    'task_status',
+                    $this->stringContains('Jules Failed'),
+                    $this->stringContains('failed'),
+                    $this->anything(),
+                    $this->anything()
+                ],
+                [
+                    1,
+                    'blockly_action',
+                    'Blockly Notification',
+                    'Agent failed on task: Broken Task',
+                    $this->anything(),
+                    $this->anything()
+                ]
+            ));
+
+        // 3. Trigger an event that causes refreshJulesStatus (e.g., labeled)
+        $payload = [
+            'action' => 'labeled',
+            'issue' => [
+                'number' => 101,
+                'title' => 'Broken Task',
+                'state' => 'open',
+                'labels' => [['name' => 'Jules']]
+            ],
+            'repository' => ['full_name' => 'owner/repo']
+        ];
+
+        // We need to set jules_session_id so refreshJulesStatus actually calls fetchSessionStatus
+        $this->pdo->exec("UPDATE tasks SET jules_session_id = 'sess_123' WHERE task_id = 1");
+
+        // Mock GitHub getIssue for upsert
+        $this->githubService->method('getIssue')->willReturn($payload['issue']);
+
+        $this->webhookHandler->handle($project, $payload, $this->githubService, $this->notificationService, $this->julesService, $this->sandboxService, 'issues');
+
+        // 4. Verification: Task status updated to failed_jules
+        $stmt = $this->pdo->query("SELECT status FROM tasks WHERE task_id = 1");
+        $actualStatus = $stmt->fetchColumn();
+        if ($actualStatus !== 'failed_jules') {
+            $allLogs = $this->pdo->query("SELECT message FROM task_logs WHERE task_id = 1")->fetchAll(PDO::FETCH_COLUMN);
+            $this->fail("Status is $actualStatus, expected failed_jules. Available logs: " . implode(", ", $allLogs));
+        }
+        $this->assertEquals('failed_jules', $actualStatus);
+
+        // Verify Blockly log
+        $stmt = $this->pdo->query("SELECT message FROM task_logs WHERE task_id = 1 AND message LIKE '%Executing [Global] Blockly automation%'");
+        $logMessage = $stmt->fetchColumn();
+        if (!$logMessage) {
+            $allLogs = $this->pdo->query("SELECT message FROM task_logs WHERE task_id = 1")->fetchAll(PDO::FETCH_COLUMN);
+            $this->fail("Log message not found. Available logs: " . implode(", ", $allLogs));
+        }
+        $this->assertNotEmpty($logMessage);
+    }
+}

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -18,6 +18,12 @@ class WebhookHandlerTest extends TestCase
         $this->pdo = new PDO('sqlite::memory:');
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
+        $this->pdo->exec("CREATE TABLE projects (
+            project_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INT NOT NULL,
+            github_repo VARCHAR(255) NOT NULL
+        )");
+
         $this->pdo->exec("CREATE TABLE tasks (
             task_id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INT NOT NULL,
@@ -53,7 +59,9 @@ class WebhookHandlerTest extends TestCase
 
     public function testHandleIssueOpened()
     {
-        $project = ['user_id' => 1, 'project_id' => 1];
+        $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+
         $event = [
             'action' => 'opened',
             'issue' => [
@@ -81,7 +89,9 @@ class WebhookHandlerTest extends TestCase
 
     public function testHandleAutorepeat()
     {
-        $project = ['user_id' => 1, 'project_id' => 1];
+        $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+
         $event = [
             'action' => 'closed',
             'issue' => [
@@ -112,7 +122,9 @@ class WebhookHandlerTest extends TestCase
     public function testHandleAutorepeatWithoutNotificationService()
     {
         // Simulate human-triggered merge (sender.type === 'User')
-        $project = ['user_id' => 1, 'project_id' => 1];
+        $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+
         $prUrl = 'https://github.com/owner/repo/pull/123';
 
         // Pre-seed task
@@ -153,7 +165,9 @@ class WebhookHandlerTest extends TestCase
 
     public function testHandleCheckSuiteInProgress()
     {
-        $project = ['user_id' => 1, 'project_id' => 1];
+        $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+
         $prUrl = 'https://github.com/owner/repo/pull/123';
 
         // Pre-seed task

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -193,7 +193,7 @@ class WebhookHandlerTest extends TestCase
         $this->pdo->method('getAttribute')->with(PDO::ATTR_DRIVER_NAME)->willReturn('sqlite');
         $this->pdo->method('prepare')->willReturnCallback(function($sql) use ($stmt) {
             // Depending on the order of calls, we might see different SQLs
-            if (str_contains($sql, 'SELECT * FROM tasks')) {
+            if (str_contains($sql, 'SELECT t.*, p.github_repo')) {
                 return $stmt;
             }
             $this->assertStringContainsString('ON CONFLICT', $sql);

--- a/test/Unit/WebhookHandlerCommentTest.php
+++ b/test/Unit/WebhookHandlerCommentTest.php
@@ -65,7 +65,7 @@ class WebhookHandlerCommentTest extends TestCase
             ->with($event['comment']['body'])
             ->willReturn('s123');
 
-        $this->taskModel->expects($this->once())
+        $this->taskModel->expects($this->exactly(2))
             ->method('findByIssueNumber')
             ->with(1, 123)
             ->willReturn($task);


### PR DESCRIPTION
This PR completes two major end-to-end workflow testing tasks from the `BLOCKLY_ROADMAP.md`: "Auto-Merge on CI Success" and "Custom Telegram Notification on Agent Error".

Key changes:
- **Event Mapping:** `WebhookHandler::mapToBlocklyEvent` now recognizes `check_run` and `status` events as `CHECKS_COMPLETED`, enabling automation on any CI status change.
- **Agent Error Handling:** Explicitly triggers a new `AGENT_ERROR` Blockly event if a task transitions to `failed_jules` during status refresh.
- **Execution Order:** Automations now run AFTER database status updates and Jules refreshes, ensuring Blockly predicates like `isTaskReady()` operate on the most current data.
- **Testing:** Added `test/Integration/BlocklyWorkflowPhase6Test.php` which uses mocks and a test database to verify both workflows end-to-end.
- **Documentation:** Updated `BLOCKLY_ROADMAP.md` to mark Phase 6 as substantially complete.

Fixes #837

---
*PR created automatically by Jules for task [4703692345100545802](https://jules.google.com/task/4703692345100545802) started by @chatelao*