### PR TITLE
Increase closed task limit on dashboard

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -159,7 +159,7 @@ class Task
                     AND t2.github_state = 'closed'
                     AND t2.status IN ('" . self::STATUS_FINISHED . "', 'completed')
                     AND (t2.created_at > t1.created_at OR (t2.created_at = t1.created_at AND t2.task_id > t1.task_id))
-                ) < 3
+                ) < 10
             ))";
         }
 
@@ -194,7 +194,7 @@ class Task
                     AND t3.github_state = 'closed'
                     AND t3.status IN ('" . self::STATUS_FINISHED . "', 'completed')
                     AND (t3.created_at > t.created_at OR (t3.created_at = t.created_at AND t3.task_id > t.task_id))
-                ) < 3
+                ) < 10
             ))";
             $params[] = $userId;
         }
@@ -234,7 +234,7 @@ class Task
                 AND t3.github_state = 'closed'
                 AND t3.status IN ('" . self::STATUS_FINISHED . "', 'completed')
                 AND (t3.created_at > t.created_at OR (t3.created_at = t.created_at AND t3.task_id > t.task_id))
-            ) < 3
+            ) < 10
         ))";
         $params[] = $userId;
 

--- a/src/frontend/api/tasks.php
+++ b/src/frontend/api/tasks.php
@@ -31,6 +31,7 @@ if (!$userId) {
 
 $projectId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $filter = $_GET['filter'] ?? 'all_open';
+$showAll = isset($_GET['all']) && ($_GET['all'] === 'true' || $_GET['all'] === '1');
 
 $db = new Database();
 $projectModel = new Project($db);
@@ -44,7 +45,7 @@ if ($projectId > 0) {
         echo json_encode(['error' => 'Project not found']);
         exit;
     }
-    $tasks = $taskModel->findByProjectId($projectId);
+    $tasks = $taskModel->findByProjectId($projectId, $showAll);
 } else {
     // Global filter
     $tasks = $taskModel->findByFilter($userId, $filter);

--- a/test/Integration/TaskFilteringTest.php
+++ b/test/Integration/TaskFilteringTest.php
@@ -81,10 +81,10 @@ class TaskFilteringTest extends TestCase
         // findByProjectId(1, false)
         $tasks = $this->taskModel->findByProjectId(1, false);
 
-        // Expected issues for Project 1: 1, 2 (open), 4, 5, 6 (last 3 completed for this project)
+        // Expected issues for Project 1: 1, 2 (open), 3, 4, 5, 6 (last 10 completed for this project)
         $issueNumbers = array_column($tasks, 'issue_number');
         sort($issueNumbers);
-        $this->assertEquals([1, 2, 4, 5, 6], $issueNumbers, "Should only show open issues and last 3 completed issues for Project 1");
+        $this->assertEquals([1, 2, 3, 4, 5, 6], $issueNumbers, "Should only show open issues and last 10 completed issues for Project 1");
 
         // findActiveByUserProjects(1)
         $activeTasks = $this->taskModel->findActiveByUserProjects(1);
@@ -92,8 +92,8 @@ class TaskFilteringTest extends TestCase
         sort($issueNumbers);
 
         // Globally open: 1, 2, 10
-        // Globally completed (last 3): 11 (17:00), 6 (15:00), 5 (14:00)
+        // Globally completed (last 10): 11 (17:00), 6 (15:00), 5 (14:00), 4 (13:00), 3 (12:00)
         // Hidden orphans: 0, 99 (empty title)
-        $this->assertEquals([1, 2, 5, 6, 10, 11], $issueNumbers, "Should only show active issues and last 3 globally completed issues");
+        $this->assertEquals([1, 2, 3, 4, 5, 6, 10, 11], $issueNumbers, "Should only show active issues and last 10 globally completed issues");
     }
 }

--- a/web/src/app/projects/[id]/ProjectDetailView.tsx
+++ b/web/src/app/projects/[id]/ProjectDetailView.tsx
@@ -19,7 +19,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
   const { rel } = useRelativePath();
   const projectId = parseInt(id);
   const { data: project, isLoading: projectLoading, error: projectError, syncIssues, isSyncing, createFromTemplate, isCreatingFromTemplate, createFromRoadmap, isCreatingFromRoadmap, createGithubIssue, isCreatingGithubIssue } = useProject(projectId);
-  const { data: tasks, isLoading: tasksLoading } = useTasks(projectId);
+  const { data: tasks, isLoading: tasksLoading } = useTasks(projectId, 'all_open', true);
   const { data: templates } = useTemplates();
   const { performAction, isPerformingAction, performingActionId } = useTaskActions();
 

--- a/web/src/hooks/useTasks.ts
+++ b/web/src/hooks/useTasks.ts
@@ -4,15 +4,18 @@ import { components } from '@/types/api';
 
 type Task = components['schemas']['Task'];
 
-export const useTasks = (projectId: number | undefined, filter: string = 'all_open') => {
+export const useTasks = (projectId: number | undefined, filter: string = 'all_open', all: boolean = false) => {
   return useQuery({
-    queryKey: ['tasks', projectId, filter],
+    queryKey: ['tasks', projectId, filter, all],
     queryFn: async (): Promise<Task[]> => {
       let url = 'tasks.php';
       const params = new URLSearchParams();
 
       if (projectId) {
         params.append('id', projectId.toString());
+        if (all) {
+          params.append('all', 'true');
+        }
       } else {
         params.append('filter', filter);
       }


### PR DESCRIPTION
This change increases the number of closed tasks shown per project on the main dashboard from 3 to 10. It also introduces an 'all' parameter to the tasks API and hook to allow fetching all tasks for a project, which is now used in the project detail view to ensure no tasks are hidden there.

Fixes #877

---
*PR created automatically by Jules for task [9614630019669116811](https://jules.google.com/task/9614630019669116811) started by @chatelao*