### PR TITLE
Remove redundant "Details" links in Project Detail View

### DIFF
--- a/web/src/app/projects/[id]/ProjectDetailView.tsx
+++ b/web/src/app/projects/[id]/ProjectDetailView.tsx
@@ -180,9 +180,6 @@ export default function ProjectDetailView({ id }: { id: string }) {
                                   </button>
                                 </>
                               )}
-                            <Link href={rel(`/tasks/?id=${task.id}`)} className="text-blue-600 hover:text-blue-900">
-                              Details
-                            </Link>
                           </div>
                         </td>
                       </tr>


### PR DESCRIPTION
Removed the redundant "Details" links from the action column in the project task list. Task details remain accessible by clicking on the issue title link.

Fixes #882

---
*PR created automatically by Jules for task [13959479366430967233](https://jules.google.com/task/13959479366430967233) started by @chatelao*