### PR TITLE
Implement task merge actions in mobile app

### DIFF
--- a/NEXT_GEN_UI_ROADMAP.md
+++ b/NEXT_GEN_UI_ROADMAP.md
@@ -95,9 +95,9 @@ The goal of Phase 3 is to launch the native mobile application and enhance the n
     - ✅ Implement the "Running Autorepeat Tasks" view for web.
     - ✅ Implement the "Global Tasks" and "In-App Notifications" view for web.
     - ✅ Implement the "Running Autorepeat Tasks" and "Project Grid" views for mobile.
-- ⏳ **Milestone 3.3: Mobile Task Management**
-    - ⏳ Implement the "Task Detail" and "Logs" view for mobile.
-    - ⏳ Support core actions (Retry, Merge) from mobile.
+- ✅ **Milestone 3.3: Mobile Task Management**
+    - ✅ Implement the "Task Detail" and "Logs" view for mobile.
+    - ✅ Support core actions (Retry, Merge) from mobile.
 - ⏳ **Milestone 3.4: Push Notifications**
     - ⏳ Integrate with Firebase or Expo Notifications to deliver native alerts for `FAILED` and `READY` states.
 

--- a/android/package-lock.json
+++ b/android/package-lock.json
@@ -6618,7 +6618,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/android/src/screens/TaskDetailScreen.tsx
+++ b/android/src/screens/TaskDetailScreen.tsx
@@ -101,6 +101,33 @@ export default function TaskDetailScreen({ route, navigation }: any) {
               </Text>
             </TouchableOpacity>
           )}
+
+          {!!task.pr_url && task.status !== 'finished' && task.github_state === 'open' && (
+            <>
+              <TouchableOpacity
+                style={[styles.primaryButton, { backgroundColor: '#9333ea', marginTop: 12 }]}
+                onPress={() => performAction({ action: 'merge_close' })}
+                disabled={isPerformingAction}
+              >
+                <Text style={styles.buttonText}>
+                  {isPerformingAction ? 'Merging...' : 'Merge & Close'}
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.primaryButton, { backgroundColor: '#4f46e5', marginTop: 12 }]}
+                onPress={() => performAction({ action: 'merge_close_duplicate' })}
+                disabled={isPerformingAction}
+              >
+                <Text style={styles.buttonText}>
+                  {isPerformingAction ? 'Processing...' : 'Merge, Close & Duplicate'}
+                </Text>
+              </TouchableOpacity>
+            </>
+          )}
+
+          {task.status === 'finished' && (
+            <Text style={styles.finishedText}>This task is finished.</Text>
+          )}
         </View>
 
         <View style={styles.logsContainer}>
@@ -295,5 +322,12 @@ const styles = StyleSheet.create({
   },
   errorLog: {
     color: '#f87171',
+  },
+  finishedText: {
+    fontSize: 14,
+    color: '#6b7280',
+    fontStyle: 'italic',
+    textAlign: 'center',
+    marginTop: 8,
   },
 });


### PR DESCRIPTION
This PR enhances the mobile application by implementing core task management actions in the `TaskDetailScreen`, achieving feature parity with the web dashboard for these operations.

Key changes:
- Ported 'Merge & Close' and 'Merge, Close & Duplicate' actions from the web dashboard to the mobile app.
- Added logic to display these buttons only when a Pull Request is available and the task is open.
- Integrated these actions with the existing `performAction` helper in the `useTask` hook.
- Updated `NEXT_GEN_UI_ROADMAP.md` to reflect the completion of Milestone 3.3.

These changes complete the "Mobile Task Management" milestone of the Next-Gen UI roadmap.

Fixes #873

---
*PR created automatically by Jules for task [5174683334972045421](https://jules.google.com/task/5174683334972045421) started by @chatelao*