### PR TITLE
Implement Phase 9: Interactive Task Management for Telegram

### DIFF
--- a/CHAT_ROADMAP.md
+++ b/CHAT_ROADMAP.md
@@ -12,6 +12,7 @@
 | 6 | [UC-C3] Quick Task Acknowledgment | ✅ |
 | 7 | [UC-C4] Chat Cleanup | ✅ |
 | 8 | Advanced Interactions | ✅ |
+| 9 | Interactive Task Management | ✅ |
 
 ## Goals
 
@@ -69,3 +70,9 @@
 - [x] Implement `/status` command to pull current task summary.
 - [x] Implement `/tasks` command to list active tasks.
 - [x] Implement `/help` command to list available commands.
+
+## Phase 9: Interactive Task Management
+- [x] Implement `/projects` command to list active projects.
+- [x] Enhance `/tasks` list with "Actions" buttons for each task.
+- [x] Implement `view_task:{taskId}` callback to show task details and available actions.
+- [x] Update `/help` command with new options.

--- a/src/backend/TelegramWebhookHandler.php
+++ b/src/backend/TelegramWebhookHandler.php
@@ -60,6 +60,10 @@ class TelegramWebhookHandler
             return $this->handleStatus($chatId);
         }
 
+        if ($text === '/projects') {
+            return $this->handleProjects($chatId);
+        }
+
         if ($text === '/tasks') {
             return $this->handleTasks($chatId);
         }
@@ -75,11 +79,37 @@ class TelegramWebhookHandler
     {
         $helpText = "<b>Available Commands:</b>\n\n";
         $helpText .= "/status - Get a summary of task counts.\n";
+        $helpText .= "/projects - List your active projects.\n";
         $helpText .= "/tasks - List active tasks with details.\n";
         $helpText .= "/cleanup - Remove read notifications from the chat.\n";
         $helpText .= "/help - Show this help message.";
 
         $this->telegramService->sendMessage($chatId, $helpText);
+        return true;
+    }
+
+    private function handleProjects(int $chatId): bool
+    {
+        $user = $this->userModel->findByTelegramChatId($chatId);
+        if (!$user) {
+            $this->telegramService->sendMessage($chatId, "Unauthorized. Please link your account.");
+            return true;
+        }
+
+        $projectModel = new Project($this->userModel->getDb());
+        $projects = $projectModel->findByUserId((int)$user['user_id']);
+
+        if (empty($projects)) {
+            $this->telegramService->sendMessage($chatId, "No projects found.");
+            return true;
+        }
+
+        $text = "<b>Your Projects:</b>\n\n";
+        foreach ($projects as $project) {
+            $text .= "📁 <b>" . htmlspecialchars($project['github_repo']) . "</b>\n";
+        }
+
+        $this->telegramService->sendMessage($chatId, $text);
         return true;
     }
 
@@ -100,20 +130,24 @@ class TelegramWebhookHandler
         }
 
         $text = "<b>Active Tasks:</b>\n\n";
+        $inlineKeyboard = [];
         foreach (array_slice($tasks, 0, 10) as $task) {
             $statusEmoji = $taskModel->getStatusEmoji($task['status']);
-            $statusLabel = $taskModel->getStatusLabel($task['status']);
-            $targetUrl = $taskModel->getTargetUrl($task);
+            $text .= "$statusEmoji <b>#" . $task['issue_number'] . "</b>: " . htmlspecialchars($task['title']) . "\n";
 
-            $text .= "$statusEmoji <b>#" . $task['issue_number'] . "</b>: <a href=\"" . htmlspecialchars($targetUrl) . "\">" . htmlspecialchars($task['title']) . "</a>\n";
-            $text .= "<i>Status: $statusLabel</i>\n\n";
+            $inlineKeyboard[] = [[
+                'text' => "#" . $task['issue_number'] . " Actions",
+                'callback_data' => "view_task:" . $task['task_id']
+            ]];
         }
 
         if (count($tasks) > 10) {
-            $text .= "<i>Showing 10 of " . count($tasks) . " tasks.</i>";
+            $text .= "\n<i>Showing 10 of " . count($tasks) . " tasks.</i>";
         }
 
-        $this->telegramService->sendMessage($chatId, $text);
+        $this->telegramService->sendMessage($chatId, $text, [
+            'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
+        ]);
         return true;
     }
 
@@ -172,7 +206,12 @@ class TelegramWebhookHandler
         $taskId = isset($parts[1]) ? (int)$parts[1] : null;
         $notificationId = isset($parts[2]) ? (int)$parts[2] : null;
 
-        if (!$taskId || !in_array($action, ['retry', 'restart', 'merge', 'acknowledge', 'approve_plan', 'fix_bug'])) {
+        if ($action === 'list_tasks') {
+            $this->telegramService->answerCallbackQuery($callbackId);
+            return $this->handleTasks($chatId);
+        }
+
+        if (!$taskId || !in_array($action, ['retry', 'restart', 'merge', 'acknowledge', 'approve_plan', 'fix_bug', 'view_task'])) {
             $this->telegramService->answerCallbackQuery($callbackId, [
                 'text' => "Invalid action.",
                 'show_alert' => true
@@ -193,9 +232,13 @@ class TelegramWebhookHandler
         }
 
         // 4. Acknowledge the query
-        $this->telegramService->answerCallbackQuery($callbackId, [
-            'text' => "Processing " . ucfirst($action) . "..."
-        ]);
+        if ($action !== 'view_task') {
+            $this->telegramService->answerCallbackQuery($callbackId, [
+                'text' => "Processing " . ucfirst($action) . "..."
+            ]);
+        } else {
+            $this->telegramService->answerCallbackQuery($callbackId);
+        }
 
         if ($notificationId) {
             $notificationService = new NotificationService($this->userModel->getDb());
@@ -216,7 +259,33 @@ class TelegramWebhookHandler
             $messageId = $callbackQuery['message']['message_id'] ?? null;
             $originalText = $callbackQuery['message']['text'] ?? '';
 
-            if ($action === 'merge') {
+            if ($action === 'view_task') {
+                $statusEmoji = $taskModel->getStatusEmoji($task['status'] ?? Task::STATUS_CREATED);
+                $statusLabel = $taskModel->getStatusLabel($task['status'] ?? Task::STATUS_CREATED);
+                $targetUrl = $taskModel->getTargetUrl($task, $repo);
+
+                $text = "$statusEmoji <b>#" . $task['issue_number'] . "</b>: <a href=\"" . htmlspecialchars($targetUrl) . "\">" . htmlspecialchars($task['title']) . "</a>\n";
+                $text .= "<i>Status: $statusLabel</i>\n\n";
+                $text .= "Choose an action:";
+
+                $actions = [];
+                $actions[] = ['text' => '🚀 Retry', 'callback_data' => "retry:$taskId"];
+                $actions[] = ['text' => '🔄 Restart', 'callback_data' => "restart:$taskId"];
+
+                if (!empty($task['pr_url'])) {
+                    $actions[] = ['text' => '✅ Merge', 'callback_data' => "merge:$taskId"];
+                }
+
+                $actions[] = ['text' => '🆗 Acknowledge', 'callback_data' => "acknowledge:$taskId"];
+
+                $inlineKeyboard = array_chunk($actions, 2);
+                $inlineKeyboard[] = [['text' => '⬅️ Back to Tasks', 'callback_data' => 'list_tasks:0']];
+
+                $this->telegramService->sendMessage($chatId, $text, [
+                    'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
+                ]);
+                return true;
+            } elseif ($action === 'merge') {
                 $prNumber = $ghs->extractPrNumber($task['pr_url'] ?? '');
                 if (!$prNumber) {
                     throw new \Exception("No pull request associated with this task.");

--- a/test/Integration/TelegramWebhookHandlerIntegrationTest.php
+++ b/test/Integration/TelegramWebhookHandlerIntegrationTest.php
@@ -38,7 +38,7 @@ class TelegramWebhookHandlerIntegrationTest extends TestCase
         $this->pdo->exec("CREATE TABLE users (user_id $pk, email VARCHAR(255), telegram_bot_token VARCHAR(255), jules_api_key VARCHAR(255), jules_quota_updated_at TIMESTAMP NULL)");
         $this->pdo->exec("CREATE TABLE notifications (notification_id $pk, user_id INT, project_id INT, type VARCHAR(50), title VARCHAR(255), message TEXT, data TEXT, is_read TINYINT DEFAULT 0, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
         $this->pdo->exec("CREATE TABLE user_github_accounts (github_account_id $pk, user_id INT, github_username VARCHAR(255), github_token VARCHAR(255))");
-        $this->pdo->exec("CREATE TABLE projects (project_id $pk, user_id INT, github_account_id INT, github_repo VARCHAR(255), github_token VARCHAR(255))");
+        $this->pdo->exec("CREATE TABLE projects (project_id $pk, user_id INT, github_account_id INT, github_repo VARCHAR(255), github_token VARCHAR(255), created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
         $this->pdo->exec("CREATE TABLE tasks (task_id $pk, user_id INT, project_id INT, issue_number INT, title VARCHAR(255), body TEXT, pr_url VARCHAR(255), jules_url VARCHAR(255), jules_status VARCHAR(50), status VARCHAR(50), github_state VARCHAR(50), jules_session_id VARCHAR(255), last_synced_at TIMESTAMP NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, github_data TEXT, autorepeat_remaining INT DEFAULT 0)");
         $this->pdo->exec("CREATE TABLE user_telegram_accounts (telegram_account_id $pk, user_id INT, telegram_chat_id BIGINT UNIQUE)");
 
@@ -317,6 +317,132 @@ class TelegramWebhookHandlerIntegrationTest extends TestCase
         $this->telegramService->expects($this->once())
             ->method('sendMessage')
             ->with(123, $this->stringContains('Cleanup complete'));
+
+        $this->assertTrue($this->handler->handle($update));
+    }
+
+    public function testHandleProjectsCommand()
+    {
+        $this->pdo->exec("INSERT INTO users (user_id, email) VALUES (1, 'user@example.com')");
+        $this->pdo->exec("INSERT INTO user_telegram_accounts (user_id, telegram_chat_id) VALUES (1, 123)");
+        $this->pdo->exec("INSERT INTO user_github_accounts (user_id, github_username, github_token) VALUES (1, 'ghuser', 'ghtoken')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_account_id, github_repo) VALUES (1, 1, 1, 'owner/repo')");
+
+        $update = [
+            'message' => [
+                'chat' => ['id' => 123],
+                'text' => '/projects'
+            ]
+        ];
+
+        $this->telegramService->expects($this->once())
+            ->method('sendMessage')
+            ->with(123, $this->logicalAnd(
+                $this->stringContains('Your Projects'),
+                $this->stringContains('owner/repo')
+            ));
+
+        $this->assertTrue($this->handler->handle($update));
+    }
+
+    public function testHandleTasksCommandEnhanced()
+    {
+        $this->pdo->exec("INSERT INTO users (user_id, email) VALUES (1, 'user@example.com')");
+        $this->pdo->exec("INSERT INTO user_telegram_accounts (user_id, telegram_chat_id) VALUES (1, 123)");
+        $this->pdo->exec("INSERT INTO user_github_accounts (user_id, github_username, github_token) VALUES (1, 'ghuser', 'ghtoken')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_account_id, github_repo) VALUES (1, 1, 1, 'owner/repo')");
+        $this->pdo->exec("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, status, github_state) VALUES (17, 1, 1, 107, 'Enhanced Task', 'executing', 'open')");
+
+        $update = [
+            'message' => [
+                'chat' => ['id' => 123],
+                'text' => '/tasks'
+            ]
+        ];
+
+        $this->telegramService->expects($this->once())
+            ->method('sendMessage')
+            ->with(123, $this->stringContains('Active Tasks'), $this->callback(function($params) {
+                return isset($params['reply_markup']['inline_keyboard']) &&
+                       $params['reply_markup']['inline_keyboard'][0][0]['text'] === '#107 Actions';
+            }));
+
+        $this->assertTrue($this->handler->handle($update));
+    }
+
+    public function testHandleViewTaskAction()
+    {
+        $this->pdo->exec("INSERT INTO users (user_id, email) VALUES (1, 'user@example.com')");
+        $this->pdo->exec("INSERT INTO user_telegram_accounts (user_id, telegram_chat_id) VALUES (1, 123)");
+        $this->pdo->exec("INSERT INTO user_github_accounts (user_id, github_username, github_token) VALUES (1, 'ghuser', 'ghtoken')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_account_id, github_repo, github_token) VALUES (1, 1, 1, 'owner/repo', 'token')");
+        $this->pdo->exec("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, pr_url, status) VALUES (18, 1, 1, 108, 'View Task', 'https://github.com/owner/repo/pull/55', 'executing')");
+
+        $update = [
+            'callback_query' => [
+                'id' => 'cb129',
+                'data' => 'view_task:18',
+                'message' => [
+                    'chat' => ['id' => 123],
+                    'message_id' => 462,
+                    'text' => 'Original Message'
+                ]
+            ]
+        ];
+
+        $this->telegramService->expects($this->once())
+            ->method('answerCallbackQuery')
+            ->with('cb129');
+
+        $this->telegramService->expects($this->once())
+            ->method('sendMessage')
+            ->with(123, $this->logicalAnd(
+                $this->stringContains('#108'),
+                $this->stringContains('View Task'),
+                $this->stringContains('Choose an action')
+            ), $this->callback(function($params) {
+                $keyboard = $params['reply_markup']['inline_keyboard'];
+                $hasRetry = false;
+                $hasMerge = false;
+                $hasBack = false;
+                foreach ($keyboard as $row) {
+                    foreach ($row as $button) {
+                        if ($button['text'] === '🚀 Retry') $hasRetry = true;
+                        if ($button['text'] === '✅ Merge') $hasMerge = true;
+                        if ($button['text'] === '⬅️ Back to Tasks') $hasBack = true;
+                    }
+                }
+                return $hasRetry && $hasMerge && $hasBack;
+            }));
+
+        $this->assertTrue($this->handler->handle($update));
+    }
+
+    public function testHandleListTasksAction()
+    {
+        $this->pdo->exec("INSERT INTO users (user_id, email) VALUES (1, 'user@example.com')");
+        $this->pdo->exec("INSERT INTO user_telegram_accounts (user_id, telegram_chat_id) VALUES (1, 123)");
+
+        $update = [
+            'callback_query' => [
+                'id' => 'cb130',
+                'data' => 'list_tasks:0',
+                'message' => [
+                    'chat' => ['id' => 123],
+                    'message_id' => 463,
+                    'text' => 'Original Message'
+                ]
+            ]
+        ];
+
+        $this->telegramService->expects($this->once())
+            ->method('answerCallbackQuery')
+            ->with('cb130');
+
+        // It should call handleTasks which sends "No active tasks found." if none exist
+        $this->telegramService->expects($this->once())
+            ->method('sendMessage')
+            ->with(123, $this->stringContains('No active tasks found.'));
 
         $this->assertTrue($this->handler->handle($update));
     }


### PR DESCRIPTION
This PR implements Phase 9 of the Telegram Chat Control roadmap, introducing proactive task management capabilities. Key features include a new /projects command, an enhanced /tasks list with inline action buttons, and a detailed view_task callback for individual task management (Retry, Restart, Merge, Acknowledge) directly from Telegram.

Fixes #851

---
*PR created automatically by Jules for task [18146974047113119285](https://jules.google.com/task/18146974047113119285) started by @chatelao*