### PR TITLE
Fix SPA fallback routing for static assets

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -67,6 +67,18 @@ if (($_COOKIE['prefer_legacy'] ?? '') !== '1' && $nextGenExists) {
     // We should try to serve the Next-Gen UI index.html if it exists.
     // We avoid catching AJAX (.php) or assets.
     if ($isWebPath && strpos($requestUri, '.php') === false) {
+        // Extract the path relative to /web/ to check for physical file existence
+        $cleanPath = parse_url($requestUri, PHP_URL_PATH);
+
+        // If the path has an extension, it's likely a static asset (js, css, txt, etc.)
+        // If it reaches here (index.php), it means the web server didn't find it.
+        $extension = pathinfo($cleanPath, PATHINFO_EXTENSION);
+        if ($extension && !file_exists(__DIR__ . $cleanPath)) {
+            http_response_code(404);
+            echo "Asset not found: " . htmlspecialchars($cleanPath);
+            exit;
+        }
+
         $webIndex = __DIR__ . '/web/index.html';
         if (file_exists($webIndex)) {
             readfile($webIndex);


### PR DESCRIPTION
This PR fixes a bug in the Single Page Application (SPA) fallback routing within `src/frontend/index.php`. 

Previously, the "Next-Gen UI Safeguard" would catch any request under the `/web/` path that did not end in `.php` and serve the main `web/index.html` file. While this is correct for extensionless client-side routes, it is incorrect for missing static assets like `.js`, `.css`, or `.txt` files. In those cases, the browser receives HTML content but expects a different format, leading to fatal loading errors (e.g., "Unexpected token '<'").

The fix:
- Extracts the path from the requested URI.
- Checks if the path has a file extension.
- Verifies if the file exists on disk.
- If it has an extension and does not exist, it returns a 404 status code instead of falling back to the SPA HTML.

All existing unit and integration tests passed, and the fix was verified by a code review.

Fixes #844

---
*PR created automatically by Jules for task [16443227937058250755](https://jules.google.com/task/16443227937058250755) started by @chatelao*