### PR TITLE
Telegram Notification Settings Management

### DIFF
--- a/CHAT_ROADMAP.md
+++ b/CHAT_ROADMAP.md
@@ -14,6 +14,8 @@
 | 8 | Advanced Interactions | ✅ |
 | 9 | Interactive Task Management | ✅ |
 | 10 | Enhanced Navigation & Contextual Actions | ✅ |
+| 11 | Notification Settings Management | ✅ |
+| 12 | Pagination & Search | ⏳ |
 
 ## Goals
 
@@ -82,3 +84,12 @@
 - [x] Enhance `/projects` with inline buttons for task filtering.
 - [x] Support project-based filtering in `/tasks`.
 - [x] Implement `refresh_task:{taskId}` action to force a status sync.
+
+## Phase 11: Notification Settings Management
+- [x] Implement `/settings` command to view current channel preferences.
+- [x] Add inline buttons to toggle notification channels (Telegram, In-App, Browser).
+- [x] Update `handleCallback` to process toggle actions and refresh settings view.
+
+## Phase 12: Pagination & Search
+- [ ] Implement pagination for `/tasks` list (Next/Prev buttons).
+- [ ] Implement `/search` command for finding tasks.

--- a/src/backend/TelegramWebhookHandler.php
+++ b/src/backend/TelegramWebhookHandler.php
@@ -72,6 +72,10 @@ class TelegramWebhookHandler
             return $this->handleTasks($chatId);
         }
 
+        if ($text === '/settings') {
+            return $this->handleSettings($chatId);
+        }
+
         if ($text === '/help') {
             return $this->handleHelp($chatId);
         }
@@ -85,6 +89,7 @@ class TelegramWebhookHandler
         $helpText .= "/status - Get a summary of task counts.\n";
         $helpText .= "/projects - List your active projects.\n";
         $helpText .= "/tasks - List active tasks with details.\n";
+        $helpText .= "/settings - Manage notification preferences.\n";
         $helpText .= "/cleanup - Remove read notifications from the chat.\n";
         $helpText .= "/help - Show this help message.";
 
@@ -120,6 +125,34 @@ class TelegramWebhookHandler
         $this->telegramService->sendMessage($chatId, $text, [
             'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
         ]);
+        return true;
+    }
+
+    private function handleToggleSetting(string $callbackId, int $chatId, string $channel, ?int $messageId): bool
+    {
+        $user = $this->userModel->findByTelegramChatId($chatId);
+        if (!$user) {
+            $this->telegramService->answerCallbackQuery($callbackId, [
+                'text' => "Unauthorized.",
+                'show_alert' => true
+            ]);
+            return false;
+        }
+
+        $notificationService = new NotificationService($this->userModel->getDb());
+        $settings = $notificationService->getUserSettings((int)$user['user_id']);
+
+        $newValue = !($settings[$channel] ?? false);
+        $notificationService->updateUserSettings((int)$user['user_id'], [$channel => $newValue]);
+
+        $this->telegramService->answerCallbackQuery($callbackId, [
+            'text' => "Setting updated."
+        ]);
+
+        if ($messageId) {
+            $this->handleSettings($chatId, $messageId);
+        }
+
         return true;
     }
 
@@ -166,6 +199,49 @@ class TelegramWebhookHandler
         $this->telegramService->sendMessage($chatId, $text, [
             'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
         ]);
+        return true;
+    }
+
+    private function handleSettings(int $chatId, ?int $editMessageId = null): bool
+    {
+        $user = $this->userModel->findByTelegramChatId($chatId);
+        if (!$user) {
+            if (!$editMessageId) {
+                $this->telegramService->sendMessage($chatId, "Unauthorized. Please link your account.");
+            }
+            return true;
+        }
+
+        $notificationService = new NotificationService($this->userModel->getDb());
+        $settings = $notificationService->getUserSettings((int)$user['user_id']);
+
+        $text = "<b>Notification Settings:</b>\n\nToggle channels to enable/disable notifications:";
+        $inlineKeyboard = [];
+
+        $channels = [
+            'telegram' => 'Telegram',
+            'in_app' => 'In-App Inbox',
+            'browser' => 'Browser'
+        ];
+
+        foreach ($channels as $key => $label) {
+            $enabled = $settings[$key] ?? false;
+            $statusEmoji = $enabled ? "✅" : "❌";
+            $inlineKeyboard[] = [[
+                'text' => "$label: $statusEmoji",
+                'callback_data' => "toggle_setting:$key"
+            ]];
+        }
+
+        if ($editMessageId) {
+            $this->telegramService->editMessageText($chatId, $editMessageId, $text, [
+                'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
+            ]);
+        } else {
+            $this->telegramService->sendMessage($chatId, $text, [
+                'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
+            ]);
+        }
         return true;
     }
 
@@ -227,6 +303,11 @@ class TelegramWebhookHandler
         if ($action === 'list_tasks') {
             $this->telegramService->answerCallbackQuery($callbackId);
             return $this->handleTasks($chatId, $targetId ?: null);
+        }
+
+        if ($action === 'toggle_setting') {
+            $channel = $parts[1] ?? '';
+            return $this->handleToggleSetting($callbackId, $chatId, $channel, $callbackQuery['message']['message_id'] ?? null);
         }
 
         if (!$targetId || !in_array($action, ['retry', 'restart', 'merge', 'acknowledge', 'approve_plan', 'fix_bug', 'view_task', 'refresh_task'])) {

--- a/src/backend/TelegramWebhookHandler.php
+++ b/src/backend/TelegramWebhookHandler.php
@@ -28,6 +28,31 @@ class TelegramWebhookHandler
         return !empty($this->webhookSecret) && hash_equals($this->webhookSecret, $providedSecret);
     }
 
+    protected function getTaskModel(): Task
+    {
+        return new Task($this->userModel->getDb());
+    }
+
+    protected function getProjectModel(): Project
+    {
+        return new Project($this->userModel->getDb());
+    }
+
+    protected function getNotificationService(): NotificationService
+    {
+        return new NotificationService($this->userModel->getDb());
+    }
+
+    protected function getJulesService(?string $apiKey = null): JulesService
+    {
+        return new JulesService(null, $apiKey);
+    }
+
+    protected function getProjectGitHubService(string $token): GitHubService
+    {
+        return new GitHubService(null, $token);
+    }
+
     public function handle(array $update): bool
     {
         if (isset($update['callback_query'])) {
@@ -105,7 +130,7 @@ class TelegramWebhookHandler
             return true;
         }
 
-        $projectModel = new Project($this->userModel->getDb());
+        $projectModel = $this->getProjectModel();
         $projects = $projectModel->findByUserId((int)$user['user_id']);
 
         if (empty($projects)) {
@@ -139,7 +164,7 @@ class TelegramWebhookHandler
             return false;
         }
 
-        $notificationService = new NotificationService($this->userModel->getDb());
+        $notificationService = $this->getNotificationService();
         $settings = $notificationService->getUserSettings((int)$user['user_id']);
 
         $newValue = !($settings[$channel] ?? false);
@@ -164,10 +189,10 @@ class TelegramWebhookHandler
             return true;
         }
 
-        $taskModel = new Task($this->userModel->getDb());
+        $taskModel = $this->getTaskModel();
         if ($projectId) {
             $tasks = $taskModel->findActiveByProjectId($projectId);
-            $projectModel = new Project($this->userModel->getDb());
+            $projectModel = $this->getProjectModel();
             $project = $projectModel->findById($projectId);
             $repoName = $project['github_repo'] ?? 'Project';
             $text = "<b>Active Tasks for $repoName:</b>\n\n";
@@ -212,7 +237,7 @@ class TelegramWebhookHandler
             return true;
         }
 
-        $notificationService = new NotificationService($this->userModel->getDb());
+        $notificationService = $this->getNotificationService();
         $settings = $notificationService->getUserSettings((int)$user['user_id']);
 
         $text = "<b>Notification Settings:</b>\n\nToggle channels to enable/disable notifications:";
@@ -253,7 +278,7 @@ class TelegramWebhookHandler
             return true;
         }
 
-        $taskModel = new Task($this->userModel->getDb());
+        $taskModel = $this->getTaskModel();
         $counts = $taskModel->getTaskCounts((int)$user['user_id']);
 
         $text = "<b>Task Status Summary</b>\n\n";
@@ -319,7 +344,7 @@ class TelegramWebhookHandler
         }
 
         // 3. Verify project permissions
-        $taskModel = new Task($this->userModel->getDb());
+        $taskModel = $this->getTaskModel();
         $taskId = $targetId;
         $task = $taskModel->findById($taskId);
 
@@ -341,12 +366,12 @@ class TelegramWebhookHandler
         }
 
         if ($notificationId) {
-            $notificationService = new NotificationService($this->userModel->getDb());
+            $notificationService = $this->getNotificationService();
             $notificationService->markAsRead($notificationId, false);
         }
 
         try {
-            $projectModel = new Project($this->userModel->getDb());
+            $projectModel = $this->getProjectModel();
             $project = $projectModel->findById($task['project_id']);
             if (!$project || !$project['github_token']) {
                 throw new \Exception("Project or GitHub token not found.");
@@ -418,9 +443,9 @@ class TelegramWebhookHandler
             } elseif ($action === 'acknowledge') {
                 $statusText = "✅ Acknowledged.";
             } elseif ($action === 'refresh_task') {
-                $julesService = new JulesService(null, $user['jules_api_key'] ?? null);
-                $notificationService = new NotificationService($this->userModel->getDb());
-                $projectGhs = new GitHubService(null, $project['github_token']);
+                $julesService = $this->getJulesService($user['jules_api_key'] ?? null);
+                $notificationService = $this->getNotificationService();
+                $projectGhs = $this->getProjectGitHubService($project['github_token']);
                 $taskModel->refreshJulesStatus((int)$user['user_id'], $projectGhs, $julesService, $notificationService, $taskId);
                 $statusText = "🔄 Status refreshed for Issue #$issueNumber.";
             } else {
@@ -450,7 +475,7 @@ class TelegramWebhookHandler
             return true;
         }
 
-        $notificationService = new NotificationService($this->userModel->getDb());
+        $notificationService = $this->getNotificationService();
         $notificationService->cleanupReadNotifications((int)$user['user_id']);
 
         $this->telegramService->sendMessage($chatId, "✅ Cleanup complete. Read notifications have been removed from Telegram.");

--- a/test/Integration/TelegramWebhookHandlerIntegrationTest.php
+++ b/test/Integration/TelegramWebhookHandlerIntegrationTest.php
@@ -9,6 +9,10 @@ use App\User;
 use App\TelegramService;
 use App\GitHubService;
 use App\Database;
+use App\Task;
+use App\Project;
+use App\JulesService;
+use App\NotificationService;
 use PDO;
 
 class TelegramWebhookHandlerIntegrationTest extends TestCase
@@ -34,13 +38,15 @@ class TelegramWebhookHandlerIntegrationTest extends TestCase
         $this->pdo->exec("DROP TABLE IF EXISTS user_github_accounts");
         $this->pdo->exec("DROP TABLE IF EXISTS notifications");
         $this->pdo->exec("DROP TABLE IF EXISTS users");
+        $this->pdo->exec("DROP TABLE IF EXISTS performance_logs");
 
         $this->pdo->exec("CREATE TABLE users (user_id $pk, email VARCHAR(255), telegram_bot_token VARCHAR(255), jules_api_key VARCHAR(255), jules_quota_updated_at TIMESTAMP NULL)");
         $this->pdo->exec("CREATE TABLE notifications (notification_id $pk, user_id INT, project_id INT, type VARCHAR(50), title VARCHAR(255), message TEXT, data TEXT, is_read TINYINT DEFAULT 0, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
         $this->pdo->exec("CREATE TABLE user_github_accounts (github_account_id $pk, user_id INT, github_username VARCHAR(255), github_token VARCHAR(255))");
         $this->pdo->exec("CREATE TABLE projects (project_id $pk, user_id INT, github_account_id INT, github_repo VARCHAR(255), github_token VARCHAR(255), created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
-        $this->pdo->exec("CREATE TABLE tasks (task_id $pk, user_id INT, project_id INT, issue_number INT, title VARCHAR(255), body TEXT, pr_url VARCHAR(255), jules_url VARCHAR(255), jules_status VARCHAR(50), status VARCHAR(50), github_state VARCHAR(50), jules_session_id VARCHAR(255), last_synced_at TIMESTAMP NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, github_data TEXT, autorepeat_remaining INT DEFAULT 0)");
+        $this->pdo->exec("CREATE TABLE tasks (task_id $pk, user_id INT, project_id INT, issue_number INT, title VARCHAR(255), body TEXT, pr_url VARCHAR(255), jules_url VARCHAR(255), jules_status VARCHAR(50), status VARCHAR(50), github_state VARCHAR(50), jules_session_id VARCHAR(255), last_synced_at TIMESTAMP NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, github_data TEXT, autorepeat_remaining INT DEFAULT 0, agent_response TEXT)");
         $this->pdo->exec("CREATE TABLE user_telegram_accounts (telegram_account_id $pk, user_id INT, telegram_chat_id BIGINT UNIQUE)");
+        $this->pdo->exec("CREATE TABLE performance_logs (log_id $pk, user_id INT, service VARCHAR(50), target VARCHAR(255), duration FLOAT, context TEXT, status_code INT, error_message TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
 
         $this->db = $this->createMock(Database::class);
         $this->db->method('getConnection')->willReturn($this->pdo);
@@ -502,9 +508,40 @@ class TelegramWebhookHandlerIntegrationTest extends TestCase
             ]
         ];
 
-        // We expect refreshJulesStatus to be called, which will trigger GitHub and Jules API calls.
-        // For this unit-ish integration test, we mainly check if it processes without crashing.
-        // It's hard to mock all dependencies since handleCallback creates new instances.
+        // Mock dependencies to avoid real network calls
+        $mockTask = $this->createMock(Task::class);
+        $mockTask->method('findById')->willReturn([
+            'task_id' => 20,
+            'user_id' => 1,
+            'project_id' => 1,
+            'issue_number' => 110,
+            'title' => 'Refresh Task'
+        ]);
+
+        $mockTask->expects($this->once())
+            ->method('refreshJulesStatus');
+
+        $mockJules = $this->createMock(JulesService::class);
+        $mockNotif = $this->createMock(NotificationService::class);
+        $mockGh = $this->createMock(GitHubService::class);
+
+        $handler = new class($this->userModel, $this->telegramService, $this->githubService, 'secret', $mockTask, $mockJules, $mockNotif, $mockGh) extends TelegramWebhookHandler {
+            public function __construct($userModel, $telegramService, $githubService, $webhookSecret, private $mockTask, private $mockJules, private $mockNotif, private $mockGh) {
+                parent::__construct($userModel, $telegramService, $githubService, $webhookSecret);
+            }
+            protected function getTaskModel(): Task {
+                return $this->mockTask;
+            }
+            protected function getJulesService(?string $apiKey = null): JulesService {
+                return $this->mockJules;
+            }
+            protected function getNotificationService(): NotificationService {
+                return $this->mockNotif;
+            }
+            protected function getProjectGitHubService(string $token): GitHubService {
+                return $this->mockGh;
+            }
+        };
 
         $this->telegramService->expects($this->once())
             ->method('answerCallbackQuery');
@@ -513,6 +550,6 @@ class TelegramWebhookHandlerIntegrationTest extends TestCase
             ->method('editMessageText')
             ->with(123, 465, $this->stringContains('🔄 Status refreshed'));
 
-        $this->assertTrue($this->handler->handle($update));
+        $this->assertTrue($handler->handle($update));
     }
 }

--- a/test/Unit/Services/TelegramSettingsTest.php
+++ b/test/Unit/Services/TelegramSettingsTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use PHPUnit\Framework\TestCase;
+use App\TelegramWebhookHandler;
+use App\User;
+use App\TelegramService;
+use App\NotificationService;
+use App\Database;
+use PDO;
+use PDOStatement;
+
+class TelegramSettingsTest extends TestCase
+{
+    private $userModel;
+    private $telegramService;
+    private $handler;
+    private $db;
+    private $pdo;
+
+    protected function setUp(): void
+    {
+        $this->userModel = $this->createMock(User::class);
+        $this->telegramService = $this->createMock(TelegramService::class);
+        $githubService = $this->createMock(\App\GitHubService::class);
+        $this->db = $this->createMock(Database::class);
+        $this->pdo = $this->createMock(PDO::class);
+
+        $this->db->method('getConnection')->willReturn($this->pdo);
+        $this->userModel->method('getDb')->willReturn($this->db);
+
+        $this->handler = new TelegramWebhookHandler($this->userModel, $this->telegramService, $githubService, 'secret');
+    }
+
+    public function testHandleSettingsCommand()
+    {
+        $chatId = 12345;
+        $userId = 1;
+
+        $this->userModel->expects($this->once())
+            ->method('findByTelegramChatId')
+            ->with($chatId)
+            ->willReturn(['user_id' => $userId]);
+
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->method('execute')->willReturn(true);
+        $stmt->method('fetchAll')->willReturn([]);
+
+        $this->pdo->method('prepare')->willReturn($stmt);
+
+        $this->telegramService->expects($this->once())
+            ->method('sendMessage')
+            ->with(
+                $chatId,
+                $this->stringContains('Notification Settings'),
+                $this->callback(function($params) {
+                    $keyboard = $params['reply_markup']['inline_keyboard'];
+                    $foundTelegram = false;
+                    foreach ($keyboard as $row) {
+                        if ($row[0]['callback_data'] === 'toggle_setting:telegram') {
+                            $foundTelegram = true;
+                        }
+                    }
+                    return $foundTelegram;
+                })
+            );
+
+        $update = [
+            'message' => [
+                'chat' => ['id' => $chatId],
+                'text' => '/settings'
+            ]
+        ];
+
+        $this->assertTrue($this->handler->handle($update));
+    }
+
+    public function testHandleToggleSettingCallback()
+    {
+        $chatId = 12345;
+        $userId = 1;
+        $callbackId = 'cb123';
+        $messageId = 6789;
+
+        $this->userModel->expects($this->atLeastOnce())
+            ->method('findByTelegramChatId')
+            ->with($chatId)
+            ->willReturn(['user_id' => $userId]);
+
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->method('execute')->willReturn(true);
+        $stmt->method('fetchAll')->willReturn([]);
+
+        $this->pdo->method('prepare')->willReturn($stmt);
+        $this->pdo->method('getAttribute')->willReturn('sqlite');
+        $this->pdo->method('beginTransaction')->willReturn(true);
+        $this->pdo->method('commit')->willReturn(true);
+
+        $this->telegramService->expects($this->once())
+            ->method('answerCallbackQuery')
+            ->with($callbackId, $this->callback(function($params) {
+                return isset($params['text']) && str_contains($params['text'], 'Setting updated');
+            }));
+
+        $this->telegramService->expects($this->once())
+            ->method('editMessageText')
+            ->with($chatId, $messageId, $this->stringContains('Notification Settings'));
+
+        $update = [
+            'callback_query' => [
+                'id' => $callbackId,
+                'data' => 'toggle_setting:telegram',
+                'message' => [
+                    'chat' => ['id' => $chatId],
+                    'message_id' => $messageId,
+                    'text' => 'Some old text'
+                ]
+            ]
+        ];
+
+        $this->assertTrue($this->handler->handle($update));
+    }
+}


### PR DESCRIPTION
This change implements Phase 11 of the Telegram Chat Control roadmap, allowing users to manage their notification channel settings directly from the Telegram bot.

Key changes:
1. **New `/settings` Command**: Users can now type `/settings` to see their current notification preferences for Telegram, In-App Inbox, and Browser channels.
2. **Interactive Toggles**: Each channel is displayed with a button (e.g., "Telegram: ✅") that toggles the setting when tapped. The message updates in-place for a seamless experience.
3. **Roadmap Expansion**: Added Phase 11 (Notification Settings Management) and Phase 12 (Pagination & Search) to `CHAT_ROADMAP.md`. Phase 11 is marked as completed.
4. **Testing**: Added comprehensive unit tests in `test/Unit/Services/TelegramSettingsTest.php` to verify the command handling and callback logic.

These enhancements improve user autonomy and reduce the need to visit the web dashboard for basic configuration.

Fixes #862

---
*PR created automatically by Jules for task [18341968121801096085](https://jules.google.com/task/18341968121801096085) started by @chatelao*