### PR TITLE
Auto-retry Jules on task creation failure

### DIFF
--- a/src/backend/Task.php
+++ b/src/backend/Task.php
@@ -439,6 +439,29 @@ class Task
         return $stmt->rowCount() > 0;
     }
 
+    public function markJulesRetryTriggered(int $id, string $commentBody): bool
+    {
+        $connection = $this->db->getConnection();
+        $driver = $connection->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        // Create a unique marker for this specific comment body to avoid re-triggering for the same failure
+        $marker = '<!-- jules_retry_triggered: ' . md5($commentBody) . ' -->';
+
+        if ($driver === 'sqlite') {
+            $sql = "UPDATE tasks
+                    SET agent_response = COALESCE(agent_response, '') || '\n" . $marker . "'
+                    WHERE task_id = ? AND (agent_response IS NULL OR agent_response NOT LIKE '%" . $marker . "%')";
+        } else {
+            $sql = "UPDATE tasks
+                    SET agent_response = CONCAT(COALESCE(agent_response, ''), '\n" . $marker . "')
+                    WHERE task_id = ? AND (agent_response IS NULL OR agent_response NOT LIKE '%" . $marker . "%')";
+        }
+
+        $stmt = $connection->prepare($sql);
+        $stmt->execute([$id]);
+        return $stmt->rowCount() > 0;
+    }
+
     public function updateGitHubCache(int $taskId, ?array $prData = null, ?array $commentsData = null): bool
     {
         $updates = [];
@@ -1042,8 +1065,19 @@ class Task
                             return ($login === 'google-labs-jules[bot]' || $login === 'jules');
                         }));
 
-                        foreach ($julesComments as $comment) {
-                            $sessionId = $this->extractSessionId($comment['body'] ?? '');
+                        foreach ($julesComments as $index => $comment) {
+                            $body = $comment['body'] ?? '';
+                            $sessionId = $this->extractSessionId($body);
+
+                            // Only check the latest comment for the failure message to avoid flapping
+                            if ($index === 0 && str_contains($body, "Jules has failed to create a task")) {
+                                if ($this->markJulesRetryTriggered((int)$task['task_id'], $body)) {
+                                    Logger::getInstance($this->db)->log($userId, $task['task_id'], "Jules failed to create task (detected in sync), re-triggering by re-adding label.", 'info');
+                                    $githubService->removeLabel($task['github_repo'], $task['issue_number'], 'jules');
+                                    $githubService->addLabel($task['github_repo'], $task['issue_number'], 'jules');
+                                }
+                            }
+
                             if ($sessionId) break;
                         }
                     }

--- a/src/backend/WebhookHandler.php
+++ b/src/backend/WebhookHandler.php
@@ -390,6 +390,15 @@ class WebhookHandler
                 $stmt->execute([$sessionId, $task['task_id']]);
             }
 
+            if ($isJulesComment && str_contains($body, "Jules has failed to create a task") && $githubService && $task) {
+                $repo = $project['github_repo'] ?? '';
+                if ($repo && $taskModel->markJulesRetryTriggered((int)$task['task_id'], $body)) {
+                    Logger::getInstance($this->db)->log($project['user_id'], $task['task_id'], "Jules failed to create task, re-triggering by re-adding label.", 'info');
+                    $githubService->removeLabel($repo, $issue['number'], 'jules');
+                    $githubService->addLabel($repo, $issue['number'], 'jules');
+                }
+            }
+
             // Always refresh status when Jules comments to capture state transitions immediately
             if ($task && $githubService && $julesService) {
                 $taskModel->refreshJulesStatus($project['user_id'], $githubService, $julesService, $notificationService, (int)$task['task_id']);

--- a/test/Integration/JulesRetryTest.php
+++ b/test/Integration/JulesRetryTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use App\Database;
+use App\WebhookHandler;
+use App\Task;
+use App\GitHubService;
+use App\JulesService;
+use App\Logger;
+use PDO;
+
+class JulesRetryTest extends TestCase
+{
+    private $db;
+    private $pdo;
+    private $handler;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->pdo->exec("CREATE TABLE users (
+            user_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name VARCHAR(255),
+            jules_api_key VARCHAR(255),
+            jules_quota_updated_at DATETIME,
+            automations_enabled BOOLEAN DEFAULT 1
+        )");
+
+        $this->pdo->exec("CREATE TABLE projects (
+            project_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INT NOT NULL,
+            github_repo VARCHAR(255) NOT NULL,
+            github_token VARCHAR(255)
+        )");
+
+        $this->pdo->exec("CREATE TABLE tasks (
+            task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INT NOT NULL,
+            project_id INT NOT NULL,
+            issue_number INT NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            body TEXT,
+            status TEXT DEFAULT 'pending',
+            jules_status TEXT,
+            jules_session_id VARCHAR(255),
+            jules_url TEXT,
+            github_state VARCHAR(20) DEFAULT 'open',
+            github_data TEXT,
+            autorepeat_remaining INT DEFAULT 0,
+            agent_response TEXT,
+            pr_url VARCHAR(255),
+            last_synced_at DATETIME,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(project_id, issue_number)
+        )");
+
+        $this->pdo->exec("CREATE TABLE performance_logs (
+            log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INT,
+            type VARCHAR(50),
+            target TEXT,
+            duration FLOAT,
+            context TEXT,
+            status_code INT,
+            error_message TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )");
+
+        $this->pdo->exec("CREATE TABLE task_logs (
+            task_log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INT,
+            task_id INT,
+            message TEXT,
+            level VARCHAR(20),
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )");
+
+        $this->db = $this->createMock(Database::class);
+        $this->db->method('getConnection')->willReturn($this->pdo);
+
+        Logger::resetInstance();
+        new Logger($this->db);
+
+        $this->handler = new WebhookHandler($this->db);
+    }
+
+    public function testWebhookTriggersRetryOnlyOnJulesComment()
+    {
+        $project = ['user_id' => 1, 'project_id' => 1, 'github_repo' => 'owner/repo'];
+        $this->pdo->exec("INSERT INTO users (user_id, name) VALUES (1, 'Test User')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES (1, 1, 'owner/repo')");
+
+        $this->pdo->prepare("INSERT INTO tasks (user_id, project_id, issue_number, title) VALUES (?, ?, ?, ?)")
+            ->execute([1, 1, 123, 'Test Issue']);
+        $taskId = $this->pdo->lastInsertId();
+
+        $githubService = $this->createMock(GitHubService::class);
+        $failureComment = "Jules has failed to create a task. You can try again later by removing and re-adding the 'jules' label.";
+
+        // 1. Not a Jules comment
+        $eventNonJules = [
+            'action' => 'created',
+            'issue' => ['number' => 123, 'title' => 'Test Issue'],
+            'comment' => ['body' => $failureComment, 'user' => ['login' => 'random_user']],
+            'repository' => ['full_name' => 'owner/repo']
+        ];
+        $githubService->expects($this->exactly(1))->method('removeLabel')->with('owner/repo', 123, 'jules');
+        $githubService->expects($this->exactly(1))->method('addLabel')->with('owner/repo', 123, 'jules');
+
+        // This should NOT call githubService
+        $this->handler->handle($project, $eventNonJules, $githubService);
+
+        // 2. Jules comment
+        $eventJules = [
+            'action' => 'created',
+            'issue' => ['number' => 123, 'title' => 'Test Issue'],
+            'comment' => ['body' => $failureComment, 'user' => ['login' => 'google-labs-jules[bot]']],
+            'repository' => ['full_name' => 'owner/repo']
+        ];
+        // This SHOULD call githubService once
+        $this->handler->handle($project, $eventJules, $githubService);
+
+        // 3. Idempotency (same comment again)
+        // This should NOT call githubService again
+        $this->handler->handle($project, $eventJules, $githubService);
+    }
+
+    public function testSyncTriggersRetryIdempotently()
+    {
+        $userId = 1;
+        $projectId = 1;
+        $repo = 'owner/repo';
+
+        $this->pdo->exec("INSERT INTO users (user_id, name, jules_api_key) VALUES ($userId, 'Test User', 'fake-key')");
+        $this->pdo->exec("INSERT INTO projects (project_id, user_id, github_repo) VALUES ($projectId, $userId, '$repo')");
+
+        $githubData = [
+            'assignee' => ['login' => 'jules'],
+            'labels' => [['name' => 'jules']]
+        ];
+
+        $this->pdo->prepare("INSERT INTO tasks (user_id, project_id, issue_number, title, status, github_data) VALUES (?, ?, ?, ?, ?, ?)")
+            ->execute([$userId, $projectId, 123, 'Test Issue', 'pending', json_encode($githubData)]);
+        $taskId = $this->pdo->lastInsertId();
+
+        $githubService = $this->createMock(GitHubService::class);
+        $githubService->method('getIssue')->willReturn(['number' => 123, 'title' => 'Test Issue', 'state' => 'open']);
+
+        $failureComment = [
+            'body' => "Jules has failed to create a task. You can try again later by removing and re-adding the 'jules' label.",
+            'user' => ['login' => 'google-labs-jules[bot]']
+        ];
+        $githubService->method('getIssueComments')->willReturn([$failureComment]);
+
+        // Should only trigger ONCE across multiple syncs
+        $githubService->expects($this->once())->method('removeLabel')->with($repo, 123, 'jules');
+        $githubService->expects($this->once())->method('addLabel')->with($repo, 123, 'jules');
+
+        $julesService = $this->createMock(JulesService::class);
+        $taskModel = new Task($this->db);
+
+        // First sync
+        $taskModel->refreshJulesStatus($userId, $githubService, $julesService, null, (int)$taskId);
+
+        // Second sync (idempotency check)
+        $taskModel->refreshJulesStatus($userId, $githubService, $julesService, null, (int)$taskId);
+    }
+}


### PR DESCRIPTION
This change introduces an automatic retry mechanism for cases where Jules fails to create a task (e.g., due to transient API errors). When a comment from Jules is detected containing the failure message "Jules has failed to create a task", the system will automatically remove and re-add the 'jules' label to the issue to trigger a new trial.

Key improvements:
- **Sender Verification:** Only comments from `jules` or `google-labs-jules[bot]` can trigger the retry.
- **Idempotency:** A unique marker `<!-- jules_retry_triggered: [hash] -->` is added to the task's `agent_response` to ensure each specific failure comment is only acted upon once, preventing infinite flapping.
- **Dual Coverage:** The logic is implemented in both the `WebhookHandler` (for real-time response) and `Task::refreshJulesStatus` (for periodic sync).
- **Tested:** New integration tests verify correct behavior for both webhooks and sync, including idempotency and sender checks.

Fixes #899

---
*PR created automatically by Jules for task [7100314259645847463](https://jules.google.com/task/7100314259645847463) started by @chatelao*