### PR TITLE
Prevent horizontal scrolling in task list

### DIFF
--- a/web/src/components/AutorepeatTasks.tsx
+++ b/web/src/components/AutorepeatTasks.tsx
@@ -16,29 +16,29 @@ export const AutorepeatTasks: React.FC = () => {
     <div className="mb-8 p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
       <h3 className="text-lg font-bold text-gray-900 mb-4">Running Autorepeat Tasks</h3>
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
+        <table className="min-w-full divide-y divide-gray-200 table-fixed">
           <thead className="bg-gray-50">
             <tr>
               <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Project</th>
               <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Issue</th>
-              <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+              <th scope="col" className="w-32 px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {tasks.map((task) => (
               <tr key={task.id}>
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                <td className="px-6 py-4 text-sm font-medium text-gray-900">
                   <a
                     href={`https://github.com/${task.github_repo}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-blue-600 hover:underline"
+                    className="text-blue-600 hover:underline break-words"
                   >
                     {task.github_repo}
                   </a>
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                  <Link href={rel(`/tasks/?id=${task.id}`)} className="text-blue-600 hover:underline">
+                <td className="px-6 py-4 text-sm text-gray-500">
+                  <Link href={rel(`/tasks/?id=${task.id}`)} className="text-blue-600 hover:underline break-words">
                     #{task.issue_number} - {task.title}
                   </Link>
                 </td>

--- a/web/src/components/__tests__/AutorepeatTasks.test.tsx
+++ b/web/src/components/__tests__/AutorepeatTasks.test.tsx
@@ -41,4 +41,19 @@ describe('AutorepeatTasks', () => {
     const link = screen.getByText(/#101/);
     expect(link).toHaveAttribute('href', '/tasks?id=1');
   });
+
+  it('applies correct layout classes for responsiveness', () => {
+    render(<AutorepeatTasks />);
+    const table = screen.getByRole('table');
+    expect(table.className).toContain('table-fixed');
+
+    const repoLink = screen.getByText('google/jules');
+    expect(repoLink.className).toContain('break-words');
+
+    const issueLink = screen.getByText(/#101/);
+    expect(issueLink.className).toContain('break-words');
+
+    const statusHeader = screen.getByText('Status');
+    expect(statusHeader.className).toContain('w-32');
+  });
 });


### PR DESCRIPTION
This change prevents the autorepeat task list from causing horizontal overflow on the dashboard by ensuring that long repository names and issue titles wrap within their cells. It uses `table-fixed` combined with `break-words` to force wrapping while maintaining a stable layout.

Fixes #868

---
*PR created automatically by Jules for task [9712955395462841562](https://jules.google.com/task/9712955395462841562) started by @chatelao*