### PR TITLE
Global Automation master switch

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -897,10 +897,11 @@ class Task
         $stmt->execute($params);
         $tasks = $stmt->fetchAll();
 
-        $userStmt = $this->db->getConnection()->prepare("SELECT jules_api_key, jules_quota_updated_at FROM users WHERE user_id = ?");
+        $userStmt = $this->db->getConnection()->prepare("SELECT jules_api_key, jules_quota_updated_at, automations_enabled FROM users WHERE user_id = ?");
         $userStmt->execute([$userId]);
         $user = $userStmt->fetch();
         $apiKey = $user['jules_api_key'] ?? null;
+        $automationsEnabled = (bool)($user['automations_enabled'] ?? true);
         $quotaUpdatedAt = $user['jules_quota_updated_at'] ?? null;
 
         // Fetch Jules quota if more than 60 minutes have passed since last update
@@ -919,7 +920,8 @@ class Task
             // If task is finished/closed but still has autorepeat cycles, trigger duplication if missed
             if (($task['autorepeat_remaining'] ?? 0) > 0 &&
                 ($task['github_state'] === 'closed' || $task['status'] === self::STATUS_FINISHED) &&
-                strpos($task['agent_response'] ?? '', '<!-- autorepeat_triggered -->') === false) {
+                strpos($task['agent_response'] ?? '', '<!-- autorepeat_triggered -->') === false &&
+                $automationsEnabled) {
 
                 $webhookHandler = new WebhookHandler($this->db);
                 $projectModel = new Project($this->db);
@@ -1090,7 +1092,7 @@ class Task
                         $message = "Task \"" . $task['title'] . "\" is ready to merge.";
 
                         // Automatic merge if autorepeat is active
-                        if (($task['autorepeat_remaining'] ?? 0) > 0) {
+                        if (($task['autorepeat_remaining'] ?? 0) > 0 && $automationsEnabled) {
                             $webhookHandler = new WebhookHandler($this->db);
                             $projectModel = new Project($this->db);
                             $project = $projectModel->findById($task['project_id']);
@@ -1132,7 +1134,7 @@ class Task
             } else {
                 // If status didn't change but it's READY, still check for auto-merge
                 // This covers cases where a previous auto-merge might have been skipped or failed.
-                if ($mappedStatus === self::STATUS_READY && ($task['autorepeat_remaining'] ?? 0) > 0) {
+                if ($mappedStatus === self::STATUS_READY && ($task['autorepeat_remaining'] ?? 0) > 0 && $automationsEnabled) {
                     $webhookHandler = new WebhookHandler($this->db);
                     $projectModel = new Project($this->db);
                     $project = $projectModel->findById($task['project_id']);

--- a/src/backend/User.php
+++ b/src/backend/User.php
@@ -259,4 +259,12 @@ class User
         );
         return $stmt->execute([$config, $userId]);
     }
+
+    public function updateAutomationsEnabled(int $userId, bool $enabled): bool
+    {
+        $stmt = $this->db->getConnection()->prepare(
+            "UPDATE users SET automations_enabled = ? WHERE user_id = ?"
+        );
+        return $stmt->execute([(int)$enabled, $userId]);
+    }
 }

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -126,7 +126,11 @@ class WebhookHandler
         }
 
         if ($result && $action === 'closed' && $githubService) {
-            $this->maybeDuplicateTask($project, $event, $githubService, $effectiveNotifService);
+            $userModel = new User($this->db);
+            $user = $userModel->findById($project['user_id']);
+            if ($user && ($user['automations_enabled'] ?? true)) {
+                $this->maybeDuplicateTask($project, $event, $githubService, $effectiveNotifService);
+            }
         }
 
         return $result;
@@ -327,8 +331,10 @@ class WebhookHandler
             if ($task && $task['issue_number']) {
                 $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService);
 
+                $userModel = new User($this->db);
+                $user = $userModel->findById($project['user_id']);
                 $githubData = json_decode($task['github_data'] ?? '{}', true);
-                if ($githubData) {
+                if ($githubData && ($user['automations_enabled'] ?? true)) {
                     // Normalize event for maybeDuplicateTask
                     $pseudoEvent = $event;
                     $pseudoEvent['issue'] = $githubData;
@@ -493,8 +499,12 @@ class WebhookHandler
                     $message = $newStatus === Task::STATUS_FAILED_PR ? "PR checks for \"" . $task['title'] . "\" failed." : "PR checks for \"" . $task['title'] . "\" are now passing.";
 
                     if ($newStatus === Task::STATUS_READY && ($task['autorepeat_remaining'] ?? 0) > 0 && $githubService) {
-                        $this->autoMergeAndDuplicate($project, array_merge($task, ['status' => $newStatus]), $githubService, $notificationService);
-                        $message .= " (Auto-merging...)";
+                        $userModel = new User($this->db);
+                        $user = $userModel->findById($project['user_id']);
+                        if ($user && ($user['automations_enabled'] ?? true)) {
+                            $this->autoMergeAndDuplicate($project, array_merge($task, ['status' => $newStatus]), $githubService, $notificationService);
+                            $message .= " (Auto-merging...)";
+                        }
                     }
 
                     $actions = [];
@@ -517,7 +527,11 @@ class WebhookHandler
             } elseif ($newStatus === Task::STATUS_READY && ($task['autorepeat_remaining'] ?? 0) > 0 && $githubService) {
                 // Even if status didn't change (still READY), attempt auto-merge if it's an autorepeat task
                 // This handles cases where a previous merge attempt might have failed but is now possible.
-                $this->autoMergeAndDuplicate($project, array_merge($task, ['status' => $newStatus]), $githubService, $notificationService);
+                $userModel = new User($this->db);
+                $user = $userModel->findById($project['user_id']);
+                if ($user && ($user['automations_enabled'] ?? true)) {
+                    $this->autoMergeAndDuplicate($project, array_merge($task, ['status' => $newStatus]), $githubService, $notificationService);
+                }
             }
 
             $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService);
@@ -565,6 +579,11 @@ class WebhookHandler
 
         $userModel = new User($this->db);
         $user = $userModel->findById($userId);
+
+        if ($user && !($user['automations_enabled'] ?? true)) {
+            Logger::getInstance($this->db)->log($userId, $taskId, "Blockly automations skipped: Automations are disabled in settings.", 'info');
+            return;
+        }
 
         $blocklyEvent = $overrideEvent ?: $this->mapToBlocklyEvent($githubEvent, $event);
         $eventContext = [

--- a/src/frontend/api/user.php
+++ b/src/frontend/api/user.php
@@ -49,6 +49,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $userModel->updateBlocklyConfig($userId, $input['blockly_config']);
     }
 
+    if (isset($input['automations_enabled'])) {
+        $userModel->updateAutomationsEnabled($userId, (bool)$input['automations_enabled']);
+    }
+
     if (isset($input['telegram_bot_name']) || isset($input['telegram_bot_token']) || isset($input['telegram_webhook_secret'])) {
         $user = $userModel->findById($userId);
         $newBotToken = $input['telegram_bot_token'] ?? $user['telegram_bot_token'] ?? '';
@@ -115,6 +119,7 @@ $output = [
     'telegram_webhook_secret' => !empty($user['telegram_webhook_secret']) ? '********' : null,
     'telegram_chat_id' => $userModel->getTelegramChatId($userId),
     'has_jules_key' => !empty($user['jules_api_key']),
+    'automations_enabled' => (bool)($user['automations_enabled'] ?? true),
     'jules_quota_usage' => isset($user['jules_quota_usage']) ? (int)$user['jules_quota_usage'] : null,
     'jules_quota_limit' => isset($user['jules_quota_limit']) ? (int)$user['jules_quota_limit'] : null,
     'blockly_config' => !empty($user['blockly_config']) ? json_decode($user['blockly_config'], true) : null,

--- a/src/sql/patches/020_add_automations_enabled_to_users.sql
+++ b/src/sql/patches/020_add_automations_enabled_to_users.sql
@@ -1,0 +1,2 @@
+-- Add automations_enabled column to users table
+ALTER TABLE users ADD COLUMN automations_enabled BOOLEAN DEFAULT TRUE;

--- a/test/Integration/BlocklyWorkflowPhase6Test.php
+++ b/test/Integration/BlocklyWorkflowPhase6Test.php
@@ -53,7 +53,8 @@ class BlocklyWorkflowPhase6Test extends TestCase
             jules_api_key VARCHAR(255),
             jules_quota_usage INT DEFAULT 0,
             jules_quota_limit INT DEFAULT 0,
-            jules_quota_updated_at DATETIME
+            jules_quota_updated_at DATETIME,
+            automations_enabled BOOLEAN DEFAULT 1
         )");
 
         $this->pdo->exec("CREATE TABLE user_github_accounts (

--- a/test/Integration/CronAutorepeatTest.php
+++ b/test/Integration/CronAutorepeatTest.php
@@ -47,7 +47,8 @@ class CronAutorepeatTest extends TestCase
             jules_api_key VARCHAR(255),
             jules_quota_usage INT DEFAULT 0,
             jules_quota_limit INT DEFAULT 0,
-            jules_quota_updated_at DATETIME
+            jules_quota_updated_at DATETIME,
+            automations_enabled BOOLEAN DEFAULT 1
         )");
 
         $this->pdo->exec("CREATE TABLE projects (

--- a/test/Integration/NotificationTriggerTest.php
+++ b/test/Integration/NotificationTriggerTest.php
@@ -62,7 +62,8 @@ class NotificationTriggerTest extends TestCase
             telegram_bot_token VARCHAR(255),
             jules_quota_usage INT DEFAULT 0,
             jules_quota_limit INT DEFAULT 0,
-            jules_quota_updated_at DATETIME
+            jules_quota_updated_at DATETIME,
+            automations_enabled BOOLEAN DEFAULT 1
         )");
 
         $this->pdo->exec("CREATE TABLE user_telegram_accounts (

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -18,6 +18,12 @@ class WebhookHandlerTest extends TestCase
         $this->pdo = new PDO('sqlite::memory:');
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
+        $this->pdo->exec("CREATE TABLE users (
+            user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name VARCHAR(255),
+            automations_enabled BOOLEAN DEFAULT 1
+        )");
+
         $this->pdo->exec("CREATE TABLE projects (
             project_id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INT NOT NULL,
@@ -60,6 +66,7 @@ class WebhookHandlerTest extends TestCase
     public function testHandleIssueOpened()
     {
         $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $this->pdo->exec("INSERT INTO users (user_id, name) VALUES (1, 'Test User')");
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
 
         $event = [
@@ -90,6 +97,7 @@ class WebhookHandlerTest extends TestCase
     public function testHandleAutorepeat()
     {
         $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $this->pdo->exec("INSERT INTO users (user_id, name) VALUES (1, 'Test User')");
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
 
         $event = [
@@ -123,6 +131,7 @@ class WebhookHandlerTest extends TestCase
     {
         // Simulate human-triggered merge (sender.type === 'User')
         $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $this->pdo->exec("INSERT INTO users (user_id, name) VALUES (1, 'Test User')");
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
 
         $prUrl = 'https://github.com/owner/repo/pull/123';
@@ -166,6 +175,7 @@ class WebhookHandlerTest extends TestCase
     public function testHandleCheckSuiteInProgress()
     {
         $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $this->pdo->exec("INSERT INTO users (user_id, name) VALUES (1, 'Test User')");
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
 
         $prUrl = 'https://github.com/owner/repo/pull/123';

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -326,18 +326,42 @@ export default function SettingsPage() {
         {activeTab === 'automation' && (
           <div className="space-y-6">
             <section className="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">Global Automation (Experimental)</h3>
-              <p className="text-sm text-gray-500 mb-6">
-                Define global workflows that apply to all your projects using Blockly.
-                These scripts are executed when events occur in any of your linked repositories.
-              </p>
+              <div className="flex items-center justify-between mb-6">
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900">Enable Automations</h3>
+                  <p className="text-sm text-gray-500">
+                    Master switch for all automated actions, including Auto-Repeat, Auto-Merge, and Blockly scripts.
+                  </p>
+                </div>
+                <button
+                  onClick={() => updateUser.mutate({ automations_enabled: !user?.automations_enabled })}
+                  disabled={updateUser.isPending}
+                  className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ring-offset-2 focus:ring-2 focus:ring-blue-500 ${
+                    user?.automations_enabled ? 'bg-blue-600' : 'bg-gray-200'
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                      user?.automations_enabled ? 'translate-x-5' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+              </div>
 
-              <BlocklyEditor
-                initialXml={user?.blockly_config?.xml}
-                onSave={(config) => {
-                  updateUser.mutate({ blockly_config: config });
-                }}
-              />
+              <div className={`transition-opacity duration-200 ${!user?.automations_enabled ? 'opacity-50 pointer-events-none' : 'opacity-100'}`}>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">Global Automation (Experimental)</h3>
+                <p className="text-sm text-gray-500 mb-6">
+                  Define global workflows that apply to all your projects using Blockly.
+                  These scripts are executed when events occur in any of your linked repositories.
+                </p>
+
+                <BlocklyEditor
+                  initialXml={user?.blockly_config?.xml}
+                  onSave={(config) => {
+                    updateUser.mutate({ blockly_config: config });
+                  }}
+                />
+              </div>
             </section>
           </div>
         )}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1967,6 +1967,8 @@ export interface components {
             jules_api_key?: string | null;
             /** @example true */
             has_jules_key?: boolean;
+            /** @example true */
+            automations_enabled?: boolean;
             /** @example 150 */
             jules_quota_usage?: number | null;
             /** @example 1000 */


### PR DESCRIPTION
This PR implements a global master switch for all automated features. Users can now disable all automations (including auto-repeat, auto-merge, and Blockly scripts) via a new toggle on the Automation tab of the account settings page. This provides an easy way to pause all background agent activity without deleting specific configurations.

Key changes:
- Database: New `automations_enabled` column in `users` table.
- Backend: Logic guards in `WebhookHandler.php` and `Task.php` to respect the user setting.
- Frontend: New master toggle in Settings page; Blockly editor is dimmed/disabled when automations are inactive.

Fixes #858

---
*PR created automatically by Jules for task [5339900687136322776](https://jules.google.com/task/5339900687136322776) started by @chatelao*