### PR TITLE
Fix PR Created automation and task linking

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -830,6 +830,29 @@ class Task
         return null;
     }
 
+    public function extractIssueNumbers(string $text, ?string $repo = null): array
+    {
+        $issueNumbers = [];
+
+        // 1. Full URLs: https://github.com/owner/repo/issues/123
+        if (preg_match_all('/https?:\/\/github\.com\/([^\/]+\/[^\/]+)\/issues\/(\d+)/i', $text, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                if ($repo === null || strtolower($match[1]) === strtolower($repo)) {
+                    $issueNumbers[] = (int)$match[2];
+                }
+            }
+        }
+
+        // 2. Relative references like #123
+        if (preg_match_all('/(?:fixes|closes|resolves|#)\s*#?(\d+)/i', $text, $matches)) {
+            foreach ($matches[1] as $num) {
+                $issueNumbers[] = (int)$num;
+            }
+        }
+
+        return array_values(array_unique($issueNumbers));
+    }
+
     public function extractPrUrl(string $text, ?string $repo = null, ?int $excludeIssueNumber = null): ?string
     {
         // Full URL

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -308,6 +308,22 @@ class WebhookHandler
         // Sync task data (including labels) during PR events
         $taskModel = new Task($this->db);
         $task = $taskModel->findByPrUrl($pr['html_url']);
+
+        // Fallback: If not found by PR URL, try searching for issue references in the PR body
+        if (!$task && !empty($pr['body'])) {
+            $referencedIssues = $taskModel->extractIssueNumbers($pr['body'], $project['github_repo']);
+            foreach ($referencedIssues as $issueNumber) {
+                $task = $taskModel->findByIssueNumber($project['project_id'], $issueNumber);
+                if ($task) {
+                    // Established link: update task with PR URL
+                    $stmt = $this->db->getConnection()->prepare("UPDATE tasks SET pr_url = ? WHERE task_id = ?");
+                    $stmt->execute([$pr['html_url'], $task['task_id']]);
+                    $task['pr_url'] = $pr['html_url'];
+                    break;
+                }
+            }
+        }
+
         if ($task && $githubService && !empty($project['github_repo'])) {
             try {
                 $issue = $githubService->getIssue($project['github_repo'], $task['issue_number']);
@@ -326,11 +342,14 @@ class WebhookHandler
             }
         }
 
+        // Run Blockly automations if task context is resolved
+        if ($task) {
+            $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService);
+        }
+
         // Handle auto-repeat if PR is merged
         if ($action === 'closed' && ($pr['merged'] ?? false) && $githubService) {
             if ($task && $task['issue_number']) {
-                $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService);
-
                 $userModel = new User($this->db);
                 $user = $userModel->findById($project['user_id']);
                 $githubData = json_decode($task['github_data'] ?? '{}', true);
@@ -342,10 +361,6 @@ class WebhookHandler
                     $pseudoEvent['issue']['state_reason'] = 'completed';
                     $this->maybeDuplicateTask($project, $pseudoEvent, $githubService, $notificationService);
                 }
-            }
-        } elseif ($action !== 'closed') {
-            if ($task) {
-                $this->runBlocklyAutomations($project, $event, $githubEvent, (int)$task['task_id'], $sandboxService);
             }
         }
 

--- a/test/Integration/PrCreatedLinkTest.php
+++ b/test/Integration/PrCreatedLinkTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\WebhookHandler;
+use App\SandboxService;
+use App\GitHubService;
+use App\NotificationService;
+use App\JulesService;
+use App\Logger;
+use App\Task;
+use App\Project;
+use App\User;
+use PDO;
+use Tests\TestDatabaseTrait;
+
+class PrCreatedLinkTest extends TestCase
+{
+    use TestDatabaseTrait;
+
+    private $db;
+    private $pdo;
+    private $githubService;
+    private $notificationService;
+    private $julesService;
+    private $sandboxService;
+    private $webhookHandler;
+
+    protected function setUp(): void
+    {
+        $this->pdo = $this->getTestPdo();
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        // Reset tables
+        $tables = [
+            'task_logs', 'tasks', 'projects', 'users', 'user_github_accounts',
+            'notifications', 'task_notification_settings', 'user_event_notification_settings',
+            'project_status_notification_settings', 'user_notification_settings'
+        ];
+        foreach ($tables as $table) {
+            $this->pdo->exec("DROP TABLE IF EXISTS $table");
+        }
+
+        $pk = $driver === 'sqlite' ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INT AUTO_INCREMENT PRIMARY KEY';
+        $timestamp = $driver === 'sqlite' ? 'DATETIME DEFAULT CURRENT_TIMESTAMP' : 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP';
+
+        $this->pdo->exec("CREATE TABLE users (
+            user_id $pk,
+            email VARCHAR(255) UNIQUE,
+            blockly_config TEXT,
+            jules_api_key VARCHAR(255),
+            automations_enabled BOOLEAN DEFAULT 1
+        )");
+
+        $this->pdo->exec("CREATE TABLE user_github_accounts (
+            github_account_id $pk,
+            user_id INT NOT NULL,
+            github_token VARCHAR(255),
+            github_username VARCHAR(255)
+        )");
+
+        $this->pdo->exec("CREATE TABLE projects (
+            project_id $pk,
+            user_id INT NOT NULL,
+            github_repo VARCHAR(255) NOT NULL,
+            github_account_id INT,
+            blockly_config TEXT
+        )");
+
+        $this->pdo->exec("CREATE TABLE tasks (
+            task_id $pk,
+            user_id INT NOT NULL,
+            project_id INT NOT NULL,
+            issue_number INT NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            body TEXT,
+            status TEXT DEFAULT 'created',
+            github_state VARCHAR(20) DEFAULT 'open',
+            github_data TEXT,
+            pr_url VARCHAR(255),
+            github_repo VARCHAR(255),
+            created_at $timestamp,
+            updated_at $timestamp,
+            UNIQUE(project_id, issue_number)
+        )");
+
+        $this->pdo->exec("CREATE TABLE task_logs (
+            log_id $pk,
+            task_id INT NOT NULL,
+            user_id INT NOT NULL,
+            message TEXT,
+            level VARCHAR(20),
+            created_at $timestamp
+        )");
+
+        $this->pdo->exec("CREATE TABLE notifications (
+            notification_id $pk,
+            user_id INT NOT NULL,
+            project_id INT,
+            type VARCHAR(50),
+            title VARCHAR(255),
+            message TEXT,
+            data TEXT,
+            is_read BOOLEAN DEFAULT 0,
+            created_at $timestamp
+        )");
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        $this->githubService = $this->createMock(GitHubService::class);
+        $this->notificationService = $this->createMock(NotificationService::class);
+        $this->julesService = $this->createMock(JulesService::class);
+
+        $this->sandboxService = new SandboxService($this->db, $this->githubService, $this->notificationService, $this->julesService);
+        $this->webhookHandler = new WebhookHandler($this->db);
+
+        Logger::resetInstance();
+        new Logger($this->db);
+    }
+
+    public function testPrCreatedAutomationSucceedsWhenLinkedViaBody()
+    {
+        // 1. Setup: Global Blockly script for PR_CREATED
+        $jsCode = "onEvent('PR_CREATED', (event) => { notify('Hello'); });";
+        $blocklyConfig = json_encode(['js' => $jsCode]);
+
+        $stmt = $this->pdo->prepare("INSERT INTO users (user_id, email, blockly_config) VALUES (1, 'test@example.com', ?)");
+        $stmt->execute([$blocklyConfig]);
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+
+        // Task exists but NO pr_url yet
+        $this->pdo->prepare("INSERT INTO tasks (task_id, user_id, project_id, issue_number, title, github_data, github_repo)
+                          VALUES (1, 1, 1, 101, 'Fix Bug', '{\"labels\":[]}', 'owner/repo')")->execute();
+
+        $project = [
+            'project_id' => 1,
+            'user_id' => 1,
+            'github_repo' => 'owner/repo',
+            'blockly_config' => null
+        ];
+
+        // 2. Trigger pull_request opened event referencing issue #101
+        $payload = [
+            'action' => 'opened',
+            'pull_request' => [
+                'number' => 42,
+                'title' => 'Fix Bug',
+                'body' => 'This fixes #101',
+                'html_url' => 'https://github.com/owner/repo/pull/42',
+                'user' => ['login' => 'jules']
+            ],
+            'repository' => ['full_name' => 'owner/repo']
+        ];
+
+        // Expectation: notify() SHOULD be called because linking works now
+        $this->notificationService->expects($this->atLeastOnce())->method('notify');
+
+        $this->webhookHandler->handle($project, $payload, $this->githubService, $this->notificationService, $this->julesService, $this->sandboxService, 'pull_request');
+
+        // Check if Blockly automation ran
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM task_logs WHERE message LIKE '%Executing [Global] Blockly automation%'");
+        $count = (int)$stmt->fetchColumn();
+
+        $this->assertGreaterThan(0, $count, "Blockly automation did not run");
+
+        // Verify pr_url was updated in the database
+        $stmt = $this->pdo->query("SELECT pr_url FROM tasks WHERE task_id = 1");
+        $this->assertEquals('https://github.com/owner/repo/pull/42', $stmt->fetchColumn());
+    }
+}


### PR DESCRIPTION
This submission fixes an issue where Blockly automations triggered by "PR Created" events would fail to execute because the Pull Request had not yet been linked to a task in the database.

The fix involves:
1.  **Issue Extraction:** Implementing `Task::extractIssueNumbers` to identify references like `#101` or full issue URLs in strings.
2.  **Robust Task Resolution:** Modifying `WebhookHandler::handlePullRequest` to use these references to find the parent task if a direct lookup by PR URL fails.
3.  **Automatic Linking:** Once a task is resolved via reference, the system now automatically updates the task record with the PR URL, establishing a permanent link.
4.  **Consistently Triggering Automations:** Improving the automation trigger logic to ensure that PR-related events consistently execute configured Blockly workflows.

An integration test was added to confirm that a "PR Created" event now successfully triggers a notification automation even when the PR starts unlinked.

Fixes #892

---
*PR created automatically by Jules for task [4716557254337848666](https://jules.google.com/task/4716557254337848666) started by @chatelao*