### PR TITLE
Fix "Asset not found" error after login

### DIFF
--- a/src/frontend/index.php
+++ b/src/frontend/index.php
@@ -72,8 +72,10 @@ if (($_COOKIE['prefer_legacy'] ?? '') !== '1' && $nextGenExists) {
 
         // If the path has an extension, it's likely a static asset (js, css, txt, etc.)
         // If it reaches here (index.php), it means the web server didn't find it.
+        // We ensure it's not a route by checking for a trailing slash (Next.js trailingSlash: true).
         $extension = pathinfo($cleanPath, PATHINFO_EXTENSION);
-        if ($extension && !file_exists(__DIR__ . $cleanPath)) {
+        $isTrailingSlash = (substr($cleanPath, -1) === '/');
+        if ($extension && !$isTrailingSlash && !file_exists(__DIR__ . $cleanPath)) {
             http_response_code(404);
             echo "Asset not found: " . htmlspecialchars($cleanPath);
             exit;


### PR DESCRIPTION
This PR fixes an issue where users would see an "Asset not found" error when navigating to certain Next-Gen UI routes (like `/web/projects/`) after logging in. The issue was caused by a too-aggressive safeguard in the PHP entry point that misidentified these routes as missing static assets. The fix ensures that any path ending in a trailing slash is treated as a route and allowed to fall back to the React SPA's `index.html`.

Fixes #860

---
*PR created automatically by Jules for task [4636808662010916358](https://jules.google.com/task/4636808662010916358) started by @chatelao*