### PR TITLE
Telegram Bot: Pagination and Search Implementation

### DIFF
--- a/CHAT_ROADMAP.md
+++ b/CHAT_ROADMAP.md
@@ -15,7 +15,7 @@
 | 9 | Interactive Task Management | ✅ |
 | 10 | Enhanced Navigation & Contextual Actions | ✅ |
 | 11 | Notification Settings Management | ✅ |
-| 12 | Pagination & Search | ⏳ |
+| 12 | Pagination & Search | ✅ |
 
 ## Goals
 
@@ -91,5 +91,5 @@
 - [x] Update `handleCallback` to process toggle actions and refresh settings view.
 
 ## Phase 12: Pagination & Search
-- [ ] Implement pagination for `/tasks` list (Next/Prev buttons).
-- [ ] Implement `/search` command for finding tasks.
+- [x] Implement pagination for `/tasks` list (Next/Prev buttons).
+- [x] Implement `/search` command for finding tasks.

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -211,6 +211,40 @@ class Task
         return $this->findByUserProjects($userId, false);
     }
 
+    public function findActiveBySearch(int $userId, string $query): array
+    {
+        $sql = "SELECT t.*, p.github_repo
+             FROM tasks t
+             JOIN projects p ON t.project_id = p.project_id
+             WHERE p.user_id = ?
+             AND t.issue_number > 0 AND t.title != ''";
+
+        $params = [$userId];
+
+        $sql .= " AND (t.title LIKE ? OR t.body LIKE ? OR t.issue_number = ?)";
+        $params[] = '%' . $query . '%';
+        $params[] = '%' . $query . '%';
+        $params[] = is_numeric($query) ? (int)$query : -1;
+
+        $sql .= " AND (t.github_state = 'open' OR (
+            t.github_state = 'closed' AND t.status IN ('" . self::STATUS_FINISHED . "', 'completed')
+            AND (
+                SELECT COUNT(*) FROM tasks t3
+                WHERE t3.user_id = ?
+                AND t3.github_state = 'closed'
+                AND t3.status IN ('" . self::STATUS_FINISHED . "', 'completed')
+                AND (t3.created_at > t.created_at OR (t3.created_at = t.created_at AND t3.task_id > t.task_id))
+            ) < 3
+        ))";
+        $params[] = $userId;
+
+        $sql .= " ORDER BY t.created_at DESC";
+
+        $stmt = $this->db->getConnection()->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchAll();
+    }
+
     public function getTaskCounts(int $userId): array
     {
         $sql = "SELECT

--- a/src/backend/TelegramWebhookHandler.php
+++ b/src/backend/TelegramWebhookHandler.php
@@ -97,6 +97,11 @@ class TelegramWebhookHandler
             return $this->handleTasks($chatId);
         }
 
+        if (str_starts_with($text, '/search ')) {
+            $query = trim(substr($text, 8));
+            return $this->handleSearch($chatId, $query);
+        }
+
         if ($text === '/settings') {
             return $this->handleSettings($chatId);
         }
@@ -115,6 +120,7 @@ class TelegramWebhookHandler
         $helpText .= "/projects - List your active projects.\n";
         $helpText .= "/tasks - List active tasks with details.\n";
         $helpText .= "/settings - Manage notification preferences.\n";
+        $helpText .= "/search &lt;query&gt; - Search for active tasks.\n";
         $helpText .= "/cleanup - Remove read notifications from the chat.\n";
         $helpText .= "/help - Show this help message.";
 
@@ -181,13 +187,93 @@ class TelegramWebhookHandler
         return true;
     }
 
-    private function handleTasks(int $chatId, ?int $projectId = null): bool
+    private function handleSearch(int $chatId, string $query, int $page = 1, ?int $editMessageId = null): bool
     {
         $user = $this->userModel->findByTelegramChatId($chatId);
         if (!$user) {
-            $this->telegramService->sendMessage($chatId, "Unauthorized. Please link your account.");
+            if (!$editMessageId) {
+                $this->telegramService->sendMessage($chatId, "Unauthorized. Please link your account.");
+            }
             return true;
         }
+
+        $pageSize = 10;
+        $offset = ($page - 1) * $pageSize;
+
+        $taskModel = $this->getTaskModel();
+        $tasks = $taskModel->findActiveBySearch((int)$user['user_id'], $query);
+
+        if (empty($tasks)) {
+            $msg = "No active tasks found matching \"$query\".";
+            if ($editMessageId) {
+                $this->telegramService->editMessageText($chatId, $editMessageId, $msg);
+            } else {
+                $this->telegramService->sendMessage($chatId, $msg);
+            }
+            return true;
+        }
+
+        $totalTasks = count($tasks);
+        $tasksPage = array_slice($tasks, $offset, $pageSize);
+
+        $text = "<b>Search Results for \"$query\":</b>\n\n";
+        $inlineKeyboard = [];
+        foreach ($tasksPage as $task) {
+            $statusEmoji = $taskModel->getStatusEmoji($task['status']);
+            $text .= "$statusEmoji <b>#" . $task['issue_number'] . "</b>: " . htmlspecialchars($task['title']) . "\n";
+
+            $inlineKeyboard[] = [[
+                'text' => "#" . $task['issue_number'] . " Actions",
+                'callback_data' => "view_task:" . $task['task_id']
+            ]];
+        }
+
+        $navButtons = [];
+        if ($page > 1) {
+            $navButtons[] = [
+                'text' => "⬅️ Previous",
+                'callback_data' => "search_tasks:" . $query . ":" . ($page - 1)
+            ];
+        }
+        if ($totalTasks > $offset + $pageSize) {
+            $navButtons[] = [
+                'text' => "Next ➡️",
+                'callback_data' => "search_tasks:" . $query . ":" . ($page + 1)
+            ];
+        }
+
+        if (!empty($navButtons)) {
+            $inlineKeyboard[] = $navButtons;
+        }
+
+        $start = $offset + 1;
+        $end = min($offset + $pageSize, $totalTasks);
+        $text .= "\n<i>Showing $start-$end of $totalTasks results.</i>";
+
+        if ($editMessageId) {
+            $this->telegramService->editMessageText($chatId, $editMessageId, $text, [
+                'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
+            ]);
+        } else {
+            $this->telegramService->sendMessage($chatId, $text, [
+                'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
+            ]);
+        }
+        return true;
+    }
+
+    private function handleTasks(int $chatId, ?int $projectId = null, int $page = 1, ?int $editMessageId = null): bool
+    {
+        $user = $this->userModel->findByTelegramChatId($chatId);
+        if (!$user) {
+            if (!$editMessageId) {
+                $this->telegramService->sendMessage($chatId, "Unauthorized. Please link your account.");
+            }
+            return true;
+        }
+
+        $pageSize = 10;
+        $offset = ($page - 1) * $pageSize;
 
         $taskModel = $this->getTaskModel();
         if ($projectId) {
@@ -202,12 +288,19 @@ class TelegramWebhookHandler
         }
 
         if (empty($tasks)) {
-            $this->telegramService->sendMessage($chatId, $projectId ? "No active tasks found for this project." : "No active tasks found.");
+            if ($editMessageId) {
+                $this->telegramService->editMessageText($chatId, $editMessageId, $projectId ? "No active tasks found for this project." : "No active tasks found.");
+            } else {
+                $this->telegramService->sendMessage($chatId, $projectId ? "No active tasks found for this project." : "No active tasks found.");
+            }
             return true;
         }
 
+        $totalTasks = count($tasks);
+        $tasksPage = array_slice($tasks, $offset, $pageSize);
+
         $inlineKeyboard = [];
-        foreach (array_slice($tasks, 0, 10) as $task) {
+        foreach ($tasksPage as $task) {
             $statusEmoji = $taskModel->getStatusEmoji($task['status']);
             $text .= "$statusEmoji <b>#" . $task['issue_number'] . "</b>: " . htmlspecialchars($task['title']) . "\n";
 
@@ -217,13 +310,37 @@ class TelegramWebhookHandler
             ]];
         }
 
-        if (count($tasks) > 10) {
-            $text .= "\n<i>Showing 10 of " . count($tasks) . " tasks.</i>";
+        $navButtons = [];
+        if ($page > 1) {
+            $navButtons[] = [
+                'text' => "⬅️ Previous",
+                'callback_data' => "list_tasks:" . ($projectId ?: 0) . ":" . ($page - 1)
+            ];
+        }
+        if ($totalTasks > $offset + $pageSize) {
+            $navButtons[] = [
+                'text' => "Next ➡️",
+                'callback_data' => "list_tasks:" . ($projectId ?: 0) . ":" . ($page + 1)
+            ];
         }
 
-        $this->telegramService->sendMessage($chatId, $text, [
-            'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
-        ]);
+        if (!empty($navButtons)) {
+            $inlineKeyboard[] = $navButtons;
+        }
+
+        $start = $offset + 1;
+        $end = min($offset + $pageSize, $totalTasks);
+        $text .= "\n<i>Showing $start-$end of $totalTasks tasks.</i>";
+
+        if ($editMessageId) {
+            $this->telegramService->editMessageText($chatId, $editMessageId, $text, [
+                'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
+            ]);
+        } else {
+            $this->telegramService->sendMessage($chatId, $text, [
+                'reply_markup' => ['inline_keyboard' => $inlineKeyboard]
+            ]);
+        }
         return true;
     }
 
@@ -327,7 +444,15 @@ class TelegramWebhookHandler
 
         if ($action === 'list_tasks') {
             $this->telegramService->answerCallbackQuery($callbackId);
-            return $this->handleTasks($chatId, $targetId ?: null);
+            $page = isset($parts[2]) ? (int)$parts[2] : 1;
+            return $this->handleTasks($chatId, $targetId ?: null, $page, $callbackQuery['message']['message_id'] ?? null);
+        }
+
+        if ($action === 'search_tasks') {
+            $this->telegramService->answerCallbackQuery($callbackId);
+            $query = $parts[1] ?? '';
+            $page = isset($parts[2]) ? (int)$parts[2] : 1;
+            return $this->handleSearch($chatId, $query, $page, $callbackQuery['message']['message_id'] ?? null);
         }
 
         if ($action === 'toggle_setting') {
@@ -335,7 +460,7 @@ class TelegramWebhookHandler
             return $this->handleToggleSetting($callbackId, $chatId, $channel, $callbackQuery['message']['message_id'] ?? null);
         }
 
-        if (!$targetId || !in_array($action, ['retry', 'restart', 'merge', 'acknowledge', 'approve_plan', 'fix_bug', 'view_task', 'refresh_task'])) {
+        if (!$targetId || !in_array($action, ['retry', 'restart', 'merge', 'acknowledge', 'approve_plan', 'fix_bug', 'view_task', 'refresh_task', 'search_tasks'])) {
             $this->telegramService->answerCallbackQuery($callbackId, [
                 'text' => "Invalid action.",
                 'show_alert' => true
@@ -365,7 +490,7 @@ class TelegramWebhookHandler
             $this->telegramService->answerCallbackQuery($callbackId);
         }
 
-        if ($notificationId) {
+        if ($notificationId && $action !== 'list_tasks' && $action !== 'search_tasks') {
             $notificationService = $this->getNotificationService();
             $notificationService->markAsRead($notificationId, false);
         }

--- a/test/Integration/TelegramPaginationSearchTest.php
+++ b/test/Integration/TelegramPaginationSearchTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Test\Integration;
+
+use App\TelegramWebhookHandler;
+use App\User;
+use App\TelegramService;
+use App\GitHubService;
+use App\Database;
+use App\Task;
+use PHPUnit\Framework\TestCase;
+
+class TelegramPaginationSearchTest extends TestCase
+{
+    private $db;
+    private $userModel;
+    private $telegramService;
+    private $githubService;
+    private $handler;
+
+    protected function setUp(): void
+    {
+        Database::resetConnection();
+        $this->db = new Database(null, ':memory:');
+        $this->db->getConnection()->exec("
+            CREATE TABLE users (
+                user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                github_token TEXT,
+                jules_api_key TEXT,
+                jules_quota_usage INTEGER DEFAULT 0,
+                jules_quota_limit INTEGER DEFAULT 0,
+                jules_quota_updated_at DATETIME,
+                automations_enabled INTEGER DEFAULT 1
+            );
+            CREATE TABLE projects (
+                project_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                github_repo TEXT,
+                github_token TEXT
+            );
+            CREATE TABLE tasks (
+                task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                project_id INTEGER,
+                issue_number INTEGER,
+                title TEXT,
+                body TEXT,
+                status TEXT,
+                github_state TEXT,
+                pr_url TEXT,
+                jules_session_id TEXT,
+                jules_status TEXT,
+                jules_url TEXT,
+                agent_response TEXT,
+                autorepeat_remaining INTEGER DEFAULT 0,
+                last_synced_at DATETIME,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(project_id, issue_number)
+            );
+            CREATE TABLE notifications (
+                notification_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                type TEXT,
+                title TEXT,
+                message TEXT,
+                metadata TEXT,
+                is_read INTEGER DEFAULT 0,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE user_notification_settings (
+                user_id INTEGER PRIMARY KEY,
+                settings TEXT
+            );
+            CREATE TABLE user_telegram_accounts (
+                user_id INTEGER PRIMARY KEY,
+                telegram_chat_id INTEGER UNIQUE,
+                telegram_username TEXT,
+                linked_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+        ");
+
+        $this->userModel = new User($this->db);
+        $this->telegramService = $this->createMock(TelegramService::class);
+        $this->githubService = $this->createMock(GitHubService::class);
+
+        $this->handler = new class($this->userModel, $this->telegramService, $this->githubService, null) extends TelegramWebhookHandler {
+             public function setDb(Database $db) {
+                 // The base class uses the userModel's DB, which is already set
+             }
+        };
+
+        // Create a test user linked to Telegram
+        $this->db->getConnection()->prepare("INSERT INTO users (github_token) VALUES (?)")
+            ->execute(['fake_token']);
+        $this->db->getConnection()->prepare("INSERT INTO user_telegram_accounts (user_id, telegram_chat_id) VALUES (?, ?)")
+            ->execute([1, 12345]);
+
+        $this->db->getConnection()->prepare("INSERT INTO projects (user_id, github_repo) VALUES (?, ?)")
+            ->execute([1, 'owner/repo']);
+    }
+
+    private function createTasks(int $count, string $titlePrefix = 'Task', int $userId = 1, int $projectId = 1, int $startIssueNumber = 1)
+    {
+        $stmt = $this->db->getConnection()->prepare("
+            INSERT INTO tasks (user_id, project_id, issue_number, title, status, github_state)
+            VALUES (?, ?, ?, ?, ?, ?)
+        ");
+        for ($i = 0; $i < $count; $i++) {
+            $issueNumber = $startIssueNumber + $i;
+            $stmt->execute([$userId, $projectId, $issueNumber, "$titlePrefix $issueNumber", Task::STATUS_CREATED, 'open']);
+        }
+    }
+
+    public function testPaginationInTasksList()
+    {
+        $this->createTasks(15); // 15 tasks, so 2 pages
+
+        $this->telegramService->expects($this->once())
+            ->method('sendMessage')
+            ->with(
+                $this->equalTo(12345),
+                $this->stringContains('Showing 1-10 of 15 tasks'),
+                $this->callback(function($options) {
+                    $keyboard = $options['reply_markup']['inline_keyboard'];
+                    $lastRow = end($keyboard);
+                    return count($lastRow) === 1 && $lastRow[0]['text'] === 'Next ➡️';
+                })
+            );
+
+        $update = [
+            'message' => [
+                'chat' => ['id' => 12345],
+                'text' => '/tasks'
+            ]
+        ];
+
+        $this->handler->handle($update);
+    }
+
+    public function testNextPageNavigation()
+    {
+        $this->createTasks(15);
+
+        $this->telegramService->expects($this->once())
+            ->method('editMessageText')
+            ->with(
+                $this->equalTo(12345),
+                $this->equalTo(678),
+                $this->stringContains('Showing 11-15 of 15 tasks'),
+                $this->callback(function($options) {
+                    $keyboard = $options['reply_markup']['inline_keyboard'];
+                    $lastRow = end($keyboard);
+                    return count($lastRow) === 1 && $lastRow[0]['text'] === '⬅️ Previous';
+                })
+            );
+
+        $callbackUpdate = [
+            'callback_query' => [
+                'id' => 'cb123',
+                'data' => 'list_tasks:0:2', // 0 means all projects, page 2
+                'message' => [
+                    'chat' => ['id' => 12345],
+                    'message_id' => 678,
+                    'text' => 'Original Text'
+                ]
+            ]
+        ];
+
+        $this->handler->handle($callbackUpdate);
+    }
+
+    public function testSearchCommand()
+    {
+        $this->createTasks(5, 'Apple');
+        $this->createTasks(5, 'Banana', 1, 1, 6); // 6 to 10
+        // Total 10 tasks now
+
+        $this->telegramService->expects($this->once())
+            ->method('sendMessage')
+            ->with(
+                $this->equalTo(12345),
+                $this->stringContains('Search Results for "Apple"'),
+                $this->callback(function($options) {
+                    return count($options['reply_markup']['inline_keyboard']) === 5;
+                })
+            );
+
+        $update = [
+            'message' => [
+                'chat' => ['id' => 12345],
+                'text' => '/search Apple'
+            ]
+        ];
+
+        $this->handler->handle($update);
+    }
+
+    public function testSearchPagination()
+    {
+        $this->createTasks(12, 'Cherry');
+
+        $this->telegramService->expects($this->once())
+            ->method('sendMessage')
+            ->with(
+                $this->equalTo(12345),
+                $this->stringContains('Showing 1-10 of 12 results'),
+                $this->callback(function($options) {
+                    $keyboard = $options['reply_markup']['inline_keyboard'];
+                    $lastRow = end($keyboard);
+                    return $lastRow[0]['text'] === 'Next ➡️';
+                })
+            );
+
+        $update = [
+            'message' => [
+                'chat' => ['id' => 12345],
+                'text' => '/search Cherry'
+            ]
+        ];
+
+        $this->handler->handle($update);
+    }
+}

--- a/test/Integration/TelegramWebhookHandlerIntegrationTest.php
+++ b/test/Integration/TelegramWebhookHandlerIntegrationTest.php
@@ -446,10 +446,10 @@ class TelegramWebhookHandlerIntegrationTest extends TestCase
             ->method('answerCallbackQuery')
             ->with('cb130');
 
-        // It should call handleTasks which sends "No active tasks found." if none exist
+        // It should call handleTasks which edits message to "No active tasks found." if none exist
         $this->telegramService->expects($this->once())
-            ->method('sendMessage')
-            ->with(123, $this->stringContains('No active tasks found.'));
+            ->method('editMessageText')
+            ->with(123, 463, $this->stringContains('No active tasks found.'));
 
         $this->assertTrue($this->handler->handle($update));
     }
@@ -479,8 +479,8 @@ class TelegramWebhookHandlerIntegrationTest extends TestCase
             ->with('cb131');
 
         $this->telegramService->expects($this->once())
-            ->method('sendMessage')
-            ->with(123, $this->logicalAnd(
+            ->method('editMessageText')
+            ->with(123, 464, $this->logicalAnd(
                 $this->stringContains('Active Tasks for owner/repo'),
                 $this->stringContains('#109')
             ));


### PR DESCRIPTION
This PR implements Phase 12 of the Telegram Chat Control Roadmap, adding pagination to the task list and a new search command.

Key changes:
1.  **Task Search:** Users can now search for active tasks using `/search <query>`. The search covers task titles, bodies, and issue numbers.
2.  **Pagination:** Both the standard `/tasks` list and the new search results now support pagination, displaying 10 items at a time with "Next" and "Previous" buttons for navigation.
3.  **Integration Testing:** A new integration test suite verifies the end-to-end flow of pagination navigation and search result accuracy.
4.  **Roadmap Update:** Phase 12 is now marked as completed in `CHAT_ROADMAP.md`.

Note: The current implementation uses `array_slice` for pagination on the application side. Future optimizations could move this to the database layer using `LIMIT` and `OFFSET`.

Fixes #848

---
*PR created automatically by Jules for task [4440502389434080906](https://jules.google.com/task/4440502389434080906) started by @chatelao*