### PR TITLE
Add Blockly Debug Page

### DIFF
--- a/src/frontend/api/admin-blockly-debug.php
+++ b/src/frontend/api/admin-blockly-debug.php
@@ -1,0 +1,188 @@
+<?php
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+use App\Database;
+use App\Auth;
+use App\User;
+use App\Project;
+use App\Task;
+use App\SandboxService;
+use App\GitHubService;
+use App\NotificationService;
+use App\JulesService;
+
+header('Content-Type: application/json');
+
+$auth = new Auth();
+$userId = null;
+
+// Support both Session and JWT authentication
+if ($auth->isLoggedIn()) {
+    $userId = $auth->getUserId();
+} else {
+    $headers = getallheaders();
+    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
+    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
+        $userId = $auth->validateToken($matches[1]);
+    }
+}
+
+if (!$userId || !$auth->isAdmin()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Access denied']);
+    exit;
+}
+
+$db = new Database();
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    $type = $_GET['type'] ?? 'logs';
+
+    if ($type === 'logs') {
+        $limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 100;
+        $stmt = $db->getConnection()->prepare(
+            "SELECT tl.*, t.issue_number, p.github_repo, u.email as user_email
+             FROM task_logs tl
+             JOIN tasks t ON tl.task_id = t.task_id
+             JOIN projects p ON t.project_id = p.project_id
+             JOIN users u ON tl.user_id = u.user_id
+             WHERE tl.message LIKE '%Blockly%'
+             ORDER BY tl.created_at DESC
+             LIMIT ?"
+        );
+        $stmt->bindValue(1, $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+        exit;
+    }
+
+    if ($type === 'summary') {
+        $summary = [];
+
+        // Projects
+        $stmt = $db->getConnection()->prepare("SELECT project_id, github_repo, blockly_config FROM projects WHERE blockly_config IS NOT NULL");
+        $stmt->execute();
+        $projects = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        foreach ($projects as $p) {
+            $config = json_decode($p['blockly_config'] ?? '', true);
+            $js = $config['js'] ?? '';
+            $events = extractEvents($js);
+            if (!empty($events)) {
+                $summary[] = [
+                    'source' => 'Project',
+                    'id' => $p['project_id'],
+                    'name' => $p['github_repo'],
+                    'events' => $events
+                ];
+            }
+        }
+
+        // Users (Global)
+        $stmt = $db->getConnection()->prepare("SELECT user_id, email, blockly_config FROM users WHERE blockly_config IS NOT NULL");
+        $stmt->execute();
+        $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        foreach ($users as $u) {
+            $config = json_decode($u['blockly_config'] ?? '', true);
+            $js = $config['js'] ?? '';
+            $events = extractEvents($js);
+            if (!empty($events)) {
+                $summary[] = [
+                    'source' => 'Global',
+                    'id' => $u['user_id'],
+                    'name' => $u['email'],
+                    'events' => $events
+                ];
+            }
+        }
+
+        echo json_encode($summary);
+        exit;
+    }
+}
+
+if ($method === 'POST') {
+    $input = json_decode(file_get_contents('php://input'), true);
+    $action = $input['action'] ?? '';
+
+    if ($action === 'fire_event') {
+        $taskId = (int)($input['task_id'] ?? 0);
+        $eventType = $input['event_type'] ?? 'DUMMY_EVENT';
+
+        if (!$taskId) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Missing task_id']);
+            exit;
+        }
+
+        $taskModel = new Task($db);
+        $task = $taskModel->findById($taskId);
+        if (!$task) {
+            http_response_code(404);
+            echo json_encode(['error' => 'Task not found']);
+            exit;
+        }
+
+        $projectModel = new Project($db);
+        $project = $projectModel->findById((int)$task['project_id']);
+        if (!$project) {
+            http_response_code(404);
+            echo json_encode(['error' => 'Project not found']);
+            exit;
+        }
+
+        $userModel = new User($db);
+        $user = $userModel->findById((int)$task['user_id']);
+
+        $githubService = new GitHubService(null, $project['github_token'] ?? '');
+        $notificationService = new NotificationService($db);
+        $julesService = new JulesService(null, $user['jules_api_key'] ?? '');
+
+        $sandboxService = new SandboxService($db, $githubService, $notificationService, $julesService);
+
+        $eventContext = [
+            'type' => $eventType,
+            'is_dummy' => true,
+            'payload' => $input['payload'] ?? []
+        ];
+
+        // We run it as a normal automation sequence (local then global)
+        $userId = (int)$task['user_id'];
+        $handledEvents = [];
+
+        $results = [];
+
+        if (!empty($project['blockly_config'])) {
+            $config = json_decode($project['blockly_config'], true);
+            if (!empty($config['js'])) {
+                $res = $sandboxService->execute($userId, $taskId, $config['js'], $eventContext, 'Local (Manual)');
+                $handledEvents = $res['handledEvents'] ?? [];
+                $results['local'] = $res;
+            }
+        }
+
+        if (!empty($user['blockly_config'])) {
+            $config = json_decode($user['blockly_config'], true);
+            if (!empty($config['js'])) {
+                $res = $sandboxService->execute($userId, $taskId, $config['js'], $eventContext, 'Global (Manual)', false, $handledEvents);
+                $results['global'] = $res;
+            }
+        }
+
+        echo json_encode([
+            'success' => true,
+            'results' => $results
+        ]);
+        exit;
+    }
+}
+
+function extractEvents($js) {
+    if (empty($js)) return [];
+    // Match onEvent("EVENT_NAME", ...
+    preg_match_all('/onEvent\s*\(\s*["\']([^"\']+)["\']/', $js, $matches);
+    return array_unique($matches[1] ?? []);
+}

--- a/web/src/app/admin/blockly/page.tsx
+++ b/web/src/app/admin/blockly/page.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import React, { useState } from 'react';
+import Navbar from '@/components/Navbar';
+import Breadcrumbs from '@/components/Breadcrumbs';
+import { useBlocklyLogs, useBlocklySummary, useFireBlocklyEvent } from '@/hooks/useBlocklyDebug';
+import { useTasks } from '@/hooks/useTasks';
+import { useProjects } from '@/hooks/useProjects';
+import { useUser } from '@/hooks/useUser';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { useRelativePath } from '@/hooks/useRelativePath';
+
+const ALL_EVENTS = [
+  "ISSUE_OPENED",
+  "ISSUE_LABELED",
+  "ISSUE_REOPENED",
+  "ISSUE_CLOSED",
+  "COMMENT_CREATED",
+  "PR_CREATED",
+  "PR_MERGED",
+  "CHECKS_COMPLETED",
+  "AGENT_ERROR",
+  "STATUS_CHANGED"
+];
+
+export default function BlocklyDebugPage() {
+  const { rel } = useRelativePath();
+  const { data: currentUser, isLoading: isUserLoading } = useUser();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isUserLoading && currentUser && currentUser.role !== 'admin') {
+      router.push(rel('/'));
+    }
+  }, [currentUser, isUserLoading, router, rel]);
+
+  const { data: logs, isLoading: logsLoading } = useBlocklyLogs();
+  const { data: summary, isLoading: summaryLoading } = useBlocklySummary();
+  const { data: projects } = useProjects();
+
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
+  const { data: tasks } = useTasks(selectedProjectId || undefined);
+
+  const [selectedTaskId, setSelectedTaskId] = useState<number>(0);
+  const [selectedEvent, setSelectedEvent] = useState<string>(ALL_EVENTS[0]);
+
+  const fireEventMutation = useFireBlocklyEvent();
+
+  const handleFireEvent = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedTaskId) return;
+
+    fireEventMutation.mutate({
+      task_id: selectedTaskId,
+      event_type: selectedEvent,
+    });
+  };
+
+  if (isUserLoading) {
+    return <div className="min-h-screen bg-gray-50"><Navbar /></div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-12">
+      <Navbar />
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+        <Breadcrumbs items={[{ label: 'Admin', href: rel('/admin') }, { label: 'Blockly Debug' }]} />
+
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">Blockly Debugging</h1>
+          <p className="text-gray-500 text-sm mt-1">Monitor triggers and test automation flows.</p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          {/* Left Column: Fire Event & Summary */}
+          <div className="space-y-8">
+            {/* Fire Event Card */}
+            <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
+              <h2 className="text-lg font-bold text-gray-900 mb-4">Fire Dummy Event</h2>
+              <form onSubmit={handleFireEvent} className="space-y-4">
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 uppercase mb-1">Project</label>
+                  <select
+                    className="w-full border border-gray-300 rounded-lg p-2 text-sm"
+                    onChange={(e) => setSelectedProjectId(Number(e.target.value))}
+                    value={selectedProjectId || ''}
+                  >
+                    <option value="">Select Project...</option>
+                    {projects?.map(p => (
+                      <option key={p.id} value={p.id}>{p.github_repo}</option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 uppercase mb-1">Task</label>
+                  <select
+                    className="w-full border border-gray-300 rounded-lg p-2 text-sm"
+                    onChange={(e) => setSelectedTaskId(Number(e.target.value))}
+                    value={selectedTaskId}
+                    disabled={!selectedProjectId}
+                  >
+                    <option value="0">Select Task...</option>
+                    {tasks?.map(t => (
+                      <option key={t.id} value={t.id}>#{t.issue_number} - {t.title}</option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 uppercase mb-1">Event Type</label>
+                  <select
+                    className="w-full border border-gray-300 rounded-lg p-2 text-sm"
+                    onChange={(e) => setSelectedEvent(e.target.value)}
+                    value={selectedEvent}
+                  >
+                    {ALL_EVENTS.map(evt => (
+                      <option key={evt} value={evt}>{evt}</option>
+                    ))}
+                  </select>
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={!selectedTaskId || fireEventMutation.isPending}
+                  className="w-full bg-blue-600 text-white font-bold py-2 rounded-lg hover:bg-blue-700 disabled:bg-gray-400 transition-colors"
+                >
+                  {fireEventMutation.isPending ? 'Firing...' : 'Fire Event'}
+                </button>
+
+                {fireEventMutation.isSuccess && (
+                  <p className="text-xs text-green-600 font-medium">Event fired successfully!</p>
+                )}
+                {fireEventMutation.isError && (
+                  <p className="text-xs text-red-600 font-medium">Error: {fireEventMutation.error.message}</p>
+                )}
+              </form>
+            </div>
+
+            {/* Event Summary Matrix */}
+            <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+              <h2 className="text-lg font-bold text-gray-900 mb-4">Event Usage Summary</h2>
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-xs">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left py-2 font-bold text-gray-500 uppercase">Target</th>
+                      {ALL_EVENTS.map(evt => (
+                        <th key={evt} className="px-1 py-2 font-bold text-gray-500 uppercase text-center" title={evt}>
+                          {evt.substring(0, 1)}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {summaryLoading ? (
+                      <tr><td colSpan={ALL_EVENTS.length + 1} className="py-4 text-center">Loading...</td></tr>
+                    ) : summary?.map(s => (
+                      <tr key={`${s.source}-${s.id}`} className="border-b hover:bg-gray-50">
+                        <td className="py-2 font-medium truncate max-w-[100px]" title={`${s.source}: ${s.name}`}>
+                          <span className={`mr-1 px-1 rounded ${s.source === 'Global' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'}`}>
+                            {s.source.charAt(0)}
+                          </span>
+                          {s.name}
+                        </td>
+                        {ALL_EVENTS.map(evt => (
+                          <td key={evt} className="text-center">
+                            {s.events.includes(evt) ? (
+                              <span className="text-green-500 font-bold">●</span>
+                            ) : (
+                              <span className="text-gray-200">○</span>
+                            )}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="text-[10px] text-gray-400 mt-4 italic">
+                Legend: {ALL_EVENTS.map((e, i) => `${e.substring(0, 1)}=${e}`).join(', ')}
+              </p>
+            </div>
+          </div>
+
+          {/* Right Column: Logs */}
+          <div className="lg:col-span-2">
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+              <div className="p-4 border-b border-gray-200 flex justify-between items-center bg-gray-50">
+                <h2 className="text-lg font-bold text-gray-900">Blockly Execution Logs</h2>
+                <div className="flex items-center space-x-2">
+                   <span className="flex h-2 w-2 relative">
+                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+                    <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+                  </span>
+                  <span className="text-[10px] font-bold text-gray-500 uppercase">Live</span>
+                </div>
+              </div>
+              <div className="overflow-x-auto max-h-[800px]">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50 sticky top-0">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-xs font-bold text-gray-500 uppercase">Time</th>
+                      <th className="px-4 py-3 text-left text-xs font-bold text-gray-500 uppercase">Context</th>
+                      <th className="px-4 py-3 text-left text-xs font-bold text-gray-500 uppercase">Message</th>
+                      <th className="px-4 py-3 text-left text-xs font-bold text-gray-500 uppercase">Level</th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {logsLoading ? (
+                      <tr><td colSpan={4} className="p-12 text-center text-gray-500">Loading logs...</td></tr>
+                    ) : logs?.length === 0 ? (
+                      <tr><td colSpan={4} className="p-12 text-center text-gray-500">No Blockly logs found.</td></tr>
+                    ) : logs?.map(log => (
+                      <tr key={log.task_log_id} className="hover:bg-gray-50 text-sm">
+                        <td className="px-4 py-3 whitespace-nowrap text-gray-500">
+                          {new Date(log.created_at).toLocaleTimeString()}
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <div className="font-medium text-gray-900">{log.github_repo}</div>
+                          <div className="text-xs text-gray-500">Task #{log.issue_number}</div>
+                        </td>
+                        <td className="px-4 py-3 font-mono text-xs text-gray-700 break-words max-w-md">
+                          {log.message}
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <span className={`px-2 py-0.5 rounded-full text-[10px] font-bold uppercase ${
+                            log.level === 'error' ? 'bg-red-100 text-red-700' :
+                            log.level === 'warning' ? 'bg-yellow-100 text-yellow-700' :
+                            'bg-blue-100 text-blue-700'
+                          }`}>
+                            {log.level}
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -66,6 +66,12 @@ export default function AdminDashboard() {
               DB Check
             </Link>
             <Link
+              href={rel('/admin/blockly')}
+              className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              Blockly Debug
+            </Link>
+            <Link
               href={rel('/admin/upgrade')}
               className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
             >

--- a/web/src/hooks/useBlocklyDebug.ts
+++ b/web/src/hooks/useBlocklyDebug.ts
@@ -1,0 +1,58 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import apiClient from '@/api/client';
+
+export interface BlocklyLog {
+  task_log_id: number;
+  user_id: number;
+  task_id: number;
+  message: string;
+  level: string;
+  created_at: string;
+  issue_number: number;
+  github_repo: string;
+  user_email: string;
+}
+
+export interface BlocklySummary {
+  source: 'Project' | 'Global';
+  id: number;
+  name: string;
+  events: string[];
+}
+
+export const useBlocklyLogs = (limit: number = 100) => {
+  return useQuery({
+    queryKey: ['blockly-logs', limit],
+    queryFn: async (): Promise<BlocklyLog[]> => {
+      const response = await apiClient.get<BlocklyLog[]>(`admin-blockly-debug.php?type=logs&limit=${limit}`);
+      return response.data;
+    },
+    refetchInterval: 5000, // Auto-refresh every 5 seconds
+  });
+};
+
+export const useBlocklySummary = () => {
+  return useQuery({
+    queryKey: ['blockly-summary'],
+    queryFn: async (): Promise<BlocklySummary[]> => {
+      const response = await apiClient.get<BlocklySummary[]>('admin-blockly-debug.php?type=summary');
+      return response.data;
+    },
+  });
+};
+
+export const useFireBlocklyEvent = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: { task_id: number; event_type: string; payload?: any }) => {
+      const response = await apiClient.post('admin-blockly-debug.php', {
+        action: 'fire_event',
+        ...data,
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['blockly-logs'] });
+    },
+  });
+};


### PR DESCRIPTION
This PR adds a dedicated Blockly debugging interface for administrators. It allows monitoring real-time execution logs filtered for Blockly events, viewing a summary matrix of event triggers across all projects and global settings, and manually firing "dummy" events to test automation flows instantly without needing real GitHub activity.

Fixes #871

---
*PR created automatically by Jules for task [9664299154004332162](https://jules.google.com/task/9664299154004332162) started by @chatelao*