### PR TITLE
Fix Access Denied Error on Task Actions and Polling

### DIFF
--- a/src/backend/Auth.php
+++ b/src/backend/Auth.php
@@ -81,6 +81,39 @@ class Auth
         return $_SESSION['user_id'] ?? null;
     }
 
+    /**
+     * Get the authenticated user ID from session or Bearer token in headers.
+     * Checks multiple potential header sources for robustness.
+     */
+    public function getAuthenticatedUserId(): ?int
+    {
+        if ($this->isLoggedIn()) {
+            return $this->getUserId();
+        }
+
+        $authHeader = '';
+
+        // 1. Try standard $_SERVER['HTTP_AUTHORIZATION']
+        if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+            $authHeader = $_SERVER['HTTP_AUTHORIZATION'];
+        }
+        // 2. Try redirected authorization (often used in Apache)
+        elseif (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+            $authHeader = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+        }
+        // 3. Try getallheaders() if available
+        elseif (function_exists('getallheaders')) {
+            $headers = getallheaders();
+            $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
+        }
+
+        if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
+            return $this->validateToken($matches[1]);
+        }
+
+        return null;
+    }
+
     public function isLoggedIn(): bool
     {
         return isset($_SESSION['user_id']);

--- a/src/backend/Project.php
+++ b/src/backend/Project.php
@@ -70,7 +70,7 @@ class Project
         $stmt = $this->db->getConnection()->prepare(
             "SELECT p.*, a.github_token, a.github_username
              FROM projects p
-             JOIN user_github_accounts a ON p.github_account_id = a.github_account_id
+             LEFT JOIN user_github_accounts a ON p.github_account_id = a.github_account_id
              WHERE p.project_id = ?"
         );
         $stmt->execute([$id]);

--- a/src/frontend/api/admin-blockly-debug.php
+++ b/src/frontend/api/admin-blockly-debug.php
@@ -15,18 +15,7 @@ use App\JulesService;
 header('Content-Type: application/json');
 
 $auth = new Auth();
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $headers = getallheaders();
-    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId || !$auth->isAdmin()) {
     http_response_code(403);

--- a/src/frontend/api/admin-db-check.php
+++ b/src/frontend/api/admin-db-check.php
@@ -11,22 +11,7 @@ header('Content-Type: application/json');
 
 $db = new Database();
 $auth = new Auth($db);
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['Authorization'] ?? '';
-    if (empty($authHeader) && function_exists('getallheaders')) {
-        $headers = getallheaders();
-        $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    }
-
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/admin-upgrade.php
+++ b/src/frontend/api/admin-upgrade.php
@@ -10,22 +10,7 @@ header('Content-Type: application/json');
 
 $db = new Database();
 $auth = new Auth($db);
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['Authorization'] ?? '';
-    if (empty($authHeader) && function_exists('getallheaders')) {
-        $headers = getallheaders();
-        $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    }
-
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/admin-users.php
+++ b/src/frontend/api/admin-users.php
@@ -10,22 +10,7 @@ header('Content-Type: application/json');
 
 $db = new Database();
 $auth = new Auth($db);
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['Authorization'] ?? '';
-    if (empty($authHeader) && function_exists('getallheaders')) {
-        $headers = getallheaders();
-        $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    }
-
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/autorepeat-tasks.php
+++ b/src/frontend/api/autorepeat-tasks.php
@@ -9,18 +9,7 @@ use App\Task;
 header('Content-Type: application/json');
 
 $auth = new Auth();
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $headers = getallheaders();
-    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/notifications.php
+++ b/src/frontend/api/notifications.php
@@ -10,22 +10,7 @@ header('Content-Type: application/json');
 
 $db = new Database();
 $auth = new Auth($db);
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['Authorization'] ?? '';
-    if (empty($authHeader) && function_exists('getallheaders')) {
-        $headers = getallheaders();
-        $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    }
-
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/performance-logs.php
+++ b/src/frontend/api/performance-logs.php
@@ -9,18 +9,7 @@ use App\Logger;
 header('Content-Type: application/json');
 
 $auth = new Auth();
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $headers = getallheaders();
-    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/project.php
+++ b/src/frontend/api/project.php
@@ -13,18 +13,7 @@ use App\NotificationService;
 header('Content-Type: application/json');
 
 $auth = new Auth();
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $headers = getallheaders();
-    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/projects.php
+++ b/src/frontend/api/projects.php
@@ -10,18 +10,7 @@ use App\GitHubService;
 header('Content-Type: application/json');
 
 $auth = new Auth();
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $headers = getallheaders();
-    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/refresh.php
+++ b/src/frontend/api/refresh.php
@@ -8,10 +8,17 @@ header('Content-Type: application/json');
 
 $auth = new Auth();
 
-$headers = getallheaders();
-$authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-$refreshToken = null;
+$authHeader = '';
+if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+    $authHeader = $_SERVER['HTTP_AUTHORIZATION'];
+} elseif (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+    $authHeader = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+} elseif (function_exists('getallheaders')) {
+    $headers = getallheaders();
+    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
+}
 
+$refreshToken = null;
 if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
     $refreshToken = $matches[1];
 }

--- a/src/frontend/api/sync-status.php
+++ b/src/frontend/api/sync-status.php
@@ -14,22 +14,7 @@ header('Content-Type: application/json');
 
 $db = new Database();
 $auth = new Auth($db);
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['Authorization'] ?? '';
-    if (empty($authHeader) && function_exists('getallheaders')) {
-        $headers = getallheaders();
-        $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    }
-
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/task-logs.php
+++ b/src/frontend/api/task-logs.php
@@ -10,18 +10,7 @@ use App\Project;
 header('Content-Type: application/json');
 
 $auth = new Auth();
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $headers = getallheaders();
-    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);
@@ -49,7 +38,9 @@ if (!$task) {
 
 // Verify project ownership
 $project = $projectModel->findById($task['project_id']);
-if (!$project || (int)$project['user_id'] !== $userId) {
+$isOwner = (int)$task['user_id'] === $userId || ($project && (int)$project['user_id'] === $userId);
+
+if (!$isOwner) {
     http_response_code(403);
     echo json_encode(['error' => 'Access denied']);
     exit;

--- a/src/frontend/api/task.php
+++ b/src/frontend/api/task.php
@@ -10,18 +10,7 @@ use App\Project;
 header('Content-Type: application/json');
 
 $auth = new Auth();
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $headers = getallheaders();
-    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);
@@ -47,7 +36,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     $project = $projectModel->findById($task['project_id']);
-    if (!$project || (int)$project['user_id'] !== $userId) {
+    $isOwner = (int)$task['user_id'] === $userId || ($project && (int)$project['user_id'] === $userId);
+
+    if (!$isOwner) {
         http_response_code(403);
         echo json_encode(['error' => 'Access denied']);
         exit;
@@ -225,7 +216,9 @@ if (!$task) {
 
 // Verify project ownership
 $project = $projectModel->findById($task['project_id']);
-if (!$project || (int)$project['user_id'] !== $userId) {
+$isOwner = (int)$task['user_id'] === $userId || ($project && (int)$project['user_id'] === $userId);
+
+if (!$isOwner) {
     http_response_code(403);
     echo json_encode(['error' => 'Access denied']);
     exit;

--- a/src/frontend/api/tasks.php
+++ b/src/frontend/api/tasks.php
@@ -10,18 +10,7 @@ use App\Task;
 header('Content-Type: application/json');
 
 $auth = new Auth();
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $headers = getallheaders();
-    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/templates.php
+++ b/src/frontend/api/templates.php
@@ -10,18 +10,7 @@ header('Content-Type: application/json');
 
 $db = new Database();
 $auth = new Auth($db);
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $headers = getallheaders();
-    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/user.php
+++ b/src/frontend/api/user.php
@@ -12,22 +12,7 @@ header('Content-Type: application/json');
 
 $db = new Database();
 $auth = new Auth($db);
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['Authorization'] ?? '';
-    if (empty($authHeader) && function_exists('getallheaders')) {
-        $headers = getallheaders();
-        $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    }
-
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);

--- a/src/frontend/api/webhook-logs.php
+++ b/src/frontend/api/webhook-logs.php
@@ -9,18 +9,7 @@ use App\WebhookLogger;
 header('Content-Type: application/json');
 
 $auth = new Auth();
-$userId = null;
-
-// Support both Session and JWT authentication
-if ($auth->isLoggedIn()) {
-    $userId = $auth->getUserId();
-} else {
-    $headers = getallheaders();
-    $authHeader = $headers['Authorization'] ?? $headers['authorization'] ?? '';
-    if (preg_match('/Bearer\s+(.*)$/i', $authHeader, $matches)) {
-        $userId = $auth->validateToken($matches[1]);
-    }
-}
+$userId = $auth->getAuthenticatedUserId();
 
 if (!$userId) {
     http_response_code(401);


### PR DESCRIPTION
The "Access denied" (403) error reported when clicking the retry button was caused by two main factors:
1. Unreliable extraction of the Bearer token from the `Authorization` header, especially during POST requests or background polling on certain server configurations (like Apache with CGI).
2. Overly restrictive ownership checks in `Project::findById` which used an `INNER JOIN` on GitHub accounts, causing valid projects to appear "missing" or "denied" if their GitHub metadata was incomplete.

I have addressed these issues by:
- Enhancing the `App\Auth` class to robustly check multiple potential header sources for the JWT token.
- Refactoring all 17 API endpoints to use this centralized and improved authentication logic.
- Relaxing the database join in `Project::findById` to a `LEFT JOIN`.
- Directly verifying task ownership via the `tasks.user_id` field to bypass redundant and potentially failing project joins.

All backend tests passed, confirming the stability of these changes.

Fixes #896

---
*PR created automatically by Jules for task [4308241306535676878](https://jules.google.com/task/4308241306535676878) started by @chatelao*