### PR TITLE
Use numbered autorepeat labels as primary source of truth

### DIFF
--- a/src/backend/GitHubService.php
+++ b/src/backend/GitHubService.php
@@ -470,7 +470,6 @@ class GitHubService
         }
 
         if ($count > 0) {
-            $newLabels[] = 'autorepeat';
             $newLabels[] = 'autorepeat: ' . $count;
         }
 

--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -324,7 +324,7 @@ class Task
              JOIN projects p ON t.project_id = p.project_id
              WHERE p.user_id = ?
              AND t.github_state = 'open'
-             AND (t.autorepeat_remaining > 0 OR t.github_data LIKE '%autorepeat%' OR t.github_data LIKE '%auto-repeat%')
+             AND (t.autorepeat_remaining > 0 OR t.github_data LIKE '%autorepeat:%' OR t.github_data LIKE '%auto-repeat:%')
              ORDER BY t.created_at DESC"
         );
         $stmt->execute([$userId]);
@@ -515,27 +515,12 @@ class Task
 
         // Try to extract from labels if not explicitly provided
         $labelCount = isset($issue['labels']) ? $this->extractAutorepeatRemainingFromLabels($issue['labels']) : null;
-        $hasGenericAutorepeatLabel = false;
-
-        // If no count is found but the label is present, default to 5
-        if ($labelCount === null && isset($issue['labels'])) {
-            foreach ($issue['labels'] as $label) {
-                $name = strtolower($label['name'] ?? '');
-                if ($name === 'autorepeat' || $name === 'auto-repeat') {
-                    $labelCount = 5;
-                    $hasGenericAutorepeatLabel = true;
-                    break;
-                }
-            }
-        }
 
         // Final value to use in the INSERT part
         $insertAutorepeatRemaining = $autorepeatRemaining ?? $labelCount ?? 0;
 
         // Determine if we should update the existing value.
-        // If we only have a generic 'autorepeat' label, we only update if the current DB value is 0.
-        $shouldUpdateAutorepeat = ($autorepeatRemaining !== null || ($labelCount !== null && !$hasGenericAutorepeatLabel));
-        $conditionalAutorepeatUpdate = ($hasGenericAutorepeatLabel && $autorepeatRemaining === null);
+        $shouldUpdateAutorepeat = ($autorepeatRemaining !== null || $labelCount !== null);
 
         if ($driver === 'sqlite') {
             $sql = "INSERT INTO tasks (user_id, project_id, issue_number, title, body, github_data, status, github_state, autorepeat_remaining)
@@ -545,8 +530,7 @@ class Task
                         body = excluded.body,
                         github_data = excluded.github_data,
                         github_state = excluded.github_state,
-                        autorepeat_remaining = " . ($shouldUpdateAutorepeat ? "excluded.autorepeat_remaining" :
-                                                    ($conditionalAutorepeatUpdate ? "CASE WHEN tasks.autorepeat_remaining = 0 THEN excluded.autorepeat_remaining ELSE tasks.autorepeat_remaining END" : "tasks.autorepeat_remaining")) . ",
+                        autorepeat_remaining = " . ($shouldUpdateAutorepeat ? "excluded.autorepeat_remaining" : "tasks.autorepeat_remaining") . ",
                         status = CASE
                             WHEN excluded.github_state = 'closed' THEN 'finished'
                             WHEN status = 'pending' THEN 'created'
@@ -560,8 +544,7 @@ class Task
                         body = VALUES(body),
                         github_data = VALUES(github_data),
                         github_state = VALUES(github_state),
-                        autorepeat_remaining = " . ($shouldUpdateAutorepeat ? "VALUES(autorepeat_remaining)" :
-                                                    ($conditionalAutorepeatUpdate ? "CASE WHEN tasks.autorepeat_remaining = 0 THEN VALUES(autorepeat_remaining) ELSE tasks.autorepeat_remaining END" : "tasks.autorepeat_remaining")) . ",
+                        autorepeat_remaining = " . ($shouldUpdateAutorepeat ? "VALUES(autorepeat_remaining)" : "tasks.autorepeat_remaining") . ",
                         status = CASE
                             WHEN VALUES(github_state) = 'closed' THEN 'finished'
                             WHEN status = 'pending' THEN 'created'
@@ -722,7 +705,7 @@ class Task
         $labels = $githubData['labels'] ?? [];
         foreach ($labels as $label) {
             $name = strtolower($label['name'] ?? '');
-            if ($name === 'autorepeat' || $name === 'auto-repeat' || str_starts_with($name, 'autorepeat:')) {
+            if (str_starts_with($name, 'autorepeat:') || str_starts_with($name, 'auto-repeat:')) {
                 return true;
             }
         }

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -224,7 +224,7 @@ class WebhookHandler
 
         $labelNames = array_filter(
             array_map(fn($l) => $l['name'], $labels),
-            fn($name) => strtolower($name) !== 'autorepeat' && strtolower($name) !== 'auto-repeat' && !str_starts_with(strtolower($name), 'autorepeat:')
+            fn($name) => strtolower($name) !== 'autorepeat' && strtolower($name) !== 'auto-repeat' && !str_starts_with(strtolower($name), 'autorepeat:') && !str_starts_with(strtolower($name), 'auto-repeat:')
         );
 
         // Ensure 'Jules' label is present to trigger the agent for the new issue

--- a/test/Integration/AutorepeatPersistenceTest.php
+++ b/test/Integration/AutorepeatPersistenceTest.php
@@ -140,6 +140,6 @@ class AutorepeatPersistenceTest extends TestCase
                 'labels' => [['name' => 'autorepeat']]
             ])
         ];
-        $this->assertTrue($this->taskModel->hasAutorepeatLabel($task2));
+        $this->assertFalse($this->taskModel->hasAutorepeatLabel($task2));
     }
 }

--- a/test/Integration/AutorepeatRaceTest.php
+++ b/test/Integration/AutorepeatRaceTest.php
@@ -140,7 +140,7 @@ class AutorepeatRaceTest extends TestCase
         ];
         $taskModel->upsert(1, 1, $issueUpdate);
 
-        // Should NOT reset to 5, should stay 3
+        // Should NOT change anything, should stay 3
         $stmt = $this->pdo->query("SELECT autorepeat_remaining FROM tasks WHERE issue_number = 201");
         $this->assertEquals(3, $stmt->fetchColumn());
 
@@ -149,7 +149,7 @@ class AutorepeatRaceTest extends TestCase
         $stmt = $this->pdo->query("SELECT autorepeat_remaining FROM tasks WHERE issue_number = 201");
         $this->assertEquals(2, $stmt->fetchColumn());
 
-        // Final sanity check: if it was 0, generic label should set it to 5
+        // Final sanity check: if it was 0, generic label should NOT set it to 5 anymore
         $issueNew = [
             'number' => 202,
             'title' => 'New Task',
@@ -158,6 +158,6 @@ class AutorepeatRaceTest extends TestCase
         ];
         $taskModel->upsert(1, 1, $issueNew);
         $stmt = $this->pdo->query("SELECT autorepeat_remaining FROM tasks WHERE issue_number = 202");
-        $this->assertEquals(5, $stmt->fetchColumn());
+        $this->assertEquals(0, $stmt->fetchColumn());
     }
 }

--- a/test/Integration/CronAutorepeatTest.php
+++ b/test/Integration/CronAutorepeatTest.php
@@ -134,7 +134,8 @@ class CronAutorepeatTest extends TestCase
 
         // Task is already 'ready', with autorepeat_remaining = 3, and is Jules related
         $githubData = json_encode([
-            'labels' => [['name' => 'Jules']],
+            'title' => 'Autorepeat Task',
+            'labels' => [['name' => 'Jules'], ['name' => 'autorepeat: 3']],
             'assignee' => ['login' => 'jules']
         ]);
         $this->pdo->prepare("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, status, pr_url, autorepeat_remaining, github_data, jules_status, jules_session_id)
@@ -181,7 +182,8 @@ class CronAutorepeatTest extends TestCase
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo, github_token, github_account_id) VALUES (1, 1, 'owner/repo', 'token', 1)");
 
         $githubData = json_encode([
-            'labels' => [['name' => 'Jules']]
+            'title' => 'Autorepeat Task',
+            'labels' => [['name' => 'Jules'], ['name' => 'autorepeat: 3']]
         ]);
         $this->pdo->prepare("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, status, pr_url, autorepeat_remaining, github_data, jules_status, jules_session_id)
                           VALUES (1, 1, 1, 101, 'Autorepeat Task', 'ready', 'https://github.com/owner/repo/pull/42', 3, ?, 'completed', 'sess_123')")
@@ -255,7 +257,11 @@ class CronAutorepeatTest extends TestCase
         $this->pdo->exec("INSERT INTO user_github_accounts (github_account_id, user_id, github_username, github_token) VALUES (1, 1, 'testuser', 'token')");
         $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo, github_token, github_account_id) VALUES (1, 1, 'owner/repo', 'token', 1)");
 
-        $githubData = json_encode(['labels' => [], 'assignee' => null]);
+        $githubData = json_encode([
+            'title' => 'Non-Jules Autorepeat',
+            'labels' => [['name' => 'autorepeat: 3']],
+            'assignee' => null
+        ]);
         $this->pdo->prepare("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, status, pr_url, autorepeat_remaining, github_data)
                           VALUES (1, 1, 1, 101, 'Non-Jules Autorepeat', 'ready', 'https://github.com/owner/repo/pull/42', 3, ?)")
                   ->execute([$githubData]);

--- a/test/Integration/WebhookHandlerTest.php
+++ b/test/Integration/WebhookHandlerTest.php
@@ -108,7 +108,7 @@ class WebhookHandlerTest extends TestCase
                 'body' => 'Description',
                 'state_reason' => 'completed',
                 'labels' => [
-                    ['name' => 'autorepeat']
+                    ['name' => 'autorepeat: 5']
                 ]
             ],
             'repository' => [
@@ -140,7 +140,7 @@ class WebhookHandlerTest extends TestCase
         $githubData = [
             'number' => 123,
             'title' => 'Issue to autorepeat',
-            'labels' => [['name' => 'autorepeat']]
+            'labels' => [['name' => 'autorepeat: 5']]
         ];
 
         $stmt = $this->pdo->prepare("INSERT INTO tasks (user_id, project_id, issue_number, title, github_data, pr_url, status) VALUES (?, ?, ?, ?, ?, ?, ?)");

--- a/test/Unit/Services/WebhookHandlerTest.php
+++ b/test/Unit/Services/WebhookHandlerTest.php
@@ -73,7 +73,7 @@ class WebhookHandlerTest extends TestCase
                 'body' => 'Body',
                 'state_reason' => 'completed',
                 'labels' => [
-                    ['name' => 'autorepeat'],
+                    ['name' => 'autorepeat: 5'],
                     ['name' => 'bug']
                 ]
             ]


### PR DESCRIPTION
This change transitions the autorepeat system to use numbered labels (e.g., `autorepeat: 5`) as the exclusive source of truth for iteration counts. Generic labels without numbers are no longer used to default the count to 5, and the system now ignores them for active task tracking. All relevant components (Task model, GitHub service, Webhook handler) and their corresponding integration tests have been updated to enforce this new standard.

Fixes #886

---
*PR created automatically by Jules for task [6408976068211172451](https://jules.google.com/task/6408976068211172451) started by @chatelao*