### PR TITLE
Fix endless autorepeat task duplication

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -385,6 +385,26 @@ class Task
         return $stmt->execute([$response, $status, $id]);
     }
 
+    public function markAutorepeatTriggered(int $id): bool
+    {
+        $connection = $this->db->getConnection();
+        $driver = $connection->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $sql = "UPDATE tasks
+                    SET agent_response = COALESCE(agent_response, '') || '\n<!-- autorepeat_triggered -->'
+                    WHERE task_id = ? AND (agent_response IS NULL OR agent_response NOT LIKE '%<!-- autorepeat_triggered -->%')";
+        } else {
+            $sql = "UPDATE tasks
+                    SET agent_response = CONCAT(COALESCE(agent_response, ''), '\n<!-- autorepeat_triggered -->')
+                    WHERE task_id = ? AND (agent_response IS NULL OR agent_response NOT LIKE '%<!-- autorepeat_triggered -->%')";
+        }
+
+        $stmt = $connection->prepare($sql);
+        $stmt->execute([$id]);
+        return $stmt->rowCount() > 0;
+    }
+
     public function updateGitHubCache(int $taskId, ?array $prData = null, ?array $commentsData = null): bool
     {
         $updates = [];
@@ -461,6 +481,7 @@ class Task
 
         // Try to extract from labels if not explicitly provided
         $labelCount = isset($issue['labels']) ? $this->extractAutorepeatRemainingFromLabels($issue['labels']) : null;
+        $hasGenericAutorepeatLabel = false;
 
         // If no count is found but the label is present, default to 5
         if ($labelCount === null && isset($issue['labels'])) {
@@ -468,6 +489,7 @@ class Task
                 $name = strtolower($label['name'] ?? '');
                 if ($name === 'autorepeat' || $name === 'auto-repeat') {
                     $labelCount = 5;
+                    $hasGenericAutorepeatLabel = true;
                     break;
                 }
             }
@@ -476,8 +498,10 @@ class Task
         // Final value to use in the INSERT part
         $insertAutorepeatRemaining = $autorepeatRemaining ?? $labelCount ?? 0;
 
-        // Determine if we should update the existing value
-        $shouldUpdateAutorepeat = ($autorepeatRemaining !== null || $labelCount !== null);
+        // Determine if we should update the existing value.
+        // If we only have a generic 'autorepeat' label, we only update if the current DB value is 0.
+        $shouldUpdateAutorepeat = ($autorepeatRemaining !== null || ($labelCount !== null && !$hasGenericAutorepeatLabel));
+        $conditionalAutorepeatUpdate = ($hasGenericAutorepeatLabel && $autorepeatRemaining === null);
 
         if ($driver === 'sqlite') {
             $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state, autorepeat_remaining)
@@ -487,7 +511,8 @@ class Task
                         body = excluded.body,
                         github_data = excluded.github_data,
                         github_state = excluded.github_state,
-                        autorepeat_remaining = " . ($shouldUpdateAutorepeat ? "excluded.autorepeat_remaining" : "tasks.autorepeat_remaining") . ",
+                        autorepeat_remaining = " . ($shouldUpdateAutorepeat ? "excluded.autorepeat_remaining" :
+                                                    ($conditionalAutorepeatUpdate ? "CASE WHEN tasks.autorepeat_remaining = 0 THEN excluded.autorepeat_remaining ELSE tasks.autorepeat_remaining END" : "tasks.autorepeat_remaining")) . ",
                         status = CASE
                             WHEN excluded.github_state = 'closed' THEN 'finished'
                             WHEN status = 'pending' THEN 'created'
@@ -501,7 +526,8 @@ class Task
                         body = VALUES(body),
                         github_data = VALUES(github_data),
                         github_state = VALUES(github_state),
-                        autorepeat_remaining = " . ($shouldUpdateAutorepeat ? "VALUES(autorepeat_remaining)" : "autorepeat_remaining") . ",
+                        autorepeat_remaining = " . ($shouldUpdateAutorepeat ? "VALUES(autorepeat_remaining)" :
+                                                    ($conditionalAutorepeatUpdate ? "CASE WHEN tasks.autorepeat_remaining = 0 THEN VALUES(autorepeat_remaining) ELSE tasks.autorepeat_remaining END" : "tasks.autorepeat_remaining")) . ",
                         status = CASE
                             WHEN VALUES(github_state) = 'closed' THEN 'finished'
                             WHEN status = 'pending' THEN 'created'

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -197,14 +197,12 @@ class WebhookHandler
         $task = $taskModel->findByIssueNumber($project['project_id'], $issue['number']);
 
         if (!$task) {
-            $task = [
-                'github_data' => json_encode($issue),
-                'status' => 'pending',
-                'agent_response' => ''
-            ];
+            // Ensure task exists in DB to have a task_id for atomic marking
+            $taskModel->upsert($project['user_id'], $project['project_id'], $issue);
+            $task = $taskModel->findByIssueNumber($project['project_id'], $issue['number']);
         }
 
-        if (!$taskModel->hasAutorepeatLabel($task)) {
+        if (!$task || !$taskModel->hasAutorepeatLabel($task)) {
             return;
         }
 
@@ -213,8 +211,8 @@ class WebhookHandler
             return;
         }
 
-        // Avoid double duplication using a marker in agent_response
-        if (strpos($task['agent_response'] ?? '', '<!-- autorepeat_triggered -->') !== false) {
+        // Atomic mark as triggered. If already marked, rowCount() will be 0 and it returns false.
+        if (!$taskModel->markAutorepeatTriggered((int)$task['task_id'])) {
             return;
         }
 
@@ -243,15 +241,6 @@ class WebhookHandler
         }
 
         if ($repo) {
-            // Mark as triggered BEFORE calling GitHub to minimize race condition window
-            if (isset($task['task_id'])) {
-                $taskModel->updateAgentResponse(
-                    $task['task_id'],
-                    ($task['agent_response'] ?? '') . "\n<!-- autorepeat_triggered -->",
-                    $task['status']
-                );
-            }
-
             $newIssue = $githubService->createIssue($repo, $issue['title'], $issue['body'] ?? null, array_values($labelNames));
 
             if (!empty($newIssue['number'])) {

--- a/test/Integration/AutorepeatRaceTest.php
+++ b/test/Integration/AutorepeatRaceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\Task;
+use App\WebhookHandler;
+use App\GitHubService;
+use App\Logger;
+use PDO;
+use Tests\TestDatabaseTrait;
+
+class AutorepeatRaceTest extends TestCase
+{
+    use TestDatabaseTrait;
+
+    private $db;
+    private $pdo;
+    private $githubService;
+
+    protected function setUp(): void
+    {
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        // Reset tables
+        $tables = ['task_logs', 'tasks', 'projects', 'users', 'user_github_accounts'];
+        foreach ($tables as $table) {
+            $this->pdo->exec("DROP TABLE IF EXISTS $table");
+        }
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
+
+        $this->pdo->exec("CREATE TABLE users (
+            user_id $pk,
+            name VARCHAR(255),
+            email VARCHAR(255) UNIQUE
+        )");
+
+        $this->pdo->exec("CREATE TABLE projects (
+            project_id $pk,
+            user_id INT NOT NULL,
+            github_repo VARCHAR(255) NOT NULL
+        )");
+
+        $this->pdo->exec("CREATE TABLE tasks (
+            task_id $pk,
+            user_id INT NOT NULL,
+            project_id INT NOT NULL,
+            issue_number INT NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            body TEXT,
+            status TEXT DEFAULT 'created',
+            github_state VARCHAR(20) DEFAULT 'open',
+            github_data TEXT,
+            autorepeat_remaining INT DEFAULT 0,
+            agent_response TEXT,
+            created_at $timestamp,
+            UNIQUE(project_id, issue_number)
+        )");
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        $this->githubService = $this->createMock(GitHubService::class);
+
+        Logger::resetInstance();
+        new Logger($this->db);
+    }
+
+    public function testMaybeDuplicateTaskIsAtomic()
+    {
+        // 1. Setup project and task
+        $this->pdo->exec("INSERT INTO users (user_id, name, email) VALUES (1, 'Test User', 'test@example.com')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+
+        $issueData = [
+            'number' => 101,
+            'title' => 'Race Condition Task',
+            'body' => 'Test body',
+            'state' => 'closed',
+            'state_reason' => 'completed',
+            'labels' => [['name' => 'autorepeat: 2'], ['name' => 'Jules']]
+        ];
+
+        $this->pdo->prepare("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, status, github_state, autorepeat_remaining, github_data)
+                          VALUES (1, 1, 1, 101, 'Race Condition Task', 'finished', 'closed', 2, ?)")
+                  ->execute([json_encode($issueData)]);
+
+        $webhookHandler = new WebhookHandler($this->db);
+        $project = ['project_id' => 1, 'user_id' => 1, 'github_repo' => 'owner/repo'];
+        $event = ['issue' => $issueData, 'repository' => ['full_name' => 'owner/repo']];
+
+        // 2. Expectation: createIssue should only be called ONCE despite multiple calls to maybeDuplicateTask
+        $this->githubService->expects($this->once())
+            ->method('createIssue')
+            ->willReturn(['number' => 102, 'title' => 'Race Condition Task', 'state' => 'open']);
+
+        // 3. Simultaneous-ish calls
+        $webhookHandler->maybeDuplicateTask($project, $event, $this->githubService);
+        $webhookHandler->maybeDuplicateTask($project, $event, $this->githubService);
+        $webhookHandler->maybeDuplicateTask($project, $event, $this->githubService);
+
+        // 4. Verification: Check that only one new task was created in DB
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM tasks WHERE issue_number = 102");
+        $this->assertEquals(1, $stmt->fetchColumn());
+
+        // Check that the marker is present
+        $stmt = $this->pdo->query("SELECT agent_response FROM tasks WHERE task_id = 1");
+        $this->assertStringContainsString('autorepeat_triggered', $stmt->fetchColumn());
+    }
+
+    public function testUpsertDoesNotResetAutorepeatCount()
+    {
+        $this->pdo->exec("INSERT INTO users (user_id, name, email) VALUES (1, 'Test User', 'test@example.com')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+
+        $taskModel = new Task($this->db);
+
+        // Initial creation with count = 3
+        $issue = [
+            'number' => 201,
+            'title' => 'Sync Test',
+            'state' => 'open',
+            'labels' => [['name' => 'autorepeat: 3']]
+        ];
+        $taskModel->upsert(1, 1, $issue);
+
+        $stmt = $this->pdo->query("SELECT autorepeat_remaining FROM tasks WHERE issue_number = 201");
+        $this->assertEquals(3, $stmt->fetchColumn());
+
+        // Simulate a webhook update with ONLY generic 'autorepeat' label
+        $issueUpdate = [
+            'number' => 201,
+            'title' => 'Sync Test',
+            'state' => 'open',
+            'labels' => [['name' => 'autorepeat']]
+        ];
+        $taskModel->upsert(1, 1, $issueUpdate);
+
+        // Should NOT reset to 5, should stay 3
+        $stmt = $this->pdo->query("SELECT autorepeat_remaining FROM tasks WHERE issue_number = 201");
+        $this->assertEquals(3, $stmt->fetchColumn());
+
+        // Simulate explicit update (e.g. from UI)
+        $taskModel->upsert(1, 1, $issueUpdate, 2);
+        $stmt = $this->pdo->query("SELECT autorepeat_remaining FROM tasks WHERE issue_number = 201");
+        $this->assertEquals(2, $stmt->fetchColumn());
+
+        // Final sanity check: if it was 0, generic label should set it to 5
+        $issueNew = [
+            'number' => 202,
+            'title' => 'New Task',
+            'state' => 'open',
+            'labels' => [['name' => 'autorepeat']]
+        ];
+        $taskModel->upsert(1, 1, $issueNew);
+        $stmt = $this->pdo->query("SELECT autorepeat_remaining FROM tasks WHERE issue_number = 202");
+        $this->assertEquals(5, $stmt->fetchColumn());
+    }
+}

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -81,6 +81,15 @@ class WebhookHandlerTest extends TestCase
 
         $stmt = $this->createMock(PDOStatement::class);
         $stmt->method('execute')->willReturn(true);
+        $stmt->method('rowCount')->willReturn(1);
+        $stmt->method('fetch')->willReturn([
+            'task_id' => 1,
+            'project_id' => 1,
+            'issue_number' => 123,
+            'github_data' => json_encode($event['issue']),
+            'autorepeat_remaining' => 0,
+            'agent_response' => ''
+        ]);
 
         $this->pdo->method('getAttribute')->with(PDO::ATTR_DRIVER_NAME)->willReturn('mysql');
         $this->pdo->method('prepare')->willReturn($stmt);


### PR DESCRIPTION
The issue where autorepeat tasks would spawn endless copies was caused by a race condition between concurrent GitHub webhooks (e.g., Pull Request merged and Issue closed). Both events would trigger the duplication logic nearly simultaneously. Since the system used a non-atomic "read-then-write" check for the duplication marker, both processes could find the marker missing and proceed to create new issues.

This PR implements a database-level atomic update (`markAutorepeatTriggered`) that appends the `<!-- autorepeat_triggered -->` marker only if it's not already present. This ensures that exactly one duplication occurs per task.

Additionally, the synchronization logic in `Task::upsert` was improved to protect the `autorepeat_remaining` count. Previously, a generic `autorepeat` label (without a count) would reset a countdown in progress (e.g., resetting 2 back to 5). The new logic only applies the default count if the current database value is zero.

Fixes #852

---
*PR created automatically by Jules for task [4035354525481190035](https://jules.google.com/task/4035354525481190035) started by @chatelao*